### PR TITLE
필요한 recompose를 막는 불필요한 remember 제거

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -258,13 +258,12 @@ fun TimeTable(
     val dayLabelHeight = CanvasPalette.dayLabelHeight
 
     val trimParam = TableContext.current.trimParam
-    val fittedTrimParam = remember {
+    val fittedTrimParam =
         if (trimParam.forceFitLectures) {
             (selectedLecture?.let { lectures + it } ?: lectures).getFittingTrimParam(
                 TableTrimParam.Default
             )
         } else trimParam
-    }
 
     Canvas(
         modifier = Modifier
@@ -420,7 +419,7 @@ private fun DrawClassTime(
     val lectureCellBorderPaint = CanvasPalette.lectureCellBorderPaint
 
     val dayOffset = classTime.day - fittedTrimParam.dayOfWeekFrom
-    val hourRangeOffset = remember {
+    val hourRangeOffset =
         Pair(
             max(classTime.startTimeInFloat - fittedTrimParam.hourFrom, 0f),
             min(
@@ -428,7 +427,6 @@ private fun DrawClassTime(
                 fittedTrimParam.hourTo - fittedTrimParam.hourFrom.toFloat() + 1
             )
         )
-    }
 
     Canvas(modifier = Modifier.fillMaxSize()) {
         val unitWidth =


### PR DESCRIPTION
#118 의 실수
fittedTrimParam 계산에 remember를 붙여 놔서 재구성이 가끔 되지 않았다.
예) 검색 화면에서 토요일 강의를 선택하면 요일 범위가 늘어나야 하는데 변하지 않음

fittedTrimParam을 받아서 hourRangeOffset을 계산할 때도 재구성이 가끔 되지 않았다.
예) trimParam이 변한 직후, selectedLecture의 그림자가 잘못된 위치에 표시됨