### PR TITLE
학점을 음수로 편집할 수 없게 변경

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -1210,7 +1210,7 @@ fun LectureDetailPagePreview() {
 
 fun String.stringToLong(): Long {
     return try {
-        this.toLong()
+        this.toLong().coerceAtLeast(0L)
     } catch (e: Exception) {
         0
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -86,6 +86,10 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, onCloseViewMode: () -> Unit
     var lectureOverlapDialogMessage by remember { mutableStateOf("") }
     var creditText by remember { mutableStateOf(editingLectureDetail.credit.toString()) }
     // FIXME: 이걸 이렇게밖에 못하나..
+    /* 현재 LectureDto 타입의 editingLectureDetail 플로우를 변경해 가면서 API 부를 때도 쓰고 화면에 정보 표시할 때도 쓰고 있는데,
+     * credit은 Long 타입이라서 학점 입력하는 editText에 빈 문자열을 넣었을 때(=다 지웠을 때) 문제가 발생한다. 그래서 credit만 별도의 MutableState<String>을 둬서 운용한다.
+     * 이때 다른 정보들은 editingLectureDetail 따라서 바뀌니까 모드가 바뀌어도 따로 할 게 없는데, 얘는 편집모드->일반모드로 바뀔 때 따로 변경해 줘야 한다. 그것이 아래의 코드.
+     */
     LaunchedEffect(editMode) {
         if (editMode.not()) creditText = editingLectureDetail.credit.toString()
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -348,7 +348,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, onCloseViewMode: () -> Unit
                                     vm.editEditingLectureDetail(editingLectureDetail.copy(credit = it.creditStringToLong()))
                                 },
                                 enabled = editMode,
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                                 modifier = Modifier.fillMaxWidth(),
                                 underlineEnabled = false,
                                 textStyle = SNUTTTypography.body1.copy(fontSize = 15.sp),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -341,7 +341,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, onCloseViewMode: () -> Unit
                                 value = creditText,
                                 onValueChange = {
                                     creditText = it
-                                    vm.editEditingLectureDetail(editingLectureDetail.copy(credit = it.stringToLong()))
+                                    vm.editEditingLectureDetail(editingLectureDetail.copy(credit = it.creditStringToLong()))
                                 },
                                 enabled = editMode,
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -1208,7 +1208,7 @@ fun LectureDetailPagePreview() {
 //    LectureDetailPage()
 }
 
-fun String.stringToLong(): Long {
+fun String.creditStringToLong(): Long {
     return try {
         this.toLong().coerceAtLeast(0L)
     } catch (e: Exception) {


### PR DESCRIPTION
[관련 스레드](https://wafflestudio.slack.com/archives/C8M9NUBBR/p1675871901565269)

음수 입력 자체를 막는 건 이상할 것 같고, 음수를 입력하고 완료 버튼 누르면 강제로 0으로 변경

https://user-images.githubusercontent.com/88367636/217588859-f70f7d63-14e1-4cee-9321-5767240d5bfd.mp4

