### PR TITLE
팝업 Glide 오류 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.activityViewModels
+import com.bumptech.glide.Glide
 import com.wafflestudio.snutt2.DialogController
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.databinding.FragmentHomeBinding
@@ -122,7 +123,8 @@ class HomeFragment : BaseFragment() {
                         PopupDialog(
                             context = requireContext(),
                             onClickHideFewDays = { popupViewModel.invalidateShownPopUp(it) },
-                            url = it.url
+                            url = it.url,
+                            glideRequestManager = Glide.with(this)
                         ).show()
                     }, onError = {}
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.activityViewModels
-import com.bumptech.glide.Glide
 import com.wafflestudio.snutt2.DialogController
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.databinding.FragmentHomeBinding
@@ -124,7 +123,6 @@ class HomeFragment : BaseFragment() {
                             context = requireContext(),
                             onClickHideFewDays = { popupViewModel.invalidateShownPopUp(it) },
                             url = it.url,
-                            glideRequestManager = Glide.with(this)
                         ).show()
                     }, onError = {}
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupDialog.kt
@@ -5,14 +5,15 @@ import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.WindowManager
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.databinding.DialogPopupBinding
 
 class PopupDialog(
     context: Context,
     private val onClickHideFewDays: () -> Unit,
-    private val url: String
+    private val url: String,
+    private val glideRequestManager: RequestManager
 ) : Dialog(context, R.style.popup_dialog) {
 
     lateinit var binding: DialogPopupBinding
@@ -37,7 +38,7 @@ class PopupDialog(
         }
 
         val defaultImage = R.drawable.img_reviews_coming_soon
-        Glide.with(context)
+        glideRequestManager
             .load(url)
             .placeholder(R.color.white)
             .error(defaultImage)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupDialog.kt
@@ -5,15 +5,14 @@ import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.WindowManager
-import com.bumptech.glide.RequestManager
+import com.bumptech.glide.Glide
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.databinding.DialogPopupBinding
 
 class PopupDialog(
     context: Context,
     private val onClickHideFewDays: () -> Unit,
-    private val url: String,
-    private val glideRequestManager: RequestManager
+    private val url: String
 ) : Dialog(context, R.style.popup_dialog) {
 
     lateinit var binding: DialogPopupBinding
@@ -38,7 +37,9 @@ class PopupDialog(
         }
 
         val defaultImage = R.drawable.img_reviews_coming_soon
-        glideRequestManager
+
+        // ApplicationContext 에 묶이지만 1회성 요청
+        Glide.with(context.applicationContext)
             .load(url)
             .placeholder(R.color.white)
             .error(defaultImage)


### PR DESCRIPTION
[crashlytics 링크](https://console.firebase.google.com/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/a6703b9452a2899e024c59bb694aade3?hl=ko&time=last-seven-days&sessionEventKey=62EB4314004100010A4DF785EEC5E672_1706310325702113428)

Glide가 이미지를 불러 오고 있는 도중에 모종의 이유로 activity가 destroy돼서 생긴 문제
activity의 context를 사용하지 않고, HomeFragment가 Glide의 RequestManager를 만들고 파라미터로 넘겨주는 형태로 변경
(https://stackoverflow.com/questions/31964737/glide-image-loading-with-application-context/32887693#32887693)