### PR TITLE
학사편람 내에 존재하는 강좌 수정 시 시간을 제외한 다른 정보 수정 허용 

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailAdapter.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailAdapter.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.RecyclerView
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.SNUTTUtils
+import com.wafflestudio.snutt2.lib.android.toast
 import com.wafflestudio.snutt2.lib.getDefaultFgColorHex
 import com.wafflestudio.snutt2.lib.network.dto.PutLectureParams
 import com.wafflestudio.snutt2.lib.network.dto.core.ClassTimeDto
@@ -117,7 +118,7 @@ class LectureDetailAdapter(
             val viewHolder = holder as ClassViewHolder?
             viewHolder!!.bindData(item) {
                 if (item.isEditable) {
-                    showDialog(item, it.context)
+                    it.context.toast("커스텀 강의가 아닌 강의의 시간대는 변경할 수 없습니디.")
                 }
             }
         }
@@ -441,10 +442,10 @@ class LectureDetailAdapter(
                     }
                 }
             )
-            editText2.isClickable = item.isEditable
-            editText2.isFocusable = item.isEditable
-            editText2.isFocusableInTouchMode = item.isEditable
-            remove.visibility = if (item.isEditable) View.VISIBLE else View.GONE
+            editText2.isClickable = false
+            editText2.isFocusable = false
+            editText2.isFocusableInTouchMode = false
+            remove.visibility = View.GONE
         }
 
         override fun onLongClick(v: View): Boolean {
@@ -512,13 +513,13 @@ class LectureDetailAdapter(
         fromPicker.setOnValueChangedListener { picker, oldVal, newVal ->
             fromTime = newVal
             /* set DisplayedValues as null to avoid out of bound index error */toPicker.displayedValues =
-                null
+            null
             toPicker.value = max(fromTime + 1, toPicker.value)
             toPicker.minValue = fromTime + 1
             toPicker.maxValue = 28
             toPicker.displayedValues = SNUTTUtils.getTimeList(fromTime + 1, 28)
             /* setValue method does not call listener, so we have to change the value manually */toTime =
-                fromTime + 1
+            fromTime + 1
         }
         toTime = (item.classTime!!.start + item.classTime!!.len).toInt() * 2
         val to = SNUTTUtils.getTimeList(fromTime + 1, 28)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailAdapter.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailAdapter.kt
@@ -16,7 +16,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.RecyclerView
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.SNUTTUtils
-import com.wafflestudio.snutt2.lib.android.toast
 import com.wafflestudio.snutt2.lib.getDefaultFgColorHex
 import com.wafflestudio.snutt2.lib.network.dto.PutLectureParams
 import com.wafflestudio.snutt2.lib.network.dto.core.ClassTimeDto
@@ -117,9 +116,6 @@ class LectureDetailAdapter(
         if (viewType == LectureItem.ViewType.ItemClass.value) {
             val viewHolder = holder as ClassViewHolder?
             viewHolder!!.bindData(item) {
-                if (item.isEditable) {
-                    it.context.toast("커스텀 강의가 아닌 강의의 시간대는 변경할 수 없습니디.")
-                }
             }
         }
         if (viewType == LectureItem.ViewType.ItemRemark.value) {
@@ -415,7 +411,7 @@ class LectureDetailAdapter(
             editText1.setText(time)
             editText1.isClickable = false
             editText1.isFocusable = false
-            editText1.setOnClickListener(listener)
+            editText1.setTextColor(Color.argb(if (item.isEditable) 51 else 255, 0, 0, 0))
             title2.hint = "장소"
             editText2.setText(item.classTime!!.place)
             editText2.addTextChangedListener(
@@ -442,9 +438,9 @@ class LectureDetailAdapter(
                     }
                 }
             )
-            editText2.isClickable = false
-            editText2.isFocusable = false
-            editText2.isFocusableInTouchMode = false
+            editText2.isClickable = item.isEditable
+            editText2.isFocusable = item.isEditable
+            editText2.isFocusableInTouchMode = item.isEditable
             remove.visibility = View.GONE
         }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailAdapter.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailAdapter.kt
@@ -513,13 +513,13 @@ class LectureDetailAdapter(
         fromPicker.setOnValueChangedListener { picker, oldVal, newVal ->
             fromTime = newVal
             /* set DisplayedValues as null to avoid out of bound index error */toPicker.displayedValues =
-            null
+                null
             toPicker.value = max(fromTime + 1, toPicker.value)
             toPicker.minValue = fromTime + 1
             toPicker.maxValue = 28
             toPicker.displayedValues = SNUTTUtils.getTimeList(fromTime + 1, 28)
             /* setValue method does not call listener, so we have to change the value manually */toTime =
-            fromTime + 1
+                fromTime + 1
         }
         toTime = (item.classTime!!.start + item.classTime!!.len).toInt() * 2
         val to = SNUTTUtils.getTimeList(fromTime + 1, 28)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailFragment.kt
@@ -128,7 +128,7 @@ class LectureDetailFragment : BaseFragment() {
             .distinctUntilChanged()
             .bindUi(this) {
                 binding.completeButton.isVisible = it
-                binding.editButton.isVisible = false // 서버 강의는 편집 불가능
+                binding.editButton.isVisible = it.not()
             }
 
         vm.selectedColor.asObservable()
@@ -154,6 +154,11 @@ class LectureDetailFragment : BaseFragment() {
         binding.backButton.throttledClicks()
             .bindUi(this) {
                 findNavController().popBackStack()
+            }
+
+        binding.editButton.throttledClicks()
+            .bindUi(this) {
+                setEditMode()
             }
     }
 
@@ -191,9 +196,7 @@ class LectureDetailFragment : BaseFragment() {
                 it.isEditable = false
                 adapter.notifyItemChanged(i)
             }
-            var pos = addClassTimeItemPosition
-            vm.lists.removeAt(pos)
-            adapter.notifyItemRemoved(pos)
+            var pos = lastClassItemPosition + 1
             vm.lists.add(pos, LectureItem(LectureItem.Type.Margin, false))
             adapter.notifyItemInserted(pos)
             vm.lists.add(pos + 1, LectureItem(LectureItem.Type.LongHeader, false))
@@ -237,8 +240,8 @@ class LectureDetailFragment : BaseFragment() {
             adapter.notifyItemRemoved(syllabusPosition - 2)
             val lastPosition = lastClassItemPosition
             // add button
-            vm.lists.add(lastPosition + 1, LectureItem(LectureItem.Type.AddClassTime, true))
-            adapter.notifyItemInserted(lastPosition + 1)
+//            vm.lists.add(lastPosition + 1, LectureItem(LectureItem.Type.AddClassTime, true))
+//            adapter.notifyItemInserted(lastPosition + 1)
 
             // change button
             val removePosition = removeItemPosition


### PR DESCRIPTION
#58 에서 학사편람 강좌의 수정을 아예 막았는데, 시간만 막도록 수정