### PR TITLE
DayTimePickerSheet 클릭 영역 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ClickableUtil.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ClickableUtil.kt
@@ -34,14 +34,6 @@ fun Modifier.clicks(
     )
 }
 
-fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
-    return if (condition) {
-        then(modifier(Modifier))
-    } else {
-        this
-    }
-}
-
 @Composable
 private fun applyEventThrottling(
     event: () -> Unit,

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ClickableUtil.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ClickableUtil.kt
@@ -34,6 +34,14 @@ fun Modifier.clicks(
     )
 }
 
+fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
+    return if (condition) {
+        then(modifier(Modifier))
+    } else {
+        this
+    }
+}
+
 @Composable
 private fun applyEventThrottling(
     event: () -> Unit,

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/RoundBorderButton.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/RoundBorderButton.kt
@@ -23,11 +23,12 @@ fun RoundBorderButton(
             .background(color, RoundedCornerShape(30))
             .padding(horizontal = 10.dp)
             .height(35.dp)
-            .conditional(onClick != null) {
-                clicks {
-                    onClick!!()
-                }
-            },
+            .then(
+                if(onClick != null)
+                    Modifier.clicks { onClick() }
+                else
+                    Modifier
+            ),
         contentAlignment = Alignment.Center
     ) {
         content()

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/RoundBorderButton.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/RoundBorderButton.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 fun RoundBorderButton(
     modifier: Modifier = Modifier,
     color: Color,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     Box(
@@ -23,7 +23,11 @@ fun RoundBorderButton(
             .background(color, RoundedCornerShape(30))
             .padding(horizontal = 10.dp)
             .height(35.dp)
-            .clicks { onClick() },
+            .conditional(onClick != null) {
+                clicks {
+                    onClick!!()
+                }
+            },
         contentAlignment = Alignment.Center
     ) {
         content()

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/RoundBorderButton.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/RoundBorderButton.kt
@@ -24,7 +24,7 @@ fun RoundBorderButton(
             .padding(horizontal = 10.dp)
             .height(35.dp)
             .then(
-                if(onClick != null)
+                if (onClick != null)
                     Modifier.clicks { onClick() }
                 else
                     Modifier

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/DayTimePickerSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/DayTimePickerSheet.kt
@@ -89,14 +89,8 @@ fun DayTimePickerSheet(
         Row(
             modifier = Modifier
                 .padding(vertical = 7.dp)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(text = stringResource(R.string.settings_timetable_config_week_day), style = SNUTTTypography.button)
-            Spacer(modifier = Modifier.weight(1f))
-            RoundBorderButton(
-                color = SNUTTColors.Gray400,
-                onClick = {
+                .fillMaxWidth()
+                .clicks {
                     var tempDayIndex by mutableStateOf(dayIndex)
                     modalState
                         .set(
@@ -119,6 +113,12 @@ fun DayTimePickerSheet(
                             }
                         }.show()
                 },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = stringResource(R.string.settings_timetable_config_week_day), style = SNUTTTypography.button)
+            Spacer(modifier = Modifier.weight(1f))
+            RoundBorderButton(
+                color = SNUTTColors.Gray400,
             ) {
                 Text(text = dayList[dayIndex], style = SNUTTTypography.button)
             }
@@ -127,14 +127,8 @@ fun DayTimePickerSheet(
         Row(
             modifier = Modifier
                 .padding(vertical = 7.dp)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(text = stringResource(R.string.lecture_detail_edit_class_time_sheet_start_time_label), style = SNUTTTypography.button)
-            Spacer(modifier = Modifier.weight(1f))
-            RoundBorderButton(
-                color = SNUTTColors.Gray400,
-                onClick = {
+                .fillMaxWidth()
+                .clicks {
                     var tempStartTime by mutableStateOf(startTime.copy())
                     editingStartTime = true
                     modalState
@@ -195,6 +189,12 @@ fun DayTimePickerSheet(
                             }
                         }.show()
                 },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = stringResource(R.string.lecture_detail_edit_class_time_sheet_start_time_label), style = SNUTTTypography.button)
+            Spacer(modifier = Modifier.weight(1f))
+            RoundBorderButton(
+                color = SNUTTColors.Gray400,
             ) {
                 Text(
                     text = startTime.toString(),
@@ -206,14 +206,8 @@ fun DayTimePickerSheet(
         Row(
             modifier = Modifier
                 .padding(vertical = 7.dp)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(text = stringResource(R.string.lecture_detail_edit_class_time_sheet_end_time_label), style = SNUTTTypography.button)
-            Spacer(modifier = Modifier.weight(1f))
-            RoundBorderButton(
-                color = SNUTTColors.Gray400,
-                onClick = {
+                .fillMaxWidth()
+                .clicks {
                     var tempEndTime by mutableStateOf(endTime.copy())
                     editingEndTime = true
                     modalState
@@ -274,6 +268,12 @@ fun DayTimePickerSheet(
                             }
                         }.show()
                 },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = stringResource(R.string.lecture_detail_edit_class_time_sheet_end_time_label), style = SNUTTTypography.button)
+            Spacer(modifier = Modifier.weight(1f))
+            RoundBorderButton(
+                color = SNUTTColors.Gray400,
             ) {
                 Text(
                     text = endTime.toString(),


### PR DESCRIPTION
Modal을 띄우는 클릭 영역을 BorderButton에서 전체 Row로 수정했다.
단순히 Row의 Modifier.click으로 옮기면 BorderButton을 클릭했을 때 modal이 나타나지 않으므로
Modifier.then을 이용하여 해결했다