### PR TITLE
검색 태그 관련 오류 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchFragment.kt
@@ -156,7 +156,7 @@ class SearchFragment : BaseFragment() {
 
         binding.filterButton.clicks()
             .bindUi(this) {
-                bottomSheet.show(parentFragmentManager, "tag_selector")
+                if(bottomSheet.isAdded.not()) bottomSheet.show(parentFragmentManager, "tag_selector")
             }
 
         binding.clearButton.clicks()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchFragment.kt
@@ -156,7 +156,7 @@ class SearchFragment : BaseFragment() {
 
         binding.filterButton.clicks()
             .bindUi(this) {
-                if(bottomSheet.isAdded.not()) bottomSheet.show(parentFragmentManager, "tag_selector")
+                if (bottomSheet.isAdded.not()) bottomSheet.show(parentFragmentManager, "tag_selector")
             }
 
         binding.clearButton.clicks()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchFragment.kt
@@ -154,7 +154,7 @@ class SearchFragment : BaseFragment() {
                 hideSoftKeyboard()
             }
 
-        binding.filterButton.clicks()
+        binding.filterButton.throttledClicks()
             .bindUi(this) {
                 if (bottomSheet.isAdded.not()) bottomSheet.show(parentFragmentManager, "tag_selector")
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchOptionFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchOptionFragment.kt
@@ -13,11 +13,13 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.databinding.DialogSearchOptionBinding
+import com.wafflestudio.snutt2.lib.network.ApiOnError
 import com.wafflestudio.snutt2.lib.rx.throttledClicks
 import com.wafflestudio.snutt2.model.TagType
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.kotlin.subscribeBy
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SearchOptionFragment : BottomSheetDialogFragment() {
@@ -27,6 +29,9 @@ class SearchOptionFragment : BottomSheetDialogFragment() {
     private lateinit var binding: DialogSearchOptionBinding
 
     private lateinit var adapter: TagSelectionAdapter
+
+    @Inject
+    lateinit var apiOnError: ApiOnError
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
 
@@ -71,9 +76,10 @@ class SearchOptionFragment : BottomSheetDialogFragment() {
 
         vm.tagsByTagType
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribeBy {
-                adapter.submitList(it)
-            }
+            .subscribeBy(
+                onNext = { adapter.submitList(it) },
+                onError = apiOnError
+            )
 
         vm.selectedTagType
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -84,7 +84,7 @@ class SearchViewModel @Inject constructor(
                         myLectureRepository.lastViewedTable.get().value?.semester!!,
                         _searchTitle.get(),
                         _searchTags.get(),
-                        null
+                        myLectureRepository.lastViewedTable.get().get()?.lectureList?.getClassTimeMask()
                     ).cachedIn(viewModelScope).asObservable()
                 },
             _selectedLecture.asObservable(),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/LoginFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/LoginFragment.kt
@@ -23,7 +23,6 @@ import com.wafflestudio.snutt2.lib.base.BaseFragment
 import com.wafflestudio.snutt2.lib.rx.throttledClicks
 import com.wafflestudio.snutt2.views.logged_in.home.popups.PopupState
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.rxjava3.kotlin.subscribeBy
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -97,7 +96,8 @@ class LoginFragment : BaseFragment() {
                     val id = result.accessToken.userId
                     val token = result.accessToken.token
                     vm.loginFacebook(id, token)
-                        .bindUi(this@LoginFragment,
+                        .bindUi(
+                            this@LoginFragment,
                             onError = { apiOnError(it) },
                             onSuccess = { routeHome() }
                         )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/LoginFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/LoginFragment.kt
@@ -97,7 +97,7 @@ class LoginFragment : BaseFragment() {
                     val id = result.accessToken.userId
                     val token = result.accessToken.token
                     vm.loginFacebook(id, token)
-                        .subscribeBy(
+                        .bindUi(this@LoginFragment,
                             onError = { apiOnError(it) },
                             onSuccess = { routeHome() }
                         )


### PR DESCRIPTION
1. onError 추가해서 인터넷 불안정할 때 태그 누르면 튕기는 버그 대응 [(crashlytics 링크)](https://console.firebase.google.com/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/715a6b4357d5255dc540f089ffe8633d?hl=ko&time=last-seven-days&sessionEventKey=62EAE806006E00011371E7EC4BA812B3_1706211191726755015)
2. isAdded() 확인해서 태그 버튼 연타했을 때 튕기는 버그 대응 [(crashlytics 링크)](https://console.firebase.google.com/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/4ae5e898deb5ce4e3261f1a9cdfe0fea?hl=ko&time=last-seven-days&sessionEventKey=62EB4313039900010A2DDB923F55E12B_1706321177689106984)
3.  빈 시간대 태그가 미적용되는 상황 수정

TODO
- onError 말고 onComplete는 어떻게 대응해야 하는지?
- isAdded() 보다 적절한 판단 방법이 있는지