### PR TITLE
Bookmarks minor patch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -197,7 +197,7 @@ dependencies {
     implementation("com.github.skydoves:colorpickerview:2.2.3")
     implementation("com.jakewharton.timber:timber:4.7.1")
     implementation("androidx.core:core-splashscreen:1.0.0")
-    implementation("com.google.accompanist:accompanist-navigation-animation:0.29.0-alpha")
+    implementation("com.google.accompanist:accompanist-navigation-animation:0.29.1-alpha")
 
     // coil
     implementation("io.coil-kt:coil-compose:2.1.0")

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/TopBar.kt
@@ -89,7 +89,10 @@ fun TopBar(
                 verticalAlignment = Alignment.CenterVertically
             ) { title() }
 
-            Row(modifier = Modifier.wrapContentWidth()) { actions() }
+            Row(
+                modifier = Modifier.wrapContentWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) { actions() }
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/TopBar.kt
@@ -39,7 +39,7 @@ fun SimpleTopBar(
         },
         navigationIcon = {
             ArrowBackIcon(
-                modifier = Modifier.clicks { onClickNavigateBack() },
+                modifier = Modifier.clicks(1000L) { onClickNavigateBack() },
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/current_table/CurrentTableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/current_table/CurrentTableRepositoryImpl.kt
@@ -95,10 +95,10 @@ class CurrentTableRepositoryImpl @Inject constructor(
     // 유저 시간표 내의 강의는 id가 바뀌어 저장되기 때문에, parent id인 lecture_id 필드를 사용한다.
     // 검색 결과 혹은 관심강좌의 강의는 원본 그대로이므로 lecture_id == null이며, id 필드를 그대로 사용한다.
     override suspend fun addBookmark(lecture: LectureDto) {
-        api._addBookmark(PostBookmarkParams(lecture.lecture_id?:lecture.id))
+        api._addBookmark(PostBookmarkParams(lecture.lecture_id ?: lecture.id))
     }
 
     override suspend fun deleteBookmark(lecture: LectureDto) {
-        api._deleteBookmark(PostBookmarkParams(lecture.lecture_id?:lecture.id))
+        api._deleteBookmark(PostBookmarkParams(lecture.lecture_id ?: lecture.id))
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/current_table/CurrentTableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/current_table/CurrentTableRepositoryImpl.kt
@@ -92,11 +92,13 @@ class CurrentTableRepositoryImpl @Inject constructor(
         } ?: emptyList()
     }
 
+    // 유저 시간표 내의 강의는 id가 바뀌어 저장되기 때문에, parent id인 lecture_id 필드를 사용한다.
+    // 검색 결과 혹은 관심강좌의 강의는 원본 그대로이므로 lecture_id == null이며, id 필드를 그대로 사용한다.
     override suspend fun addBookmark(lecture: LectureDto) {
-        api._addBookmark(PostBookmarkParams(lecture.id))
+        api._addBookmark(PostBookmarkParams(lecture.lecture_id?:lecture.id))
     }
 
     override suspend fun deleteBookmark(lecture: LectureDto) {
-        api._deleteBookmark(PostBookmarkParams(lecture.id))
+        api._deleteBookmark(PostBookmarkParams(lecture.lecture_id?:lecture.id))
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/LectureDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/LectureDto.kt
@@ -9,6 +9,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class LectureDto(
     @Json(name = "_id") val id: String,
+    @Json(name = "lecture_id") val lecture_id: String? = null,
     @Json(name = "classification") val classification: String?,
     @Json(name = "department") val department: String?,
     @Json(name = "academic_year") val academic_year: String?,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -176,7 +176,8 @@ class RootActivity : AppCompatActivity() {
                         navController.getBackStackEntry(NavigationDestination.Home)
                     }
                     val lectureDetailViewModel = hiltViewModel<LectureDetailViewModelNew>(parentEntry)
-                    LectureDetailPage(lectureDetailViewModel)
+                    val searchViewModel = hiltViewModel<SearchViewModel>(parentEntry)
+                    LectureDetailPage(lectureDetailViewModel, searchViewModel)
                 }
 
                 composable2(NavigationDestination.LectureColorSelector) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -417,9 +417,11 @@ fun LazyItemScope.SearchListItem(
                             )
                             lectureDetailViewModel.setViewMode(true)
                             bottomSheetContentSetter.invoke {
-                                LectureDetailPage(onCloseViewMode = {
-                                    scope.launch { sheetState.hide() }
-                                }, vm = lectureDetailViewModel)
+                                LectureDetailPage(onCloseViewMode = { scope ->
+                                    scope.launch {
+                                        sheetState.hide()
+                                    }
+                                }, vm = lectureDetailViewModel, searchViewModel = searchViewModel)
                             }
                             scope.launch { sheetState.show() }
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -499,6 +499,7 @@ fun LazyItemScope.SearchListItem(
                                                             searchViewModel.deleteBookmark(
                                                                 lectureDataWithState.item
                                                             )
+                                                            searchViewModel.toggleLectureSelection(lectureDataWithState.item)
                                                             modalState.hide()
                                                             context.toast(context.getString(R.string.bookmark_remove_toast))
                                                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -209,7 +209,7 @@ fun TimetablePage() {
                     BookmarkPageIcon(
                         modifier = centerAlignedModifier
                             .size(30.dp)
-                            .clicks { navController.navigate(NavigationDestination.Bookmark) },
+                            .clicks { navController.navigate(NavigationDestination.Bookmark) { launchSingleTop = true } },
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900)
                     )
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -144,7 +144,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
     }
 
     val bookmarkList by searchViewModel.bookmarkList.collectAsState()
-    val isBookmarked = remember(bookmarkList) { bookmarkList.map { it.item.id }.contains(editingLectureDetail.id) }
+    val isBookmarked = remember(bookmarkList) { bookmarkList.map { it.item.id }.contains(editingLectureDetail.lecture_id) }
     LaunchedEffect(Unit) {
         if (isCustom.not()) {
             scope.launch {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -213,7 +213,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
                         )
                     },
                     actions = {
-                        if (isCustom.not()) {
+                        if (isCustom.not() && editMode.not()) {
                             BookmarkIcon(
                                 modifier = Modifier.size(30.dp).clicks {
                                     scope.launch {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -144,7 +144,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
     }
 
     val bookmarkList by searchViewModel.bookmarkList.collectAsState()
-    val isBookmarked = remember(bookmarkList) { bookmarkList.map { it.item.id }.contains(editingLectureDetail.lecture_id?:editingLectureDetail.id) }
+    val isBookmarked = remember(bookmarkList) { bookmarkList.map { it.item.id }.contains(editingLectureDetail.lecture_id ?: editingLectureDetail.id) }
     LaunchedEffect(Unit) {
         if (isCustom.not()) {
             scope.launch {
@@ -213,7 +213,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
                         )
                     },
                     actions = {
-                        if(isCustom.not()) {
+                        if (isCustom.not()) {
                             BookmarkIcon(
                                 modifier = Modifier.size(30.dp).clicks {
                                     scope.launch {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -144,7 +144,7 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
     }
 
     val bookmarkList by searchViewModel.bookmarkList.collectAsState()
-    val isBookmarked = remember(bookmarkList) { bookmarkList.map { it.item.id }.contains(editingLectureDetail.lecture_id) }
+    val isBookmarked = remember(bookmarkList) { bookmarkList.map { it.item.id }.contains(editingLectureDetail.lecture_id?:editingLectureDetail.id) }
     LaunchedEffect(Unit) {
         if (isCustom.not()) {
             scope.launch {
@@ -213,27 +213,27 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
                         )
                     },
                     actions = {
-                        if (vm.isViewMode().not()) {
-                            if(isCustom.not()) {
-                                BookmarkIcon(
-                                    modifier = Modifier.size(30.dp).clicks {
-                                        scope.launch {
-                                            launchSuspendApi(apiOnProgress, apiOnError) {
-                                                if (isBookmarked) {
-                                                    searchViewModel.deleteBookmark(editingLectureDetail)
-                                                    context.toast("관심강좌 목록에서 제외하였습니다.")
-                                                } else {
-                                                    searchViewModel.addBookmark(editingLectureDetail)
-                                                    context.toast("관심장좌 목록에 추가하였습니다.")
-                                                }
+                        if(isCustom.not()) {
+                            BookmarkIcon(
+                                modifier = Modifier.size(30.dp).clicks {
+                                    scope.launch {
+                                        launchSuspendApi(apiOnProgress, apiOnError) {
+                                            if (isBookmarked) {
+                                                searchViewModel.deleteBookmark(editingLectureDetail)
+                                                context.toast("관심강좌 목록에서 제외하였습니다.")
+                                            } else {
+                                                searchViewModel.addBookmark(editingLectureDetail)
+                                                context.toast("관심장좌 목록에 추가하였습니다.")
                                             }
                                         }
-                                    },
-                                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                                    marked = isBookmarked,
-                                )
-                                Spacer(modifier = Modifier.width(10.dp))
-                            }
+                                    }
+                                },
+                                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                                marked = isBookmarked,
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                        }
+                        if (vm.isViewMode().not()) {
                             Text(
                                 text = if (editMode) stringResource(R.string.lecture_detail_top_bar_complete)
                                 else stringResource(R.string.lecture_detail_top_bar_edit),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -214,6 +214,26 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
                     },
                     actions = {
                         if (vm.isViewMode().not()) {
+                            if(isCustom.not()) {
+                                BookmarkIcon(
+                                    modifier = Modifier.size(30.dp).clicks {
+                                        scope.launch {
+                                            launchSuspendApi(apiOnProgress, apiOnError) {
+                                                if (isBookmarked) {
+                                                    searchViewModel.deleteBookmark(editingLectureDetail)
+                                                    context.toast("관심강좌 목록에서 제외하였습니다.")
+                                                } else {
+                                                    searchViewModel.addBookmark(editingLectureDetail)
+                                                    context.toast("관심장좌 목록에 추가하였습니다.")
+                                                }
+                                            }
+                                        }
+                                    },
+                                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                                    marked = isBookmarked,
+                                )
+                                Spacer(modifier = Modifier.width(10.dp))
+                            }
                             Text(
                                 text = if (editMode) stringResource(R.string.lecture_detail_top_bar_complete)
                                 else stringResource(R.string.lecture_detail_top_bar_edit),
@@ -605,21 +625,6 @@ fun LectureDetailPage(vm: LectureDetailViewModelNew, searchViewModel: SearchView
                                                         }.show()
                                                 }
                                             )
-                                        }
-                                    }
-                                    LectureDetailButton(
-                                        title = if (isBookmarked) stringResource(R.string.lecture_detail_remove_bookmark_button) else stringResource(R.string.lecture_detail_add_bookmark_button)
-                                    ) {
-                                        scope.launch {
-                                            launchSuspendApi(apiOnProgress, apiOnError) {
-                                                if (isBookmarked) {
-                                                    searchViewModel.deleteBookmark(editingLectureDetail)
-                                                    context.toast("관심장좌 목록에서 제외하였습니다.")
-                                                } else {
-                                                    searchViewModel.addBookmark(editingLectureDetail)
-                                                    context.toast("관심장좌 목록에 추가하였습니다.")
-                                                }
-                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,8 @@
     <string name="lecture_detail_review_button">강의평</string>
     <string name="lecture_detail_reset_button">초기화</string>
     <string name="lecture_detail_delete_button">삭제</string>
+    <string name="lecture_detail_add_bookmark_button">관심강좌 지정</string>
+    <string name="lecture_detail_remove_bookmark_button">관심강좌 제외</string>
     <string name="lecture_detail_remark_hint">비고를 입력해주세요</string>
     <string name="lecture_detail_add_class_time">+ 시간 및 장소 추가</string>
     <string name="lecture_detail_delete_dialog_title">강의 삭제</string>


### PR DESCRIPTION
## 변경사항
- 강의 상세 페이지에서 관심강좌 지정/해제 가능하게 변경


https://user-images.githubusercontent.com/88367636/224707885-13d1d589-c336-405e-813e-493ce6280947.mp4


- 버그 방어 
    - TopBar의 action 버튼에 연타방지 시간 충분히 길게 변경)
    - 관심강좌 페이지 navigate할 때 `launchSingleTop = true`로 변경 (그냥 이걸 디폴트로 하는 확장 함수를 만드는 게..)

- LectureDto에 lecture_id 필드 추가
    - `isBookmarked`를 따지는 로직이나 API에서는 `lecture_id`가 null이 아니면 그것을 사용하고(내 로컬 강의이므로), null인 경우 `id`를 사용한다.
        - 관심강좌 페이지나 강의 검색 결과로 관심강좌 추가/제거 할 때는 `id` 필드 사용
        - 내 시간표 강의의 상세 페이지에서 할 때는 `lecture_id` 필드 사용
## TODO
1. ~개인이 갖고 있는 강의들의 id를 서버 강의의 id와 일치시키는 서버 배치잡 기다리기~
2. ~문구, 디자인 통일 확인하기 (글씨 옆 아이콘 여부, 버튼 위치 등)~
3. Known issue: [NavBackStack과 ViewModel 문제](https://console.firebase.google.com/u/0/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/e3178a510857fb58cf034e831d8862a0?hl=ko&time=last-thirty-days&versions=3.1.0%20(2010030100)&sessionEventKey=63F08A15008600011F656D8C1D7859C1_1779853287502917240)
    - ~accompanist issue에서 해결 중으로 보이니.. 일단 대기~
    - 이거는 그냥 accompanist-navigation을 들어내 버리기로.
4. `selectedLecture` 관련: BookmarkPage와 SearchPage가 같은 vm을 공유하기 때문에, toggle만 해놓고 이동하면 시간표에 회색 shadow가 보이는 문제가 있다. 
    - BookmarkPage에 진입할 때마다 `selectedLecture`를 초기화해 버리기 보다는, BookmarkList에 없으면 초기화하는 것이 가장 적절해 보인다.
    - 그리고 BookmarkPage에서 나갈 때는 null로 초기화하는 게 좋을 것 같은데, 이게 UI에 반영되면서 깜빡! 하는 문제가 있다.
    - 조금 더 고민해보고 다음 패치에 반영하기
