### PR TITLE
팝업 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -34,7 +34,6 @@ class HomeViewModel @Inject constructor(
                         } ?: tableRepository.fetchDefaultTable()
                     },
                     async { userRepository.fetchUserInfo() },
-                    async { userRepository.fetchAndSetPopup() },
                 )
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupComposable.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupComposable.kt
@@ -52,13 +52,11 @@ fun Popup(url: String, onClickFewDays: () -> Unit, onClickClose: () -> Unit) {
                 Text(
                     text = stringResource(id = R.string.popup_hide_message),
                     modifier = Modifier
-                        .padding(
-                            horizontal = 20.dp,
-                            vertical = 10.dp
-                        )
+                        .padding(vertical = 10.dp)
                         .weight(3f)
                         .clicks { onClickFewDays() },
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
                     color = SNUTTColors.AllWhite
                 )
                 Spacer(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/popups/PopupState.kt
@@ -4,4 +4,5 @@ import com.wafflestudio.snutt2.lib.network.dto.GetPopupResults
 
 class PopupState {
     var popup: GetPopupResults.Popup? = null
+    var fetched: Boolean = false
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignUpPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/SignUpPage.kt
@@ -85,7 +85,6 @@ fun SignUpPage() {
                 val id = loginResult.accessToken.userId
                 val token = loginResult.accessToken.token
                 userViewModel.signUpFacebook(id, token)
-                userViewModel.fetchPopup()
                 navController.navigateAsOrigin(NavigationDestination.Home)
             } catch (e: Exception) {
                 apiOnError(e)


### PR DESCRIPTION
RootActivity에서 `refreshData`를 통해 팝업을 불러오고 HomePage에서 띄웠었는데 과거에는 `refreshData`가 다 끝나고 나서 홈 화면이 그려졌기 때문에 팝업이 잘 표시됐다. 
그런데 스플래시 화면 바꿀 때, `refreshData`와 `setUpUI`가 병렬적으로 불리게 바꾸면서 홈 화면 그려진 다음에 팝업 fetch가 끝나서 팝업이 보여지지 않고, 다른 화면 갔다가 HomePage 돌아올 때 그제서야 팝업이 떴다.

그래서 HomePage에서 LaunchedEffect로 팝업을 fetch해오도록 하되, application scope를 갖는 PopupState에 필드 하나를 추가해서 딱 한번만 LaunchedEffect 내의 블록이 실행될 수 있도록 변경했다.

하는 김에 `당분간 보지 않기` 문구가 너비가 좁은 기기에서 두 줄로 보이는 것도 수정