### PR TITLE
release snutt 3.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -197,7 +197,7 @@ dependencies {
     implementation("com.github.skydoves:colorpickerview:2.2.3")
     implementation("com.jakewharton.timber:timber:4.7.1")
     implementation("androidx.core:core-splashscreen:1.0.0")
-    implementation("com.google.accompanist:accompanist-navigation-animation:0.29.1-alpha")
+    implementation("com.google.accompanist:accompanist-navigation-animation:0.29.0-alpha")
 
     // coil
     implementation("io.coil-kt:coil-compose:2.1.0")

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.1.1
+snuttVersionName=3.1.2-rc.1

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.1.2-rc.2
+snuttVersionName=3.1.2

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.1.2-rc.1
+snuttVersionName=3.1.2-rc.2


### PR DESCRIPTION
## 3.1.1 -> 3.1.2 변경사항
1. #143
- 강의 상세 페이지에서 관심강좌 지정/해제 가능하게 변경
- LectureDto에 lecture_id 필드 추가
    - isBookmarked를 따지는 로직이나 API에서는 lecture_id가 null이 아니면 그것을 사용하고(내 로컬 강의이므로), null인 경우 id를 사용
        - 관심강좌 페이지나 강의 검색 결과로 관심강좌 추가/제거 할 때는 id 필드 사용
        - 내 시간표 강의의 상세 페이지에서 할 때는 lecture_id 필드 사용

2. #146
- 연타 방지를 위해 `sentEnabled` 변수를 둬서 확실하게 방어
- 화면이 멈춰있는 짧은 시간의 자연스러움을 위해 로딩 인디케이터 추가
- 로딩 인디케이터는 `apiOnProgress`에 들어 있지만, `title != null`일 때만 해당 `title`로 모달이 뜨게 된다. 
    - 로컬 로그인, 페이스북 로그인, 피드백 전송의 세 군데에만 적용
    
3. #148
- 버전 올리면 EditText의 Focus 문제로 크래시가 나는 `accompanist-navigation-animation:0.29.1-alpha`를 0.29.0-alpha로 롤백
- 알파는 웬만하면 쓰지 말기..