### PR TITLE
검색 페이지에서 강의 상세 페이지를 바텀시트로 띄우도록 변경

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -60,6 +60,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.TableListViewModelNew
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimeTable
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimetableViewModel
+import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailPage
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailViewModelNew
 import kotlinx.coroutines.*
 
@@ -272,7 +273,12 @@ fun SearchPage(
                                     }, onClickDetail = {
                                         lectureDetailViewModel.initializeEditingLectureDetail(it.item)
                                         lectureDetailViewModel.setViewMode(true)
-                                        navController.navigate(NavigationDestination.LectureDetail)
+                                        bottomSheetContentSetter.invoke {
+                                            LectureDetailPage(onCloseViewMode = {
+                                                scope.launch { sheetState.hide() }
+                                            })
+                                        }
+                                        scope.launch { sheetState.show() }
                                     }, onClickReview = {
                                         scope.launch {
                                             val job: CompletableJob = Job()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.*
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun LectureDetailPage() {
+fun LectureDetailPage(onCloseViewMode: () -> Unit = {}) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
@@ -116,7 +116,7 @@ fun LectureDetailPage() {
                     } else editExitDialogState = true
                 } else if (viewMode) {
                     vm.setViewMode(false)
-                    navController.popBackStack()
+                    onCloseViewMode()
                 } else {
                     navController.popBackStack()
                 }


### PR DESCRIPTION
- Navigate로 강의 상세 페이지를 갔다 오면 LazyListState가 보존이 되지 않는 문제가 존재 (스크롤이 초기화)

- RootActivity까지 state hoist를 하면 해결될 것 같긴 한데 
   - RootActivity -> HomePage -> SearchPage까지 lazyListState를 파라미터로 옮겨줘야 하고(또는 compositionLocal), 
   - SearchViewModel에서 query()나 clear() 함수 쓸 때 lazyListState를 초기화 해야 하는데 다시 이벤트를 전달하는 콜백까지 필요합니다.
   
그래서 어차피 '강의평'도 바텀시트로 나오는 거, 통일성도 갖출 겸 '자세히'도 바텀시트로 나오면 좋지 않을까 생각했습니다.

https://user-images.githubusercontent.com/88367636/210176811-43e9a533-2205-4baf-84fc-071d3bb2d75a.mp4


