### PR TITLE
JobCancellationException 캐치하기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/ApiOnError.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/ApiOnError.kt
@@ -296,6 +296,7 @@ class ApiOnError @Inject constructor(
                         ).show()
                     }
                 }
+                is kotlinx.coroutines.CancellationException -> {} // do nothing
                 else -> {
                     Toast.makeText(
                         context,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -596,7 +596,7 @@ suspend fun lectureApiWithOverlapDialog(
         when (e) {
             is ErrorParsedHttpException -> {
                 if (e.errorDTO?.code == LECTURE_TIME_OVERLAP) {
-                    onLectureOverlap(e.errorDTO.ext!!["confirm_message"] ?: "")
+                    onLectureOverlap(e.errorDTO.ext?.get("confirm_message") ?: "")
                 } else apiOnError(e)
             }
             else -> apiOnError(e)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetableViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetableViewModel.kt
@@ -39,10 +39,11 @@ class TimetableViewModel @Inject constructor(
     }
 
     suspend fun updateTheme() {
-        tableRepository.updateTableTheme(
-            currentTable.value?.id!!,
-            previewTheme.value!!
-        ) // FIXME
+        currentTable.value?.id?.let { id ->
+            previewTheme.value?.let { theme ->
+                tableRepository.updateTableTheme(id, theme)
+            }
+        }
     }
 
     suspend fun setPreviewTheme(previewTheme: TimetableColorTheme?) {


### PR DESCRIPTION
- API를 부르거나 코루틴을 쓰는 버튼을 뒤로가기 버튼과 동시에 누르면 JobCancellationException이 나는데, apiOnError가 이걸 안 잡으면 ```알 수 없는 에러입니다``` 가 뜨게 된다. 
- 부자연스럽기 때문에 캐치해서 아무 동작도 하지 않도록 수정
- 그리고 안전을 위해 !! 두 개 ?:로 변경