### PR TITLE
로딩 인디케이터 추가 및 개발자 괴롭히기 페이지 개선

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/LoadingIndicator.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/LoadingIndicator.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.snutt2.components.compose
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.ui.SNUTTTypography
+
+@Composable
+fun LoadingIndicator() {
+    Row(modifier = Modifier.padding(bottom = 20.dp), verticalAlignment = Alignment.CenterVertically) {
+        CircularProgressIndicator(backgroundColor = SNUTTColors.Black300)
+        Spacer(modifier = Modifier.width(20.dp))
+        Text(text = stringResource(R.string.loading_indicator_message), style = SNUTTTypography.body1)
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/ApiOnProgress.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/ApiOnProgress.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snutt2.lib.network
 
 interface ApiOnProgress {
-    fun showProgress()
+
+    var progressShowing: Boolean
+    fun showProgress(title: String? = null)
     fun hideProgress()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -304,14 +304,17 @@ fun NavController.navigateAsOrigin(route: String) {
 suspend fun launchSuspendApi(
     apiOnProgress: ApiOnProgress,
     apiOnError: ApiOnError,
+    onError: () -> Unit = {},
+    loadingIndicatorTitle: String? = null,
     api: suspend () -> Unit
 ) {
     try {
-        apiOnProgress.showProgress()
+        loadingIndicatorTitle?.let { apiOnProgress.showProgress(it) }
         api.invoke()
     } catch (e: Exception) {
         apiOnError(e)
+        onError()
     } finally {
-        apiOnProgress.hideProgress()
+        if (loadingIndicatorTitle != null) apiOnProgress.hideProgress()
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -27,6 +27,7 @@ import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.navigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.components.compose.LoadingIndicator
 import com.wafflestudio.snutt2.components.compose.ShowModal
 import com.wafflestudio.snutt2.components.compose.rememberModalState
 import com.wafflestudio.snutt2.lib.network.ApiOnError
@@ -131,23 +132,32 @@ class RootActivity : AppCompatActivity() {
     fun setUpUI(startDestination: String) {
         val navController = rememberAnimatedNavController()
         val homePageController = remember { HomePageController() }
-        var isProgressVisible by remember { mutableStateOf(false) }
         val compactMode by userViewModel.compactMode.collectAsState()
-
-        val apiOnProgress = remember {
-            object : ApiOnProgress {
-                override fun showProgress() {
-                    isProgressVisible = true
-                }
-
-                override fun hideProgress() {
-                    isProgressVisible = false
-                }
-            }
-        }
 
         val dialogState = rememberModalState()
         ShowModal(state = dialogState)
+
+        val apiOnProgress = remember {
+            object : ApiOnProgress {
+                override var progressShowing: Boolean = false
+
+                override fun showProgress(title: String?) {
+                    if (title != null) {
+                        progressShowing = true
+                        dialogState.set(onDismiss = {}, title = title) {
+                        LoadingIndicator()
+                    }.show()
+                    }
+                }
+
+                override fun hideProgress() {
+                    if (progressShowing) {
+                        dialogState.hide()
+                        progressShowing = false
+                    }
+                }
+            }
+        }
 
         CompositionLocalProvider(
             LocalNavController provides navController,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignInPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignInPage.kt
@@ -55,7 +55,7 @@ fun SignInPage() {
     val handleLocalSignIn = {
         coroutineScope.launch {
             try {
-                apiOnProgress.showProgress()
+                apiOnProgress.showProgress(context.getString(R.string.sign_in_sign_in_button))
                 userViewModel.loginLocal(idField, passwordField)
                 homeViewModel.refreshData()
                 navController.navigateAsOrigin(NavigationDestination.Home)
@@ -69,7 +69,7 @@ fun SignInPage() {
     val handleFacebookSignIn = {
         coroutineScope.launch {
             try {
-                apiOnProgress.showProgress()
+                apiOnProgress.showProgress(context.getString(R.string.sign_in_sign_in_button))
                 val loginResult = facebookLogin(context)
                 userViewModel.loginFacebook(
                     loginResult.accessToken.userId,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignUpPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignUpPage.kt
@@ -65,7 +65,7 @@ fun SignUpPage() {
         } else {
             coroutineScope.launch {
                 try {
-                    apiOnProgress.showProgress()
+                    apiOnProgress.showProgress("회원가입")
                     userViewModel.signUpLocal(idField, emailField, passwordField)
                     homeViewModel.refreshData()
                     navController.navigateAsOrigin(NavigationDestination.Home)
@@ -80,7 +80,7 @@ fun SignUpPage() {
     val handleFacebookSignUp = {
         coroutineScope.launch {
             try {
-                apiOnProgress.showProgress()
+                apiOnProgress.showProgress("페이스북 회원가입")
                 val loginResult = facebookLogin(context)
                 val id = loginResult.accessToken.userId
                 val token = loginResult.accessToken.token

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,8 @@
     <string name="settings_app_report_title">개발자 괴롭히기</string>
     <string name="settings_app_report_email">이메일</string>
     <string name="settings_app_report_detail">내용</string>
+    <string name="settings_app_report_loading_indicator_title">피드백 전송</string>
+    <string name="settings_app_report_content_hint">불편한 점이나 버그를 적어주세요</string>
     <string name="settings_personal_information_policy">개인정보처리방침</string>
     <string name="settings_service_info">서비스 약관</string>
     <string name="settings_version_info">버전 정보</string>
@@ -259,4 +261,5 @@
     <string name="bookmark_page_placeholder_1">추가한 관심강좌가 없습니다</string>
     <string name="bookmark_page_placeholder_2">고민되는 강의를 관심강좌에 추가하여</string>
     <string name="bookmark_page_placeholder_3">관리해보세요.</string>
+    <string name="loading_indicator_message">잠시만 기다려 주세요…</string>
 </resources>


### PR DESCRIPTION
## 개발자 괴롭히기 페이지 개선
### 기존 문제
한 버튼에 대한 짧은 간격 연타는 방지하고 있지만, 전송 버튼 클릭->전송->결과 확인->뒤로가기 까지의 시간 동안 아무 안내 없이 화면이 그대로 있고, 이때 전송 버튼을 다시 누르면 피드백이 두 번 보내지는 문제가 존재

### 해결
1. 전송 버튼을 누르면 비활성화하여 이중 전송을 원천 차단 (네트워크 에러로 다시 전송을 누를 수 있어야 할 때는 다시 활성화)
2. 사용성 개선을 위해 + 방치되어있던 ApiOnProgress의 활용을 위해 로딩 인디케이터 추가
 
## 로딩 인디케이터
Material Component인 CircularProgressIndicator를 modal로 띄워 준다.
회원가입&로그인, 피드백 전송에 우선 적용


https://user-images.githubusercontent.com/88367636/223635933-8362bc72-4032-4de7-8540-cdf694601a29.mp4

https://user-images.githubusercontent.com/88367636/223636054-ba3879e6-aa08-4f00-882b-df9b5a7256c4.mp4