### PR TITLE
MoreActionBottomSheet에서 LocalTableState 값 없는 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/bookmark/BookmarkPage.kt
@@ -23,6 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.layouts.modalBottomSheetLayout.ModalBottomSheetLayout
+import com.wafflestudio.snutt2.components.compose.bottomSheet
 import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
@@ -47,7 +48,7 @@ fun BookmarkPage(searchViewModel: SearchViewModel) {
     val apiOnError = LocalApiOnError.current
     val apiOnProgress = LocalApiOnProgress.current
     val context = LocalContext.current
-    val bottomSheet = LocalBottomSheetState.current
+    val bottomSheet = bottomSheet()
     val scope = rememberCoroutineScope()
     val userViewModel = hiltViewModel<UserViewModel>()
     val timetableViewModel = hiltViewModel<TimetableViewModel>()
@@ -100,50 +101,52 @@ fun BookmarkPage(searchViewModel: SearchViewModel) {
         }
     }
 
-    ModalBottomSheetLayout(
-        sheetContent = bottomSheet.content,
-        sheetState = bottomSheet.state,
-        sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
-        onDismissScrim = {
-            scope.launch { bottomSheet.hide() }
-        }
-    ) {
-        Column(
-            modifier = Modifier
-                .background(SNUTTColors.White900)
-                .fillMaxWidth()
+    CompositionLocalProvider(LocalBottomSheetState provides bottomSheet) {
+        ModalBottomSheetLayout(
+            sheetContent = bottomSheet.content,
+            sheetState = bottomSheet.state,
+            sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
+            onDismissScrim = {
+                scope.launch { bottomSheet.hide() }
+            }
         ) {
-            SimpleTopBar(title = stringResource(R.string.bookmark_page_title), onClickNavigateBack = { onBackPressedCallback.handleOnBackPressed() })
-            Box(
+            Column(
                 modifier = Modifier
-                    .weight(1f)
+                    .background(SNUTTColors.White900)
                     .fillMaxWidth()
             ) {
-                CompositionLocalProvider(LocalTableState provides tableState) {
-                    TimeTable(selectedLecture = selectedLecture, touchEnabled = false)
-                }
-                if (bookmarks.isEmpty()) {
-                    BookmarkPlaceHolder()
-                } else {
-                    LazyColumn(
-                        state = rememberLazyListState(),
-                        modifier = Modifier
-                            .background(SNUTTColors.Dim2)
-                            .fillMaxSize()
-                    ) {
-                        items(bookmarks) {
-                            LectureListItem(
-                                lectureDataWithState = it,
-                                searchViewModel = searchViewModel, // 다른 viewModel은 데이터를 갖지 않고 api만 사용하므로 route가 Bookmark인 hiltViewModel 그냥 사용
-                                reviewWebViewContainer = reviewWebViewContainer,
-                                isBookmarkPage = true,
-                                timetableViewModel = timetableViewModel,
-                                tableListViewModel = tableListViewModel,
-                                lectureDetailViewModel = lectureDetailViewModel,
-                                userViewModel = userViewModel,
-                            )
+                SimpleTopBar(title = stringResource(R.string.bookmark_page_title), onClickNavigateBack = { onBackPressedCallback.handleOnBackPressed() })
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                ) {
+                    CompositionLocalProvider(LocalTableState provides tableState) {
+                        TimeTable(selectedLecture = selectedLecture, touchEnabled = false)
+                    }
+                    if (bookmarks.isEmpty()) {
+                        BookmarkPlaceHolder()
+                    } else {
+                        LazyColumn(
+                            state = rememberLazyListState(),
+                            modifier = Modifier
+                                .background(SNUTTColors.Dim2)
+                                .fillMaxSize()
+                        ) {
+                            items(bookmarks) {
+                                LectureListItem(
+                                    lectureDataWithState = it,
+                                    searchViewModel = searchViewModel, // 다른 viewModel은 데이터를 갖지 않고 api만 사용하므로 route가 Bookmark인 hiltViewModel 그냥 사용
+                                    reviewWebViewContainer = reviewWebViewContainer,
+                                    isBookmarkPage = true,
+                                    timetableViewModel = timetableViewModel,
+                                    tableListViewModel = tableListViewModel,
+                                    lectureDetailViewModel = lectureDetailViewModel,
+                                    userViewModel = userViewModel,
+                                )
+                            }
+                            item { Divider(color = SNUTTColors.White400) }
                         }
-                        item { Divider(color = SNUTTColors.White400) }
                     }
                 }
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -100,6 +100,9 @@ fun TimetablePage() {
                     BookmarkPageIcon(
                         modifier = centerAlignedModifier
                             .size(30.dp)
+                            // TODO
+                            // bottomSheet가 hide 되고 content를 비우는데, 이론상으로는 이 두 라인 사이에 navigation이 일어날 수도 있다.
+                            // 일단 시험삼아 이렇게 해 보고 이래도 같은 에러가 터지는지 확인하기
                             .clicks(enabled = bottomSheetState.isVisible.not()) {
                                 navController.navigate(NavigationDestination.Bookmark) { launchSingleTop = true }
                             },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -100,12 +100,7 @@ fun TimetablePage() {
                     BookmarkPageIcon(
                         modifier = centerAlignedModifier
                             .size(30.dp)
-                            // TODO
-                            // bottomSheet가 hide 되고 content를 비우는데, 이론상으로는 이 두 라인 사이에 navigation이 일어날 수도 있다.
-                            // 일단 시험삼아 이렇게 해 보고 이래도 같은 에러가 터지는지 확인하기
-                            .clicks(enabled = bottomSheetState.isVisible.not()) {
-                                navController.navigate(NavigationDestination.Bookmark) { launchSingleTop = true }
-                            },
+                            .clicks { navController.navigate(NavigationDestination.Bookmark) { launchSingleTop = true } },
                     )
                 }
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt2.views.logged_in.home.timetable
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -26,7 +25,6 @@ import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.showTitleChangeDialog
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun TimetablePage() {
     val scope = rememberCoroutineScope()
@@ -35,7 +33,6 @@ fun TimetablePage() {
     val navController = LocalNavController.current
     val drawerState = LocalDrawerState.current
     val table = LocalTableState.current.table
-    val bottomSheetState = LocalBottomSheetState.current.state
     val composableStates = ComposableStatesWithScope(scope)
     val tableListViewModel = hiltViewModel<TableListViewModel>()
     val userViewModel = hiltViewModel<UserViewModel>()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.timetable
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -25,6 +26,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.showTitleChangeDialog
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun TimetablePage() {
     val scope = rememberCoroutineScope()
@@ -33,6 +35,7 @@ fun TimetablePage() {
     val navController = LocalNavController.current
     val drawerState = LocalDrawerState.current
     val table = LocalTableState.current.table
+    val bottomSheetState = LocalBottomSheetState.current.state
     val composableStates = ComposableStatesWithScope(scope)
     val tableListViewModel = hiltViewModel<TableListViewModel>()
     val userViewModel = hiltViewModel<UserViewModel>()
@@ -97,7 +100,9 @@ fun TimetablePage() {
                     BookmarkPageIcon(
                         modifier = centerAlignedModifier
                             .size(30.dp)
-                            .clicks { navController.navigate(NavigationDestination.Bookmark) { launchSingleTop = true } },
+                            .clicks(enabled = bottomSheetState.isVisible.not()) {
+                                navController.navigate(NavigationDestination.Bookmark) { launchSingleTop = true }
+                            },
                     )
                 }
             }


### PR DESCRIPTION
[크래시리틱스](https://console.firebase.google.com/u/0/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/894bd178277a78ab7b93ae9b301df0d4?hl=ko&time=last-seven-days&sessionEventKey=64A58818030E0001740D863F351EF853_1830814980442319895)

## 원인
바텀시트를 닫은 직후 아주 빨리 BookmarkPage로 이동하면, BottomSheet의 content가 남아 있는 상태로 BookmarkPage의 LocalBottomSheet.current가 불리게 된다. BookmakrPage에는 LocalTableState가 provide되지 않기 때문에 크래시

## 해결
BookmarkPage에서 bottomSheet를 굳이 CompositionLocal에서 가져올 이유가 없다. BookmarkPage만 쓰는 BottomSheet 만들고 그걸 자기 트리 아래(주로 LectureListItem)로 전파한다.