### PR TITLE
rootActivity 내 코드 간소화 및 refreshData 함수 일부 변경

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -34,7 +34,6 @@ import com.wafflestudio.snutt2.views.logged_in.home.HomePageController
 import com.wafflestudio.snutt2.views.logged_in.home.HomeViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.popups.PopupState
 import com.wafflestudio.snutt2.views.logged_in.home.settings.*
-import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimetableViewModel
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureColorSelectorPage
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailCustomPage
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailPage
@@ -44,8 +43,6 @@ import com.wafflestudio.snutt2.views.logged_out.SignInPage
 import com.wafflestudio.snutt2.views.logged_out.SignUpPage
 import com.wafflestudio.snutt2.views.logged_out.TutorialPage
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -53,8 +50,6 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class RootActivity : AppCompatActivity() {
     private val userViewModel: UserViewModel by viewModels()
-
-    private val timetableViewModel: TimetableViewModel by viewModels()
 
     private val homeViewModel: HomeViewModel by viewModels()
 
@@ -76,20 +71,14 @@ class RootActivity : AppCompatActivity() {
         setContentView(R.layout.activity_root)
 
         lifecycleScope.launch {
-            var token = userViewModel.accessToken.filterNotNull().first()
-            if (token.isNotEmpty()) {
-                try {
-                    homeViewModel.refreshData()
-                } catch (e: Exception) {
-                    // when storage's token is invalid
-                    token = ""
-                }
-            }
-            val startDestination =
-                if (token.isEmpty()) NavigationDestination.Onboard else NavigationDestination.Home
-            setUpContents(startDestination)
+            homeViewModel.refreshData()
             isInitialRefreshFinished = true
         }
+        val token = userViewModel.accessToken.value
+        setUpContents(
+            if (token.isEmpty()) NavigationDestination.Onboard
+            else NavigationDestination.Home
+        )
         setUpSplashScreen(composeRoot)
         startUpdatingPushToken()
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -76,10 +76,14 @@ class RootActivity : AppCompatActivity() {
         setContentView(R.layout.activity_root)
 
         lifecycleScope.launch {
-            val token = userViewModel.accessToken.filterNotNull().first()
+            var token = userViewModel.accessToken.filterNotNull().first()
             if (token.isNotEmpty()) {
-                homeViewModel.refreshData()
-                userViewModel.fetchPopup()
+                try {
+                    homeViewModel.refreshData()
+                } catch (e: Exception) {
+                    // when storage's token is invalid
+                    token = ""
+                }
             }
             val startDestination =
                 if (token.isEmpty()) NavigationDestination.Onboard else NavigationDestination.Home

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.views.logged_in.home
 
 import androidx.lifecycle.ViewModel
+import com.wafflestudio.snutt2.data.current_table.CurrentTableRepository
 import com.wafflestudio.snutt2.data.notifications.NotificationRepository
 import com.wafflestudio.snutt2.data.tables.TableRepository
 import com.wafflestudio.snutt2.data.user.UserRepository
@@ -12,6 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    private val currentTableRepository: CurrentTableRepository,
     private val tableRepository: TableRepository,
     private val userRepository: UserRepository,
     private val notificationRepository: NotificationRepository,
@@ -21,8 +23,9 @@ class HomeViewModel @Inject constructor(
         try {
             coroutineScope {
                 awaitAll(
-                    async { tableRepository.fetchDefaultTable() },
-                    async { tableRepository.getTableList() },
+                    async {
+                        currentTableRepository.currentTable.value ?: tableRepository.fetchDefaultTable()
+                    },
                     async { userRepository.fetchUserInfo() },
                 )
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -27,6 +27,7 @@ class HomeViewModel @Inject constructor(
                         currentTableRepository.currentTable.value ?: tableRepository.fetchDefaultTable()
                     },
                     async { userRepository.fetchUserInfo() },
+                    async { userRepository.fetchAndSetPopup() },
                 )
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignInPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignInPage.kt
@@ -56,7 +56,6 @@ fun SignInPage() {
                 apiOnProgress.showProgress()
                 userViewModel.loginLocal(idField, passwordField)
                 homeViewModel.refreshData()
-                userViewModel.fetchPopup()
                 navController.navigateAsOrigin(NavigationDestination.Home)
             } catch (e: Exception) {
                 apiOnError(e)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignUpPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignUpPage.kt
@@ -29,6 +29,7 @@ import com.wafflestudio.snutt2.lib.android.toast
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.views.*
+import com.wafflestudio.snutt2.views.logged_in.home.HomeViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import kotlinx.coroutines.launch
 
@@ -43,6 +44,7 @@ fun SignUpPage() {
     val coroutineScope = rememberCoroutineScope()
 
     val userViewModel = hiltViewModel<UserViewModel>()
+    val homeViewModel = hiltViewModel<HomeViewModel>()
 
     var idField by remember { mutableStateOf("") }
     var passwordField by remember { mutableStateOf("") }
@@ -58,7 +60,7 @@ fun SignUpPage() {
                 try {
                     apiOnProgress.showProgress()
                     userViewModel.signUpLocal(idField, emailField, passwordField)
-                    userViewModel.fetchPopup()
+                    homeViewModel.refreshData()
                     navController.navigateAsOrigin(NavigationDestination.Home)
                 } catch (e: Exception) {
                     apiOnError(e)


### PR DESCRIPTION
~~1. Storage의 token이 invalid할 경우 refreshData()에서 에러가 나므로 catch하고 token을 empty로 바꿔서 Onboard로 이동하도록 유도~~
2. refreshData() 함수에서 popup도 fetch하도록 변경
3. recent table API는 local storage에 시간표가 없을 때만 사용
4. setUpContents()가 refreshData() 이후 수행되어서 스플래시가 UI 다 그려지기 전에 꺼지는 것 수정


FIXME: 만약에 유저가 탈퇴했는데, 탈퇴하기 전 해당 계정으로 로그인되어있던 다른 기기에서 앱을 켜면 터지는 문제 존재. ApiOnError에서 WRONG_USER_TOKEN를 캐치하고 로그아웃을 시도하는데, 유저가 탈퇴한 상태니 또 exception이 나고 여기서 Toast를 낼 때 크래시가 나는 상황