### PR TITLE
시간-교시 변경 구 클라 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
+import kotlin.math.roundToInt
 
 @JsonClass(generateAdapter = true)
 @Parcelize
@@ -13,29 +14,29 @@ data class ClassTimeDto(
     @Json(name = "_id") val id: String? = null,
     @Json(name = "start_time") val start_time: String = "",
     @Json(name = "end_time") val end_time: String = "",
-    @Json(name = "start") val start: Float, // old
-    @Json(name = "len") val len: Float, // old
+    @Json(name = "start") val start: Float, // deprecated
+    @Json(name = "len") val len: Float, // deprecated
 ) : Parcelable {
 
     val startTimeInFloat: Float
         get() =
             if (start_time.isNotEmpty()) start_time.split(':')[0].toFloat() + start_time.split(':')[1].toFloat() / 60f
-            else start
+            else start + 8 // 구 클라 대응
 
     val endTimeInFloat: Float
         get() =
             if (end_time.isNotEmpty()) end_time.split(':')[0].toFloat() + end_time.split(':')[1].toFloat() / 60f
-            else start + len
+            else start + len + 8 // 구 클라 대응
 
     val startTimeHour: Int
         get() = startTimeInFloat.toInt()
 
     val startTimeMinute: Int
-        get() = start_time.split(':')[1].toInt()
+        get() = (60 * (startTimeInFloat - startTimeHour)).roundToInt()
 
     val endTimeHour: Int
         get() = endTimeInFloat.toInt()
 
     val endTimeMinute: Int
-        get() = end_time.split(':')[1].toInt()
+        get() = (60 * (endTimeInFloat - endTimeHour)).roundToInt()
 }


### PR DESCRIPTION
저장소의 lastViewTable이 구 클라의 classTime로 되어있을 때 start랑 len만 가지고도 정상적으로 동작하도록 변경
(서버가 시간-교시 변경 적용한 후로 한 번도 앱을 사용하지 않았을 경우만 해당하는 엣지 케이스)

SNUTTStringUtil의 getSimplifiedClassTime에서는 start_time을 직접 써서, 강의 상세에 들어가면 시간이 정상적으로 표시되지 않긴 한데 겨우 이것 때문에 구 클라 대응 코드를 추가하는 건 불필요하다고 생각해서 변경하지 않음
