### PR TITLE
Picker에서 IndexOutOfBoundsException 방어

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/Picker.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/Picker.kt
@@ -69,44 +69,46 @@ fun <T> Picker(
                 }
             ),
     ) {
-        if (centerItemIndex > 1) {
+        if (list.isNotEmpty()) {
+            if (centerItemIndex > 1) {
+                PickerItem(
+                    modifier = Modifier
+                        .offset(y = -columnHeightDp * 2 + localOffset.dp)
+                        .alpha((columnHeightDp / 4 + localOffset.dp / 2) / columnHeightDp),
+                    content = {
+                        PickerItemContent(centerItemIndex - 2)
+                    }
+                )
+            }
+            if (centerItemIndex > 0) {
+                PickerItem(
+                    modifier = Modifier
+                        .offset(y = -columnHeightDp + localOffset.dp)
+                        .alpha((columnHeightDp * 3 / 4 + localOffset.dp / 2) / columnHeightDp),
+                    content = { PickerItemContent(centerItemIndex - 1) }
+                )
+            }
+            Box(modifier = Modifier.height(columnHeightDp).fillMaxWidth().background(SNUTTColors.Gray100, RoundedCornerShape(30f)).offset(y = -columnHeightDp / 2).zIndex(-5f))
             PickerItem(
-                modifier = Modifier
-                    .offset(y = -columnHeightDp * 2 + localOffset.dp)
-                    .alpha((columnHeightDp / 4 + localOffset.dp / 2) / columnHeightDp),
-                content = {
-                    PickerItemContent(centerItemIndex - 2)
-                }
+                modifier = Modifier.offset(y = localOffset.dp),
+                content = { PickerItemContent(centerItemIndex) }
             )
-        }
-        if (centerItemIndex > 0) {
-            PickerItem(
-                modifier = Modifier
-                    .offset(y = -columnHeightDp + localOffset.dp)
-                    .alpha((columnHeightDp * 3 / 4 + localOffset.dp / 2) / columnHeightDp),
-                content = { PickerItemContent(centerItemIndex - 1) }
-            )
-        }
-        Box(modifier = Modifier.height(columnHeightDp).fillMaxWidth().background(SNUTTColors.Gray100, RoundedCornerShape(30f)).offset(y = -columnHeightDp / 2).zIndex(-5f))
-        PickerItem(
-            modifier = Modifier.offset(y = localOffset.dp),
-            content = { PickerItemContent(centerItemIndex) }
-        )
-        if (list.isNotEmpty() && centerItemIndex < list.size - 1) {
-            PickerItem(
-                modifier = Modifier
-                    .offset(y = columnHeightDp + localOffset.dp)
-                    .alpha(-(-columnHeightDp * 3 / 4 + localOffset.dp / 2) / columnHeightDp),
-                content = { PickerItemContent(centerItemIndex + 1) }
-            )
-        }
-        if (list.isNotEmpty() && centerItemIndex < list.size - 2) {
-            PickerItem(
-                modifier = Modifier
-                    .offset(y = columnHeightDp * 2 + localOffset.dp)
-                    .alpha(-(-columnHeightDp / 4 + localOffset.dp / 2) / columnHeightDp),
-                content = { PickerItemContent(centerItemIndex + 2) }
-            )
+            if (centerItemIndex < list.size - 1) {
+                PickerItem(
+                    modifier = Modifier
+                        .offset(y = columnHeightDp + localOffset.dp)
+                        .alpha(-(-columnHeightDp * 3 / 4 + localOffset.dp / 2) / columnHeightDp),
+                    content = { PickerItemContent(centerItemIndex + 1) }
+                )
+            }
+            if (centerItemIndex < list.size - 2) {
+                PickerItem(
+                    modifier = Modifier
+                        .offset(y = columnHeightDp * 2 + localOffset.dp)
+                        .alpha(-(-columnHeightDp / 4 + localOffset.dp / 2) / columnHeightDp),
+                    content = { PickerItemContent(centerItemIndex + 2) }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/Picker.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/Picker.kt
@@ -92,7 +92,7 @@ fun <T> Picker(
             modifier = Modifier.offset(y = localOffset.dp),
             content = { PickerItemContent(centerItemIndex) }
         )
-        if (centerItemIndex < list.size - 1) {
+        if (list.isNotEmpty() && centerItemIndex < list.size - 1) {
             PickerItem(
                 modifier = Modifier
                     .offset(y = columnHeightDp + localOffset.dp)
@@ -100,7 +100,7 @@ fun <T> Picker(
                 content = { PickerItemContent(centerItemIndex + 1) }
             )
         }
-        if (centerItemIndex < list.size - 2) {
+        if (list.isNotEmpty() && centerItemIndex < list.size - 2) {
             PickerItem(
                 modifier = Modifier
                     .offset(y = columnHeightDp * 2 + localOffset.dp)


### PR DESCRIPTION
네트워크가 끊긴 채로 homeDrawer에 들어가서 + 버튼을 누르면 빈 리스트로 Picker UI를 만들게 되는데, 이때 앱이 터진다.
빈 list로 Picker를 띄우려 하면 아무 것도 안 뜨도록 수정