### PR TITLE
위젯 해상도 깨지는 문제 해결

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt
@@ -1,7 +1,10 @@
 package com.wafflestudio.snutt2
 
 import android.app.Application
+import android.content.res.Configuration
+import androidx.compose.animation.ExperimentalAnimationApi
 import com.wafflestudio.snutt2.lib.rx.DirectFirstHandleScheduler
+import com.wafflestudio.snutt2.provider.TimetableWidgetProvider
 import dagger.hilt.android.HiltAndroidApp
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import rxdogtag2.RxDogTag
@@ -20,6 +23,12 @@ class SNUTTApplication : Application() {
         RxAndroidPlugins.setMainThreadSchedulerHandler {
             DirectFirstHandleScheduler(true)
         }
+    }
+
+    @OptIn(ExperimentalAnimationApi::class)
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        TimetableWidgetProvider.refreshWidget(applicationContext)
     }
 
     companion object {


### PR DESCRIPTION
화면이 회전되어서 해상도가 (x, y)에서 (y, x)로 바뀐 채 모종의 이유로 위젯이 onUpdate() 될 경우 해상도가 깨져서 보인다.
회전될 때마다 onUpdate()를 수행하도록 한다.