### PR TITLE
LectureDetailPage 시간 및 장소의 width가 올바르지 않은 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -365,6 +365,7 @@ fun LectureDetailPage(
                 }
                 Column(
                     modifier = Modifier
+                        .fillMaxWidth()
                         .background(SNUTTColors.White900)
                         .padding(bottom = 10.dp)
                 ) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -370,7 +370,9 @@ fun LectureDetailPage(
                 ) {
                     Text(
                         text = stringResource(R.string.lecture_detail_class_time),
-                        modifier = Modifier.padding(start = 20.dp, top = 10.dp, bottom = 14.dp),
+                        modifier = Modifier
+                            .padding(start = 20.dp, top = 10.dp, bottom = 14.dp)
+                            .fillMaxWidth(),
                         style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
                     )
                     editingLectureDetail.class_time_json.forEachIndexed { idx, classTime ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -372,8 +372,7 @@ fun LectureDetailPage(
                     Text(
                         text = stringResource(R.string.lecture_detail_class_time),
                         modifier = Modifier
-                            .padding(start = 20.dp, top = 10.dp, bottom = 14.dp)
-                            .fillMaxWidth(),
+                            .padding(start = 20.dp, top = 10.dp, bottom = 14.dp),
                         style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
                     )
                     editingLectureDetail.class_time_json.forEachIndexed { idx, classTime ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -365,14 +365,14 @@ fun LectureDetailPage(
                 }
                 Column(
                     modifier = Modifier
+                        .fillMaxWidth()
                         .background(SNUTTColors.White900)
                         .padding(bottom = 10.dp)
                 ) {
                     Text(
                         text = stringResource(R.string.lecture_detail_class_time),
                         modifier = Modifier
-                            .padding(start = 20.dp, top = 10.dp, bottom = 14.dp)
-                            .fillMaxWidth(),
+                            .padding(start = 20.dp, top = 10.dp, bottom = 14.dp),
                         style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
                     )
                     editingLectureDetail.class_time_json.forEachIndexed { idx, classTime ->


### PR DESCRIPTION
LectureDetailPage에서 시간 및 장소가 아무것도 없을 경우, 편집 완료 시 시간 및 장소 Column의 width가 화면 전체를 채우지 않는 버그를 수정했습니다