### PR TITLE
버그픽스: DrawerState에 초기값 주기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.views
 
 import androidx.compose.material.DrawerState
+import androidx.compose.material.DrawerValue
 import androidx.compose.runtime.compositionLocalOf
 import androidx.navigation.NavController
 import com.wafflestudio.snutt2.components.compose.BottomSheet
@@ -21,8 +22,8 @@ val LocalApiOnProgress = compositionLocalOf<ApiOnProgress> {
     throw RuntimeException("")
 }
 
-val LocalDrawerState = compositionLocalOf<DrawerState> {
-    throw RuntimeException("")
+val LocalDrawerState = compositionLocalOf {
+    DrawerState(DrawerValue.Closed)
 }
 
 val LocalBottomSheetState = compositionLocalOf<BottomSheet> {


### PR DESCRIPTION
CreateTableBottomSheet가 LocalDrawerState.context를 가지고 있는데, 바텀시트의 content가 dispose되지 않은 채로 BookmarkPage로 가면 크래시 발생한다.

CompositionLocal의 무분별한 사용이 1차 원인이고. BookmarkPage를 별도의 route로 만든게 2차 원인이라 근본적인 해결책이 필요하긴 하나, 손대기 참 애매해서 우선 이렇게 픽스