### PR TITLE
강의 상세 페이지에서 creditText 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -85,7 +85,7 @@ fun LectureDetailPage(
      * 이때 다른 정보들은 editingLectureDetail 따라서 바뀌니까 모드가 바뀌어도 따로 할 게 없는데, 얘는 편집모드->일반모드로 바뀔 때 따로 변경해 줘야 한다. 그것이 아래의 코드.
      */
     LaunchedEffect(modeType) {
-        if (modeType is ModeType.Editing) creditText = editingLectureDetail.credit.toString()
+        if (modeType !is ModeType.Editing) creditText = editingLectureDetail.credit.toString()
     }
 
     /* 바텀시트 관련 */


### PR DESCRIPTION
#147 에서 editMode를 enum으로 마이그레이션 하면서 실수로 로직을 거꾸로 옮겼다.