### PR TITLE
버그픽스: 다크모드에서 navigate 시 화면이 하얗게 깜빡이는 버그 수정

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,7 +24,7 @@
         <item name="editTextStyle">@style/EditTextStyle</item>
 
         <!--For Background color-->
-        <item name="android:windowBackground">@color/white</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
 
         <!--For SearchView home indicator -->
         <item name="homeAsUpIndicator">@drawable/ic_back</item>


### PR DESCRIPTION
다크모드에서 navigate 시 애니메이션이 실행되면서 화면이 하얗게 깜빡이는 버그를 수정했다.
AppTheme의 android:windowBackground는 액티비티의 배경색이 지정되지 않은 경우 색을 적용해주는데, white였던 걸 transparent로 바꾸었다.