### PR TITLE
Page composable 내부에서 viewModel 가져와서 사용하는 템플릿 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -182,6 +182,7 @@ dependencies {
     implementation("androidx.paging:paging-compose:${Deps.Version.PagingCompose}")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.0")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
+    implementation("androidx.compose.runtime:runtime-rxjava3:1.1.1")
 
     // misc
     implementation("androidx.core:core-ktx:1.7.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,6 +180,8 @@ dependencies {
     implementation("androidx.compose.runtime:runtime-livedata:${Deps.Version.Compose}")
     implementation("androidx.compose.ui:ui-tooling:${Deps.Version.Compose}")
     implementation("androidx.paging:paging-compose:${Deps.Version.PagingCompose}")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
 
     // misc
     implementation("androidx.core:core-ktx:1.7.0")

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -5,15 +5,20 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.rxjava3.subscribeAsState
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
+import com.wafflestudio.snutt2.model.TableTrimParam
 import com.wafflestudio.snutt2.views.logged_in.home.HomeNavControllerContext
 
 @Composable
 fun SettingsPage() {
     val navController = HomeNavControllerContext.current
     val viewModel = hiltViewModel<SettingsViewModel>()
+    val tableTrimParam = viewModel.trimParam
+        .asObservable()
+        .subscribeAsState(initial = TableTrimParam.Default)
 
     Column {
         Button(onClick = { navController.navigate("appReport") }) { Text(text = "appReport") }
@@ -22,7 +27,7 @@ fun SettingsPage() {
         Button(onClick = { navController.navigate("timetableConfig") }) { Text(text = "timetableConfig") }
         Button(onClick = { navController.navigate("userConfig") }) { Text(text = "userConfig") }
         // FIXME: 임시 사용 예시이다. migration 이후에 지워주자.
-        Text(text = "${viewModel.trimParam.get()}")
+        Text(text = "$tableTrimParam")
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -21,6 +21,7 @@ fun SettingsPage() {
         Button(onClick = { navController.navigate("teamInfo") }) { Text(text = "teamInfo") }
         Button(onClick = { navController.navigate("timetableConfig") }) { Text(text = "timetableConfig") }
         Button(onClick = { navController.navigate("userConfig") }) { Text(text = "userConfig") }
+        // FIXME: 임시 사용 예시이다. migration 이후에 지워주자.
         Text(text = "${viewModel.trimParam.get()}")
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -6,12 +6,14 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.wafflestudio.snutt2.views.logged_in.home.HomeNavControllerContext
 
 @Composable
 fun SettingsPage() {
     val navController = HomeNavControllerContext.current
+    val viewModel = hiltViewModel<SettingsViewModel>()
 
     Column {
         Button(onClick = { navController.navigate("appReport") }) { Text(text = "appReport") }
@@ -19,6 +21,7 @@ fun SettingsPage() {
         Button(onClick = { navController.navigate("teamInfo") }) { Text(text = "teamInfo") }
         Button(onClick = { navController.navigate("timetableConfig") }) { Text(text = "timetableConfig") }
         Button(onClick = { navController.navigate("userConfig") }) { Text(text = "userConfig") }
+        Text(text = "${viewModel.trimParam.get()}")
     }
 }
 


### PR DESCRIPTION
기존 ViewModel 을 이 PR과 같은 형태로 Page 에서 사용할 수 있도록 import 해서 쓸 수 있다.

이때 고려해야 하는 점은
- 해당 ViewModel 들은 Activity Scope 에 묶여서 생성되므로, SingleActivity 인 SNUTT 앱에서는 거의 Singleton 하게 공유되고 있다.
- 웬만하면 밸류 자체를 그대로 가져오는 형태보다 (instant get) observable 를 가져와서 상태로 만드는 형태로 사용할 수 있도록 하자

```kt
@Composable
fun SettingsPage() {
    val navController = HomeNavControllerContext.current
    val viewModel = hiltViewModel<SettingsViewModel>()
    val tableTrimParam = viewModel.trimParam. // <- 이런 형태로
        .asObservable()
        .subscribeAsState(initial = TableTrimParam.Default)
// ...
}
```