### PR TITLE
gitignore에 node_modules 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,4 +147,5 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
+node_modules/
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio


### PR DESCRIPTION
RN 작업하면서 root directory에 node_modules가 생겼는데 다른 브랜치로 갈때마다 난리나는 거 싫어서 그냥 추가