### PR TITLE
다크모드에서 내비게이션 시 깜빡이는 이슈 해결

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
@@ -1,10 +1,13 @@
 package com.wafflestudio.snutt2.ui
 
+import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.views.LocalThemeState
 
 private val LightThemeColors @Composable get() = lightColors(
@@ -46,6 +49,15 @@ fun isDarkMode(): Boolean {
 fun SNUTTTheme(
     content: @Composable () -> Unit
 ) {
+    /* <다크모드에서 내비게이션 시 흰색 깜빡이는 이슈 해결>
+     * 내비게이션 시 액티비티 배경색인 흰색(styles.xml에서 android:windowBackground 로 지정된 색)이 잠깐 노출된다.
+     * 원래는 values-night/styles.xml를 통해 다크모드의 색을 지정하지만, 우리는 시스템의 테마와 앱의 테마를
+     * 다르게 설정할 수 있기 때문에 여기서 직접 설정해 준다.
+     */
+    (LocalContext.current as Activity).window.setBackgroundDrawableResource(
+        if (isDarkMode()) R.color.black_dark
+        else R.color.white
+    )
     MaterialTheme(
         colors = if (isDarkMode()) DarkThemeColors else LightThemeColors,
         typography = SNUTTTypography,

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,6 +13,7 @@
 
     <color name="white">#ffffff</color>
     <color name="black">#FF000000</color>
+    <color name="black_dark">#FF2B2B2B</color>
 
     <color name="transparent">#00000000</color>
 


### PR DESCRIPTION
내비게이션 시 액티비티 배경색인 흰색(styles.xml에서 android:windowBackground 로 지정된 색)이 잠깐 노출된다.
원래는 values-night/styles.xml를 통해 다크모드의 색을 지정하지만, 우리는 시스템의 테마와 앱의 테마를 다르게 설정할 수 있기 때문에 여기서 직접 설정해 준다.

참조: [styles.xml](https://github.com/wafflestudio/snutt-android/blob/816df3044648e9f370c01fe234358ab061b39d07/app/src/main/res/values/styles.xml#L27)