### PR TITLE
Edit ci.yml (Ubuntu 18.04 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           access_token: ${{ github.token }}
 
   static-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: cancel-workflow
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
           path: ./**/build/reports/ktlint/**/*.html
 
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: static-check
     steps:
       - name: Checkout


### PR DESCRIPTION
[관련 내용](https://github.com/actions/runner-images/issues/6002)

deprecate된 4월 3일부터 한번도 액션을 안 돌려서 모르고 있었다는 충격적인 사실