### PR TITLE
시간 및 장소 추가 편하게 하기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -447,7 +447,9 @@ fun LectureDetailPage(
                                         editingLectureDetail.copy(
                                             class_time_json = editingLectureDetail.class_time_json
                                                 .toMutableList()
-                                                .also { it.add(ClassTimeDto.Default) }
+                                                .also {
+                                                    it.add(it.lastOrNull() ?: ClassTimeDto.Default)
+                                                }
                                         )
                                     )
                                 },


### PR DESCRIPTION
[유저 피드백](https://wafflestudio.slack.com/archives/C8M9NUBBR/p1683943764483749)

`+ 시간 및 장소 추가`를 누르면, 디폴트(월 09:30)가 아닌 이미 있던 시간이 추가된다. 아무 시간도 없었을 때만 디폴트가 추가된다.