### PR TITLE
BottomSheet 개편

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
@@ -40,6 +40,11 @@ class TableRepositoryImpl @Inject constructor(
     override suspend fun createTable(year: Long, semester: Long, title: String?) {
         val response = api._postTable(PostTableParams(year, semester, title))
         snuttStorage.tableMap.update(response.associateBy { it.id })
+        response
+            .firstOrNull { it.year == year && it.semester == semester && it.title == title }
+            ?.let {
+                fetchTableById(it.id)
+            }
     }
 
     override suspend fun deleteTable(id: String) {

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewContainer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewContainer.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.lib.android.webview
 
 import android.content.Context
-import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.webkit.*
 import androidx.compose.runtime.MutableState
@@ -19,9 +18,6 @@ class WebViewContainer(
     private val isDarkMode: Boolean,
 ) {
     val loadState: MutableState<LoadState> = mutableStateOf(LoadState.InitialLoading(0))
-
-    private val darkModeFlag =
-        context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
 
     val webView: WebView = WebView(context).apply {
         if (BuildConfig.DEBUG) {
@@ -116,5 +112,12 @@ class WebViewContainer(
             )
         }.flush()
         webView.reload()
+    }
+}
+
+class CloseBridge(val onClose: () -> (Unit)) {
+    @JavascriptInterface
+    fun postMessage(response: String) {
+        onClose()
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -1,6 +1,10 @@
 package com.wafflestudio.snutt2.views
 
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material.DrawerState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.navigation.NavController
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
@@ -21,6 +25,16 @@ val LocalApiOnProgress = compositionLocalOf<ApiOnProgress> {
 val LocalDrawerState = compositionLocalOf<DrawerState> {
     throw RuntimeException("")
 }
+
+@OptIn(ExperimentalMaterialApi::class)
+val LocalBottomSheetState = compositionLocalOf<ModalBottomSheetState> {
+    throw RuntimeException("")
+}
+
+val LocalBottomSheetContentSetter =
+    compositionLocalOf<(@Composable ColumnScope.() -> Unit) -> Unit> {
+        throw RuntimeException("")
+    }
 
 val LocalNavController = compositionLocalOf<NavController> {
     throw RuntimeException("")

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeDrawer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeDrawer.kt
@@ -96,7 +96,6 @@ fun HomeDrawer() {
                                 selectedCourseBook,
                                 newTableTitle
                             )
-                            // TODO: 새로 만들면 바로 그 시간표로 이동하면 좋지 않을까? (create의 응답으로 tableId가 와야 한다)
                             scope.launch {
                                 sheetState.hide()
                                 keyboardManager?.hide()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -123,8 +123,14 @@ fun HomePage() {
             bottomSheetContent = { Box(modifier = Modifier.size(1.dp)) }
         }
     }
-    BackHandler(enabled = sheetState.isVisible) {
-        scope.launch { sheetState.hide() }
+    BackHandler(enabled = sheetState.isVisible || drawerState.isOpen || pageController.homePageState.value != HomeItem.Timetable) {
+        if (sheetState.isVisible) {
+            scope.launch { sheetState.hide() }
+        } else if (drawerState.isOpen) {
+            scope.launch { drawerState.close() }
+        } else {
+            pageController.update(HomeItem.Timetable)
+        }
     }
 
     CompositionLocalProvider(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.home
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -121,6 +122,9 @@ fun HomePage() {
         if (!sheetState.isVisible) {
             bottomSheetContent = { Box(modifier = Modifier.size(1.dp)) }
         }
+    }
+    BackHandler(enabled = sheetState.isVisible) {
+        scope.launch { sheetState.hide() }
     }
 
     CompositionLocalProvider(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -37,12 +36,10 @@ import com.wafflestudio.snutt2.views.logged_in.home.HomeItem
 import kotlinx.coroutines.launch
 
 @Composable
-fun ReviewPage(height: Float = 1.0f) {
-    val context = LocalContext.current
+fun ReviewPage() {
     val webViewContainer = LocalReviewWebView.current
     val homePageController = LocalHomePageController.current
     val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
-    val scope = rememberCoroutineScope()
 
     val onBackPressedCallback = remember {
         object : OnBackPressedCallback(true) {
@@ -60,6 +57,14 @@ fun ReviewPage(height: Float = 1.0f) {
         onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(onBackPressedCallback)
         onDispose { onBackPressedCallback.remove() }
     }
+
+    ReviewWebView()
+}
+
+@Composable
+fun ReviewWebView(height: Float = 1.0f) {
+    val webViewContainer = LocalReviewWebView.current
+    val scope = rememberCoroutineScope()
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
@@ -37,7 +37,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.HomeItem
 import kotlinx.coroutines.launch
 
 @Composable
-fun ReviewPage() {
+fun ReviewPage(height: Float = 1.0f) {
     val context = LocalContext.current
     val webViewContainer = LocalReviewWebView.current
     val homePageController = LocalHomePageController.current
@@ -63,7 +63,8 @@ fun ReviewPage() {
 
     Column(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxWidth()
+            .fillMaxHeight(height)
             .background(SNUTTColors.White900)
     ) {
         when (val loadState = webViewContainer.loadState.value) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchOptionSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchOptionSheet.kt
@@ -52,7 +52,6 @@ fun SearchOptionSheet(
         modifier = Modifier
             .background(SNUTTColors.White900)
             .fillMaxWidth()
-            .clicks { }
     ) {
         Spacer(modifier = Modifier.height(40.dp))
         // tag column의 높이를 tagType column의 높이로 설정

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -106,9 +106,14 @@ fun SearchPage(
         )
     }
 
+    // 강의평 바텀시트가 한번 올라왔다가 내려갈 때 원래 보던 창으로 돌아가기 위해 goBack() 수행
+    // * 처음 SearchPage에 진입할 때도 sheetState는 invisible일 텐데, 이 때는 goBack() 하지 않아야 한다. (sheetWasShown 변수 존재 이유)
+    var sheetWasShown by remember { mutableStateOf(false) }
     LaunchedEffect(sheetState.isVisible) {
-        if (!sheetState.isVisible) {
+        if (!sheetState.isVisible && sheetWasShown) {
             reviewWebViewContainer.webView.goBack()
+        } else {
+            sheetWasShown = true
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -108,7 +108,7 @@ fun SearchPage(
 
     LaunchedEffect(sheetState.isVisible) {
         if (!sheetState.isVisible) {
-            reviewWebViewContainer.openPage(null)
+            reviewWebViewContainer.webView.goBack()
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -10,13 +10,13 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
@@ -104,7 +104,7 @@ val LocalCanvasContext = compositionLocalOf<CanvasContext> {
     throw RuntimeException("")
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun TimetablePage(
     uncheckedNotification: Boolean

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -44,7 +44,7 @@ import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.isDarkMode
 import com.wafflestudio.snutt2.views.*
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewPage
+import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import kotlinx.coroutines.*
 
@@ -111,6 +111,9 @@ fun LectureDetailPage() {
                 )
             }
         }
+    BackHandler(enabled = sheetState.isVisible) {
+        scope.launch { sheetState.hide() }
+    }
 
     CompositionLocalProvider(
         LocalReviewWebView provides reviewWebViewContainer,
@@ -419,7 +422,7 @@ fun LectureDetailPage() {
                                         joinAll(job)
                                         scope.launch {
                                             sheetContentSetter.invoke {
-                                                ReviewPage(0.95f)
+                                                ReviewWebView(0.95f)
                                             }
                                             sheetState.show()
                                         }


### PR DESCRIPTION
- 이상한 기존 형태를 버리고, ModalBottomSheetLayout를 사용해서 정리

- 하위 컴포저블에서는 compositionLocal로 받는 람다를 이용하여 그때그때 바텀시트 내부 content를 설정

- 이렇게 만든 바텀시트를 HomeDrawer의 각종 기능, SearchPage의 필터, 그리고 LectureDetail의 강의평에 적용

https://user-images.githubusercontent.com/88367636/209560671-0ac5128e-1ba5-4ed2-b59c-93f8702705a3.mp4



FIXME
- LectureDetail이랑 HomePage가 서로 다른 Destination의 컴포저블이라 ModalBottomSheetLayout를 양 쪽에 모두 적용하거나, RootActivity의 setUpUI에서 적용해야 하는데

  - 양쪽 모두 적용: 반복되는 코드가 생김
  - setUpUI에 적용: transition animation이 이상해짐

TODO
1. HomeDrawer() 함수가 람다 지옥으로 인해 가독성이 매우 낮아, 코드 정리가 필요
2. 바뀐 바텀시트를 강의 시간 변경하는 부분에 적용하기 (Picker 새롭게 디자인도 필요)