### PR TITLE
팝업 undeliverable exception 오류 

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
@@ -124,7 +124,7 @@ class HomeFragment : BaseFragment() {
                             onClickHideFewDays = { popupViewModel.invalidateShownPopUp(it) },
                             url = it.url,
                         )
-                        if(activity?.isFinishing?.not() == true) {
+                        if (activity?.isFinishing?.not() == true) {
                             popupDialog.show()
                         }
                     }, onError = {}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeFragment.kt
@@ -119,11 +119,14 @@ class HomeFragment : BaseFragment() {
             popupViewModel.fetchPopup()
                 .subscribeBy(
                     onSuccess = {
-                        PopupDialog(
+                        val popupDialog = PopupDialog(
                             context = requireContext(),
                             onClickHideFewDays = { popupViewModel.invalidateShownPopUp(it) },
                             url = it.url,
-                        ).show()
+                        )
+                        if(activity?.isFinishing?.not() == true) {
+                            popupDialog.show()
+                        }
                     }, onError = {}
                 )
         }


### PR DESCRIPTION
[관련 crashlytics](https://console.firebase.google.com/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/6fec91b19b01a3db5b4ec159e4c4d832?time=last-seven-days&sessionEventKey=6316E6F50207000113C145396D0149CB_1718593843180846344)

팝업 다이얼로그를 띄우는 순간에 어떠한 이유로 activity가 finish된 상태일 때가 있어서 오류가 발생하는 것으로 보입니다. 
실제로 위젯과 뒤로가기 버튼을 무차별적으로 반복 클릭해서 root activity의 수명 주기가 꼬이는 환경을 인공적으로 재현해 볼 수 있습니다(해당 오류의 발생도 로그에서 확인). 일반적인 사용 환경에서 어떻게 이게 일어나는지는 잘 모르겠지만...
 
팝업 띄울 때 activity가 실행 중인지만 확인해주게 바꿔주면 일단 해결되는 것 같습니다.

남은 crashlytics 오류 중에 [textView](https://console.firebase.google.com/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/927b9ec513f9e1951e6e6dcbbdf2cb19?time=last-seven-days&sessionEventKey=6316F677039900012E28674570766353_1718610923444105618)에서 나는 오류랑 [setNormalMode 함수](https://console.firebase.google.com/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/eaa34f44423d36d39886692664cd03c0?time=last-seven-days&sessionEventKey=6316DD1802AF00014034FAD9317BE157_1718583176729627766) 에서 나는 오류는 원인을 파악하지 못하고 있는데 셋 다 고치고 나서 배포할까요? 아니면 팝업 오류만 고쳐서 2.3.5 배포할까요?