### PR TITLE
release snutt 3.1.1

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/EditText.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/EditText.kt
@@ -50,7 +50,7 @@ fun EditText(
     var isFocused by remember { mutableStateOf(false) }
     val customTextSelectionColors = TextSelectionColors(
         handleColor = SNUTTColors.Black900,
-        backgroundColor = SNUTTColors.Black900
+        backgroundColor = SNUTTColors.Black300
     )
     CompositionLocalProvider(
         LocalTextSelectionColors provides customTextSelectionColors,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/AppReportPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/AppReportPage.kt
@@ -124,10 +124,6 @@ fun AppReportPage() {
                 value = detail, onValueChange = { detail = it },
                 hint = "불편한 점이나 버그를 적어주세요",
                 textStyle = SNUTTTypography.body1.copy(fontSize = 17.sp),
-                keyboardOptions = KeyboardOptions(
-                    imeAction = ImeAction.Done, keyboardType = KeyboardType.Ascii,
-                ),
-                keyboardActions = KeyboardActions(onDone = { sendFeedback() }),
             )
         }
     }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.1.0
+snuttVersionName=3.1.1-rc.1

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.1.1-rc.2
+snuttVersionName=3.1.1

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.1.1-rc.1
+snuttVersionName=3.1.1-rc.2


### PR DESCRIPTION
## 3.1.0 -> 3.1.1 변경사항
1. #141 
- 강의 상세 페이지 편집화면에서 학점 부분에 음수를 타이핑 할 수 없게 변경
- keyboardType을 `KeyboardType.Decimal`로 변경

2. #142
- 연타 방지를 위해 throttleMs를 1000ms로 조정
    - 그냥 다이얼로그 하나 띄워서 전송하시겠습니까? 하는 게 확실할 것 같다.
- 두 EditText의 KeyboardAction, KeyboardOption, singleLine 등을 더 자연스러운 사용을 위해 개선
- 전송 아이콘이 png파일이었는데, 배경색이 있어서 다크모드 때 이상했다. svg 파일로 따서 변경

3. #144 
- 시간표 화면 좌상단 서랍 아이콘에 다크모드 빠졌던거 적용
- 커서 색깔에 다크모드 적용

4. #145 
- 버전 업
- 개발자 괴롭히기 두번째 EditText의 KeyboardAction는 완료 말고 그냥 줄바꿈으로 변경, keyboardType도 일반 텍스트로 변경
- 비밀번호 변경 창의 KeyboardAction들도 자연스러운 사용을 위해 개선
- TextSelectionColors의 backgroundColor을 반투명한 색으로 변경 