### PR TITLE
시간표 제목이 길 때 학점 텍스트가 안보이는 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/DrawerTableItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/DrawerTableItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wafflestudio.snutt2.R
@@ -59,9 +60,11 @@ fun DrawerTableItem(
             )
             Spacer(modifier = Modifier.width(10.dp))
             Text(
+                modifier = Modifier.weight(1f, fill=false),
                 text = table.title,
                 style = SNUTTTypography.body1,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/DrawerTableItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/DrawerTableItem.kt
@@ -60,7 +60,7 @@ fun DrawerTableItem(
             )
             Spacer(modifier = Modifier.width(10.dp))
             Text(
-                modifier = Modifier.weight(1f, fill=false),
+                modifier = Modifier.weight(1f, fill = false),
                 text = table.title,
                 style = SNUTTTypography.body1,
                 maxLines = 1,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -54,7 +54,9 @@ fun TimetablePage() {
                     style = SNUTTTypography.h2,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.clicks {
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .clicks {
                         showTitleChangeDialog(table.title, table.id, composableStates, tableListViewModel::changeTableName)
                     }
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -57,8 +57,8 @@ fun TimetablePage() {
                     modifier = Modifier
                         .weight(1f, fill = false)
                         .clicks {
-                        showTitleChangeDialog(table.title, table.id, composableStates, tableListViewModel::changeTableName)
-                    }
+                            showTitleChangeDialog(table.title, table.id, composableStates, tableListViewModel::changeTableName)
+                        }
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(


### PR DESCRIPTION
시간표 제목이 길면 학점 텍스트가 안보이거나 이상하게 보이는 걸 고쳤다
Modifier.weight(1f) 이용