### PR TITLE
시간-교시 변경, pagination duplicate key 대응, 기타 버그 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,10 +204,6 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.0")
     implementation("com.google.accompanist:accompanist-navigation-animation:0.26.4-beta")
 
-    // glide
-    implementation("com.github.bumptech.glide:glide:4.12.0")
-    annotationProcessor("com.github.bumptech.glide:compiler:4.12.0")
-
     // coil
     implementation("io.coil-kt:coil-compose:2.1.0")
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/components/TimetableView.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/TimetableView.kt
@@ -255,9 +255,9 @@ class TimetableView : View {
     ) {
         val dayOffset = classTime.day - fittedTrimParam.dayOfWeekFrom
         val hourRangeOffset = Pair(
-            max(classTime.start - fittedTrimParam.hourFrom + 8, 0f),
+            max(classTime.startTimeInFloat - fittedTrimParam.hourFrom, 0f),
             min(
-                classTime.start + classTime.len - fittedTrimParam.hourFrom + 8,
+                classTime.endTimeInFloat - fittedTrimParam.hourFrom,
                 fittedTrimParam.hourTo - fittedTrimParam.hourFrom.toFloat() + 1
             )
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/Picker.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/Picker.kt
@@ -20,14 +20,14 @@ import kotlin.math.roundToInt
 @Composable
 fun <T> Picker(
     list: List<T>,
-    initialValue: T,
+    initialCenterIndex: Int,
     onValueChanged: (Int) -> Unit,
     PickerItemContent: @Composable (Int) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val columnHeightDp = 35.dp
 
-    val animatedOffset = remember { Animatable(list.indexOf(initialValue) * columnHeightDp.value) }
+    val animatedOffset = remember { Animatable(initialCenterIndex * columnHeightDp.value) }
         .apply {
             updateBounds(0f, (columnHeightDp.value * list.size))
         }
@@ -50,7 +50,7 @@ fun <T> Picker(
     // list 자체의 변경에 따른 변화를 반영한다. (recompose 로 되는 방법 찾기)
     // FIXME: 시작 시간의 변경에 따라 끝나는 시간의 list 가 바뀌는데, 이때 미세한 떨림 존재
     LaunchedEffect(list.size) {
-        centerItemIndex = list.indexOf(initialValue)
+        centerItemIndex = initialCenterIndex
         animatedOffset.snapTo(columnHeightDp.value * centerItemIndex)
     }
 
@@ -63,7 +63,7 @@ fun <T> Picker(
                 orientation = Orientation.Vertical,
                 state = rememberDraggableState { delta ->
                     scope.launch {
-                        animatedOffset.snapTo(animatedOffset.value - delta / 2)
+                        animatedOffset.snapTo(animatedOffset.value - delta / 4)
                     }
                 },
                 onDragStopped = { velocity ->

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ProgressDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ProgressDialog.kt
@@ -7,9 +7,13 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -46,6 +50,7 @@ fun ProgressDialog(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun CustomDialog(
     onDismiss: () -> Unit,
@@ -55,13 +60,20 @@ fun CustomDialog(
     negativeButtonText: String = stringResource(R.string.common_cancel),
     content: @Composable () -> Unit
 ) {
-    Dialog(onDismissRequest = onDismiss) {
+    val screenWidthInDp = with(LocalDensity.current) { LocalView.current.width.toDp() }
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
         Surface {
-            Column {
+            Column(modifier = Modifier.width(screenWidthInDp - 50.dp)) {
                 title?.let {
                     Row {
                         Box(modifier = Modifier.padding(20.dp)) {
-                            Text(text = it, style = SNUTTTypography.h2)
+                            Text(
+                                text = it,
+                                style = SNUTTTypography.h2.copy(fontWeight = FontWeight.Normal)
+                            )
                         }
                         Box(modifier = Modifier.weight(1f))
                     }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Color
 import androidx.compose.runtime.Composable
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.lib.network.dto.core.ClassTimeDto
 import com.wafflestudio.snutt2.lib.network.dto.core.CourseBookDto
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.model.TableTrimParam
@@ -128,3 +129,7 @@ fun List<LectureDto>.getFittingTrimParam(tableTrimParam: TableTrimParam): TableT
         hourTo = (flatMap { it.class_time_json.map { ceil(it.endTimeInFloat).toInt() - 1 } } + tableTrimParam.hourTo).maxOf { it },
         forceFitLectures = true
     )
+
+fun ClassTimeDto.isContainedInTrimParam(tableTrimParam: TableTrimParam): Boolean =
+    tableTrimParam.dayOfWeekFrom <= this.day && this.day <= tableTrimParam.dayOfWeekTo &&
+        tableTrimParam.hourFrom <= this.startTimeHour && this.endTimeHour <= tableTrimParam.hourTo + 1

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
@@ -15,9 +15,8 @@ import kotlin.math.floor
 fun LectureDto.contains(queryDay: Int, queryTime: Float): Boolean {
     for (classTimeDto in this.class_time_json) {
         val day1 = classTimeDto.day
-        val start1 = classTimeDto.start
-        val len1 = classTimeDto.len
-        val end1 = start1 + len1
+        val start1 = classTimeDto.startTimeInFloat
+        val end1 = classTimeDto.endTimeInFloat
         val len2 = 0.5f
         val end2 = queryTime + len2
         if (day1 != queryDay) continue
@@ -125,7 +124,7 @@ fun List<LectureDto>.getFittingTrimParam(tableTrimParam: TableTrimParam): TableT
     TableTrimParam(
         dayOfWeekFrom = (flatMap { it.class_time_json.map { it.day } } + tableTrimParam.dayOfWeekFrom).minOf { it },
         dayOfWeekTo = (flatMap { it.class_time_json.map { it.day } } + tableTrimParam.dayOfWeekTo).maxOf { it },
-        hourFrom = (flatMap { it.class_time_json.map { floor(it.start).toInt() + 8 } } + tableTrimParam.hourFrom).minOf { it },
-        hourTo = (flatMap { it.class_time_json.map { ceil(it.start + it.len).toInt() - 1 + 8 } } + tableTrimParam.hourTo).maxOf { it },
+        hourFrom = (flatMap { it.class_time_json.map { floor(it.startTimeInFloat).toInt() } } + tableTrimParam.hourFrom).minOf { it },
+        hourTo = (flatMap { it.class_time_json.map { ceil(it.endTimeInFloat).toInt() - 1 } } + tableTrimParam.hourTo).maxOf { it },
         forceFitLectures = true
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/data/SNUTTStringUtils.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/data/SNUTTStringUtils.kt
@@ -7,7 +7,6 @@ import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
 import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
 import timber.log.Timber
 import java.text.DateFormat
-import java.text.DecimalFormat
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
@@ -30,25 +29,23 @@ object SNUTTStringUtils {
 
     // 간소화된 강의 시간
     fun getSimplifiedClassTime(lectureDto: LectureDto): String {
-        var text = ""
+        val texts = StringBuilder()
         lectureDto.class_time_json.forEachIndexed { index, classTimeDto ->
-            val day = classTimeDto.day
-            val start = classTimeDto.start
-            val len = classTimeDto.len
-            val place = classTimeDto.place
-            text += SNUTTUtils.numberToWday(day.toInt()) + DecimalFormat().format(start.toDouble())
-            if (index != lectureDto.class_time_json.size - 1) text += "/"
+            texts.append(SNUTTUtils.numberToWday(classTimeDto.day))
+            texts.append(" ")
+            texts.append(classTimeDto.start_time)
+            texts.append("~")
+            texts.append(classTimeDto.end_time)
+            if (index != lectureDto.class_time_json.size - 1) texts.append("/")
         }
-        if (text.isEmpty()) text = "(없음)"
-        return text
+        if (texts.isEmpty()) texts.append("(없음)")
+        return texts.toString()
     }
 
     fun getSimplifiedLocation(lectureDto: LectureDto): String {
         var text = ""
         lectureDto.class_time_json.forEachIndexed { index, classTimeDto ->
             val day = classTimeDto.day
-            val start = classTimeDto.start
-            val len = classTimeDto.len
             val place = classTimeDto.place
             text += place
             if (index != lectureDto.class_time_json.size - 1) text += "/"
@@ -105,9 +102,13 @@ object SNUTTStringUtils {
     }
 
     fun getClassTimeText(classTime: ClassTimeDto): String {
-        return SNUTTUtils.numberToWday(classTime.day) + " " +
-            SNUTTUtils.numberToTime(classTime.start) + "~" +
-            SNUTTUtils.numberToEndTimeAdjusted(classTime.start, classTime.len)
+        return StringBuilder()
+            .append(SNUTTUtils.numberToWday(classTime.day))
+            .append(" ")
+            .append(classTime.start_time)
+            .append("~")
+            .append(classTime.end_time)
+            .toString()
     }
 
     fun String.isEmailInvalid(): Boolean {

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
@@ -9,8 +9,27 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class ClassTimeDto(
     @Json(name = "day") val day: Int,
-    @Json(name = "start") val start: Float,
-    @Json(name = "len") val len: Float,
     @Json(name = "place") val place: String,
-    @Json(name = "_id") val id: String? = null
-) : Parcelable
+    @Json(name = "_id") val id: String? = null,
+    @Json(name = "start_time") val start_time: String = "",
+    @Json(name = "end_time") val end_time: String = "",
+) : Parcelable {
+
+    val startTimeInFloat: Float
+        get() = start_time.split(':')[0].toFloat() + start_time.split(':')[1].toFloat() / 60f
+
+    val endTimeInFloat: Float
+        get() = end_time.split(':')[0].toFloat() + end_time.split(':')[1].toFloat() / 60f
+
+    val startTimeHour: Float
+        get() = start_time.split(':')[0].toFloat()
+
+    val startTimeMinute: Int
+        get() = start_time.split(':')[1].toInt()
+
+    val endTimeHour: Float
+        get() = end_time.split(':')[0].toFloat()
+
+    val endTimeMinute: Int
+        get() = end_time.split(':')[1].toInt()
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
@@ -13,22 +13,28 @@ data class ClassTimeDto(
     @Json(name = "_id") val id: String? = null,
     @Json(name = "start_time") val start_time: String = "",
     @Json(name = "end_time") val end_time: String = "",
+    @Json(name = "start") val start: Float,     // old
+    @Json(name = "len") val len: Float,         // old
 ) : Parcelable {
 
     val startTimeInFloat: Float
-        get() = start_time.split(':')[0].toFloat() + start_time.split(':')[1].toFloat() / 60f
+        get() =
+            if (start_time.isNotEmpty()) start_time.split(':')[0].toFloat() + start_time.split(':')[1].toFloat() / 60f
+            else start
 
     val endTimeInFloat: Float
-        get() = end_time.split(':')[0].toFloat() + end_time.split(':')[1].toFloat() / 60f
+        get() =
+            if (end_time.isNotEmpty()) end_time.split(':')[0].toFloat() + end_time.split(':')[1].toFloat() / 60f
+            else start + len
 
-    val startTimeHour: Float
-        get() = start_time.split(':')[0].toFloat()
+    val startTimeHour: Int
+        get() = startTimeInFloat.toInt()
 
     val startTimeMinute: Int
         get() = start_time.split(':')[1].toInt()
 
-    val endTimeHour: Float
-        get() = end_time.split(':')[0].toFloat()
+    val endTimeHour: Int
+        get() = endTimeInFloat.toInt()
 
     val endTimeMinute: Int
         get() = end_time.split(':')[1].toInt()

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
@@ -13,8 +13,8 @@ data class ClassTimeDto(
     @Json(name = "_id") val id: String? = null,
     @Json(name = "start_time") val start_time: String = "",
     @Json(name = "end_time") val end_time: String = "",
-    @Json(name = "start") val start: Float,     // old
-    @Json(name = "len") val len: Float,         // old
+    @Json(name = "start") val start: Float, // old
+    @Json(name = "len") val len: Float, // old
 ) : Parcelable {
 
     val startTimeInFloat: Float

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeDrawer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeDrawer.kt
@@ -583,8 +583,7 @@ private fun CreateNewTableBottomSheet(
             Spacer(modifier = Modifier.height(5.dp))
             Picker(
                 list = allCourseBook,
-                initialValue = allCourseBook.find { it.year == selectedCourseBook.year && it.semester == selectedCourseBook.semester }
-                    ?: allCourseBook.first(),
+                initialCenterIndex = allCourseBook.indexOfFirst { it.year == selectedCourseBook.year && it.semester == selectedCourseBook.semester },
                 onValueChanged = { index ->
                     onPickerChange(allCourseBook[index])
                 },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -2,7 +2,7 @@
 
 package com.wafflestudio.snutt2.views.logged_in.home.search
 
-import androidx.compose.animation.*
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.spring
@@ -45,6 +45,10 @@ import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getLectureTagText
 import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getSimplifiedClassTime
 import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getSimplifiedLocation
 import com.wafflestudio.snutt2.lib.getColor
+import com.wafflestudio.snutt2.lib.network.ApiOnError
+import com.wafflestudio.snutt2.lib.network.ApiOnProgress
+import com.wafflestudio.snutt2.lib.network.ErrorCode.LECTURE_TIME_OVERLAP
+import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.model.TagDto
 import com.wafflestudio.snutt2.ui.SNUTTColors
@@ -86,6 +90,9 @@ fun SearchPage(
     val selectedTags by searchViewModel.selectedTags.collectAsState()
     var searchOptionSheetState by remember { mutableStateOf(false) }
     val placeHolderState by searchViewModel.placeHolderState.collectAsState()
+
+    var lectureOverlapDialogState by remember { mutableStateOf(false) }
+    var lectureOverlapDialogMessage by remember { mutableStateOf("") }
 
     Column {
         SearchTopBar {
@@ -200,10 +207,17 @@ fun SearchPage(
                                         }
                                     }, onClickAdd = {
                                         scope.launch(Dispatchers.IO) {
-                                            launchSuspendApi(apiOnProgress, apiOnError) {
+                                            lectureApiWithOverlapDialog(
+                                                apiOnProgress,
+                                                apiOnError,
+                                                onLectureOverlap = { message ->
+                                                    lectureOverlapDialogMessage = message
+                                                    lectureOverlapDialogState = true
+                                                }
+                                            ) {
                                                 timetableViewModel.addLecture(
                                                     lecture = it.item,
-                                                    is_force = false // TODO: is_forced
+                                                    is_force = false
                                                 )
                                                 searchViewModel.toggleLectureSelection(it.item)
                                             }
@@ -255,6 +269,29 @@ fun SearchPage(
                 }
             }
             searchOptionSheetState = false
+        }
+    }
+
+    if (lectureOverlapDialogState) {
+        CustomDialog(
+            onDismiss = { lectureOverlapDialogState = false },
+            onConfirm = {
+                scope.launch {
+                    selectedLecture?.let { lecture ->
+                        launchSuspendApi(apiOnProgress, apiOnError) {
+                            timetableViewModel.addLecture(
+                                lecture = lecture,
+                                is_force = true
+                            )
+                            searchViewModel.toggleLectureSelection(lecture)
+                        }
+                    }
+                    lectureOverlapDialogState = false
+                }
+            },
+            title = stringResource(id = R.string.lecture_overlap_error_message)
+        ) {
+            Text(text = lectureOverlapDialogMessage)
         }
     }
 }
@@ -496,6 +533,29 @@ private fun LazyItemScope.TagCell(
                 .clicks { onClick() }
         )
         Spacer(modifier = Modifier.width(10.dp))
+    }
+}
+
+suspend fun lectureApiWithOverlapDialog(
+    apiOnProgress: ApiOnProgress,
+    apiOnError: ApiOnError,
+    onLectureOverlap: (String) -> Unit,
+    api: suspend () -> Unit
+) {
+    try {
+        apiOnProgress.showProgress()
+        api.invoke()
+    } catch (e: Exception) {
+        when (e) {
+            is ErrorParsedHttpException -> {
+                if (e.errorDTO?.code == LECTURE_TIME_OVERLAP) {
+                    onLectureOverlap(e.errorDTO.ext!!["confirm_message"] ?: "")
+                } else apiOnError(e)
+            }
+            else -> apiOnError(e)
+        }
+    } finally {
+        apiOnProgress.hideProgress()
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -192,7 +192,7 @@ fun SearchPage(
                         LazyColumn(
                             state = lazyListState, modifier = Modifier.fillMaxSize()
                         ) {
-                            items(searchResultPagingItems, key = { it.item.id }) {
+                            items(searchResultPagingItems) {
                                 it?.let {
                                     SearchListItem(lectureDataWithState = it, onSelect = {
                                         scope.launch {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -43,6 +43,7 @@ import com.wafflestudio.snutt2.data.TimetableColorTheme
 import com.wafflestudio.snutt2.lib.contains
 import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getCreditSumFromLectureList
 import com.wafflestudio.snutt2.lib.getFittingTrimParam
+import com.wafflestudio.snutt2.lib.isContainedInTrimParam
 import com.wafflestudio.snutt2.lib.network.dto.core.*
 import com.wafflestudio.snutt2.lib.rx.dp
 import com.wafflestudio.snutt2.lib.rx.sp
@@ -359,8 +360,11 @@ private fun DrawTableGrid() {
 private fun DrawLecture(lecture: LectureDto) {
     val context = LocalContext.current
     val theme = TableContext.current.previewTheme ?: TableContext.current.table.theme
+    val fittedTrimParam = LocalCanvasContext.current.fittedTrimParam
 
-    lecture.class_time_json.forEach {
+    lecture.class_time_json.filter {
+        it.isContainedInTrimParam(fittedTrimParam)
+    }.forEach {
         DrawClassTime(
             classTime = it,
             courseTitle = lecture.course_title,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -50,9 +50,7 @@ import com.wafflestudio.snutt2.lib.toDayString
 import com.wafflestudio.snutt2.model.TableTrimParam
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
-import com.wafflestudio.snutt2.views.LocalDrawerState
-import com.wafflestudio.snutt2.views.LocalNavController
-import com.wafflestudio.snutt2.views.NavigationDestination
+import com.wafflestudio.snutt2.views.*
 import com.wafflestudio.snutt2.views.logged_in.home.TableContext
 import com.wafflestudio.snutt2.views.logged_in.home.TableListViewModelNew
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailViewModelNew
@@ -112,6 +110,8 @@ fun TimetablePage(
 
     val navController = LocalNavController.current
     val drawerState = LocalDrawerState.current
+    val apiOnError = LocalApiOnError.current
+    val apiOnProgress = LocalApiOnProgress.current
     val tableListViewModel = hiltViewModel<TableListViewModelNew>()
     val keyboardManager = LocalSoftwareKeyboardController.current
     val table = TableContext.current.table
@@ -127,12 +127,14 @@ fun TimetablePage(
                 keyboardManager?.hide()
             }, onConfirm = { newTitle ->
             scope.launch {
-                tableListViewModel.changeNameTableNew(
-                    tableId = table.id,
-                    name = newTitle
-                )
-                changeTitleDialogState = false
-                keyboardManager?.hide()
+                launchSuspendApi(apiOnProgress, apiOnError) {
+                    tableListViewModel.changeNameTableNew(
+                        tableId = table.id,
+                        name = newTitle
+                    )
+                    changeTitleDialogState = false
+                    keyboardManager?.hide()
+                }
             }
         }, oldTitle = table.title
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -514,7 +514,7 @@ object Defaults {
         class_time_mask = emptyList()
     )
     val defaultClassTimeDto = ClassTimeDto(
-        day = 0, place = "", id = null, start_time = "9:30", end_time = "10:45",
+        day = 0, place = "", id = null, start_time = "9:30", end_time = "10:45", start = 9.5f, len = 1.25f,
     )
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -257,7 +257,7 @@ fun TimeTable(
                             val day =
                                 ((event.x - canvasContext.hourLabelWidth) / unitWidth).toInt() + fittedTrimParam.dayOfWeekFrom
                             val time =
-                                ((event.y - canvasContext.dayLabelHeight) / unitHeight) + fittedTrimParam.hourFrom - 8
+                                ((event.y - canvasContext.dayLabelHeight) / unitHeight) + fittedTrimParam.hourFrom
 
                             for (lecture in lectures) {
                                 if (lecture.contains(day, time)) {
@@ -391,9 +391,9 @@ private fun DrawClassTime(
 
     val dayOffset = classTime.day - fittedTrimParam.dayOfWeekFrom
     val hourRangeOffset = Pair(
-        max(classTime.start - fittedTrimParam.hourFrom + 8, 0f),
+        max(classTime.startTimeInFloat - fittedTrimParam.hourFrom, 0f),
         min(
-            classTime.start + classTime.len - fittedTrimParam.hourFrom + 8,
+            classTime.endTimeInFloat - fittedTrimParam.hourFrom,
             fittedTrimParam.hourTo - fittedTrimParam.hourFrom.toFloat() + 1
         )
     )
@@ -510,7 +510,7 @@ object Defaults {
         class_time_mask = emptyList()
     )
     val defaultClassTimeDto = ClassTimeDto(
-        day = 0, start = 0f, len = 1f, place = "", id = null
+        day = 0, place = "", id = null, start_time = "9:30", end_time = "10:45",
     )
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailCustomPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailCustomPage.kt
@@ -497,3 +497,4 @@ fun LectureDetailCustomPage() {
             }
         }
     }
+    

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailViewModelNew.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailViewModelNew.kt
@@ -10,7 +10,9 @@ import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.Defaults
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -67,8 +69,9 @@ class LectureDetailViewModelNew @Inject constructor(
         viewModelScope.launch { _editingLectureDetail.emit(newLectureDto) }
     }
 
-    suspend fun updateLecture2() {
+    suspend fun updateLecture2(is_forced: Boolean = false) {
         val param = buildPutLectureParams()
+        param.isForced = is_forced
         currentTableRepository.updateLecture(_editingLectureDetail.value.id, param)
     }
 
@@ -81,8 +84,9 @@ class LectureDetailViewModelNew @Inject constructor(
         return currentTable.value?.lectureList?.find { it.id == editingLectureDetail.value.id }!! // TODO: 왜 resetLecture 의 api 응답이 TableDto 인지..
     }
 
-    suspend fun createLecture2() {
+    suspend fun createLecture2(is_forced: Boolean = false) {
         val param = buildPostLectureParams()
+        param.isForced = is_forced
         currentTableRepository.createCustomLecture(param)
     }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -10,55 +10,293 @@
         <item>일</item>
     </string-array>
     <string-array name="time_string">
-        <!-- 24시 적용할 때를 위해 -->
         <item>0:00</item>
+        <item>0:05</item>
+        <item>0:10</item>
+        <item>0:15</item>
+        <item>0:20</item>
+        <item>0:25</item>
         <item>0:30</item>
+        <item>0:35</item>
+        <item>0:40</item>
+        <item>0:45</item>
+        <item>0:50</item>
+        <item>0:55</item>
         <item>1:00</item>
+        <item>1:05</item>
+        <item>1:10</item>
+        <item>1:15</item>
+        <item>1:20</item>
+        <item>1:25</item>
         <item>1:30</item>
+        <item>1:35</item>
+        <item>1:40</item>
+        <item>1:45</item>
+        <item>1:50</item>
+        <item>1:55</item>
         <item>2:00</item>
+        <item>2:05</item>
+        <item>2:10</item>
+        <item>2:15</item>
+        <item>2:20</item>
+        <item>2:25</item>
         <item>2:30</item>
+        <item>2:35</item>
+        <item>2:40</item>
+        <item>2:45</item>
+        <item>2:50</item>
+        <item>2:55</item>
         <item>3:00</item>
+        <item>3:05</item>
+        <item>3:10</item>
+        <item>3:15</item>
+        <item>3:20</item>
+        <item>3:25</item>
         <item>3:30</item>
+        <item>3:35</item>
+        <item>3:40</item>
+        <item>3:45</item>
+        <item>3:50</item>
+        <item>3:55</item>
         <item>4:00</item>
+        <item>4:05</item>
+        <item>4:10</item>
+        <item>4:15</item>
+        <item>4:20</item>
+        <item>4:25</item>
         <item>4:30</item>
+        <item>4:35</item>
+        <item>4:40</item>
+        <item>4:45</item>
+        <item>4:50</item>
+        <item>4:55</item>
         <item>5:00</item>
+        <item>5:05</item>
+        <item>5:10</item>
+        <item>5:15</item>
+        <item>5:20</item>
+        <item>5:25</item>
         <item>5:30</item>
+        <item>5:35</item>
+        <item>5:40</item>
+        <item>5:45</item>
+        <item>5:50</item>
+        <item>5:55</item>
         <item>6:00</item>
+        <item>6:05</item>
+        <item>6:10</item>
+        <item>6:15</item>
+        <item>6:20</item>
+        <item>6:25</item>
         <item>6:30</item>
+        <item>6:35</item>
+        <item>6:40</item>
+        <item>6:45</item>
+        <item>6:50</item>
+        <item>6:55</item>
         <item>7:00</item>
+        <item>7:05</item>
+        <item>7:10</item>
+        <item>7:15</item>
+        <item>7:20</item>
+        <item>7:25</item>
         <item>7:30</item>
+        <item>7:35</item>
+        <item>7:40</item>
+        <item>7:45</item>
+        <item>7:50</item>
+        <item>7:55</item>
         <item>8:00</item>
+        <item>8:05</item>
+        <item>8:10</item>
+        <item>8:15</item>
+        <item>8:20</item>
+        <item>8:25</item>
         <item>8:30</item>
+        <item>8:35</item>
+        <item>8:40</item>
+        <item>8:45</item>
+        <item>8:50</item>
+        <item>8:55</item>
         <item>9:00</item>
+        <item>9:05</item>
+        <item>9:10</item>
+        <item>9:15</item>
+        <item>9:20</item>
+        <item>9:25</item>
         <item>9:30</item>
+        <item>9:35</item>
+        <item>9:40</item>
+        <item>9:45</item>
+        <item>9:50</item>
+        <item>9:55</item>
         <item>10:00</item>
+        <item>10:05</item>
+        <item>10:10</item>
+        <item>10:15</item>
+        <item>10:20</item>
+        <item>10:25</item>
         <item>10:30</item>
+        <item>10:35</item>
+        <item>10:40</item>
+        <item>10:45</item>
+        <item>10:50</item>
+        <item>10:55</item>
         <item>11:00</item>
+        <item>11:05</item>
+        <item>11:10</item>
+        <item>11:15</item>
+        <item>11:20</item>
+        <item>11:25</item>
         <item>11:30</item>
+        <item>11:35</item>
+        <item>11:40</item>
+        <item>11:45</item>
+        <item>11:50</item>
+        <item>11:55</item>
         <item>12:00</item>
+        <item>12:05</item>
+        <item>12:10</item>
+        <item>12:15</item>
+        <item>12:20</item>
+        <item>12:25</item>
         <item>12:30</item>
+        <item>12:35</item>
+        <item>12:40</item>
+        <item>12:45</item>
+        <item>12:50</item>
+        <item>12:55</item>
         <item>13:00</item>
+        <item>13:05</item>
+        <item>13:10</item>
+        <item>13:15</item>
+        <item>13:20</item>
+        <item>13:25</item>
         <item>13:30</item>
+        <item>13:35</item>
+        <item>13:40</item>
+        <item>13:45</item>
+        <item>13:50</item>
+        <item>13:55</item>
         <item>14:00</item>
+        <item>14:05</item>
+        <item>14:10</item>
+        <item>14:15</item>
+        <item>14:20</item>
+        <item>14:25</item>
         <item>14:30</item>
+        <item>14:35</item>
+        <item>14:40</item>
+        <item>14:45</item>
+        <item>14:50</item>
+        <item>14:55</item>
         <item>15:00</item>
+        <item>15:05</item>
+        <item>15:10</item>
+        <item>15:15</item>
+        <item>15:20</item>
+        <item>15:25</item>
         <item>15:30</item>
+        <item>15:35</item>
+        <item>15:40</item>
+        <item>15:45</item>
+        <item>15:50</item>
+        <item>15:55</item>
         <item>16:00</item>
+        <item>16:05</item>
+        <item>16:10</item>
+        <item>16:15</item>
+        <item>16:20</item>
+        <item>16:25</item>
         <item>16:30</item>
+        <item>16:35</item>
+        <item>16:40</item>
+        <item>16:45</item>
+        <item>16:50</item>
+        <item>16:55</item>
         <item>17:00</item>
+        <item>17:05</item>
+        <item>17:10</item>
+        <item>17:15</item>
+        <item>17:20</item>
+        <item>17:25</item>
         <item>17:30</item>
+        <item>17:35</item>
+        <item>17:40</item>
+        <item>17:45</item>
+        <item>17:50</item>
+        <item>17:55</item>
         <item>18:00</item>
+        <item>18:05</item>
+        <item>18:10</item>
+        <item>18:15</item>
+        <item>18:20</item>
+        <item>18:25</item>
         <item>18:30</item>
+        <item>18:35</item>
+        <item>18:40</item>
+        <item>18:45</item>
+        <item>18:50</item>
+        <item>18:55</item>
         <item>19:00</item>
+        <item>19:05</item>
+        <item>19:10</item>
+        <item>19:15</item>
+        <item>19:20</item>
+        <item>19:25</item>
         <item>19:30</item>
+        <item>19:35</item>
+        <item>19:40</item>
+        <item>19:45</item>
+        <item>19:50</item>
+        <item>19:55</item>
         <item>20:00</item>
+        <item>20:05</item>
+        <item>20:10</item>
+        <item>20:15</item>
+        <item>20:20</item>
+        <item>20:25</item>
         <item>20:30</item>
+        <item>20:35</item>
+        <item>20:40</item>
+        <item>20:45</item>
+        <item>20:50</item>
+        <item>20:55</item>
         <item>21:00</item>
+        <item>21:05</item>
+        <item>21:10</item>
+        <item>21:15</item>
+        <item>21:20</item>
+        <item>21:25</item>
         <item>21:30</item>
+        <item>21:35</item>
+        <item>21:40</item>
+        <item>21:45</item>
+        <item>21:50</item>
+        <item>21:55</item>
         <item>22:00</item>
+        <item>22:05</item>
+        <item>22:10</item>
+        <item>22:15</item>
+        <item>22:20</item>
+        <item>22:25</item>
         <item>22:30</item>
+        <item>22:35</item>
+        <item>22:40</item>
+        <item>22:45</item>
+        <item>22:50</item>
+        <item>22:55</item>
         <item>23:00</item>
+        <item>23:05</item>
+        <item>23:10</item>
+        <item>23:15</item>
+        <item>23:20</item>
+        <item>23:25</item>
         <item>23:30</item>
-        <item>24:00</item>
+        <item>23:35</item>
+        <item>23:40</item>
+        <item>23:45</item>
+        <item>23:50</item>
+        <item>23:55</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,4 +201,5 @@
     <string name="example_email">example@gmail.com</string>
     <string name="reviews_error_message">네트워크 연결을 확인해주세요</string>
     <string name="reviews_error_retry">다시 불러오기</string>
+    <string name="lecture_overlap_error_message">시간대 겹침</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 android.enableJetifier=true
 android.useAndroidX=true


### PR DESCRIPTION
pagination에서 중복 item -> 우선 key를 명시하지 않아서 position을 Key로 쓰도록 한다. comment로 단 영상처럼 보이게 되지만 드문 경우이고 사용에는 문제가 없으므로 패스

강의 겹침 다이얼로그 추가 -> 하면서 dialog 가로 길이도 원래 길이로 늘렸다. (여백 좌우 25sp)

시간-교시 관련 -> start, len field를 deprecate하고 start_time, end_time을 사용

trimparam 관련 -> trimparam에 속하지 않는 강의가 바깥쪽에 그려지던 것 수정
