### PR TITLE
Remote Config 관련

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/RemoteConfig.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RemoteConfig.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,8 +22,8 @@ class RemoteConfig @Inject constructor(
     apiOnError: ApiOnError,
 ) {
     private val config = callbackFlow {
-        launch(Dispatchers.IO) {
-            userRepository.accessToken.filter { it.isNotEmpty() }.collect {
+        userRepository.accessToken.filter { it.isNotEmpty() }.collect {
+            withContext(Dispatchers.IO) {
                 try {
                     send(api._getRemoteConfig())
                 } catch (e: Exception) {

--- a/app/src/main/java/com/wafflestudio/snutt2/RemoteConfig.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RemoteConfig.kt
@@ -1,0 +1,52 @@
+package com.wafflestudio.snutt2
+
+import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.lib.network.ApiOnError
+import com.wafflestudio.snutt2.lib.network.SNUTTRestApi
+import com.wafflestudio.snutt2.lib.network.dto.core.RemoteConfigDto
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RemoteConfig @Inject constructor(
+    api: SNUTTRestApi,
+    userRepository: UserRepository,
+    apiOnError: ApiOnError,
+) {
+    private val config = callbackFlow {
+        launch(Dispatchers.IO) {
+            userRepository.accessToken.filter { it.isNotEmpty() }.collect {
+                try {
+                    send(api._getRemoteConfig())
+                } catch (e: Exception) {
+                    apiOnError(e)
+                }
+            }
+        }
+        awaitClose {}
+    }.stateIn(
+        CoroutineScope(Dispatchers.Main),
+        SharingStarted.Eagerly,
+        RemoteConfigDto()
+    )
+
+    val friendBundleSrc: String
+        get() = config.value.reactNativeBundleSrc?.src?.get("android") ?: ""
+
+    val vacancyNotificationBannerEnabled: Boolean
+        get() = config.value.vacancyBannerConfig.visible
+
+    val sugangSNUUrl: String
+        get() = config.value.vacancyUrlConfig.url ?: ""
+
+    val settingPageNewBadgeTitles: List<String>
+        get() = config.value.settingsBadgeConfig.new
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepository.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.data.user
 
 import com.wafflestudio.snutt2.lib.network.dto.GetUserFacebookResults
-import com.wafflestudio.snutt2.lib.network.dto.core.RemoteConfigDto
 import com.wafflestudio.snutt2.lib.network.dto.core.UserDto
 import com.wafflestudio.snutt2.model.TableTrimParam
 import com.wafflestudio.snutt2.ui.ThemeMode
@@ -19,8 +18,6 @@ interface UserRepository {
     val compactMode: StateFlow<Boolean>
 
     val firstBookmarkAlert: StateFlow<Boolean>
-
-    val remoteConfig: StateFlow<RemoteConfigDto>
 
     // login with local id
     suspend fun postSignIn(id: String, password: String)
@@ -96,6 +93,4 @@ interface UserRepository {
     suspend fun setCompactMode(compact: Boolean)
 
     suspend fun setFirstBookmarkAlertShown()
-
-    suspend fun fetchRemoteConfig()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
@@ -6,14 +6,12 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.wafflestudio.snutt2.data.SNUTTStorage
 import com.wafflestudio.snutt2.lib.network.SNUTTRestApi
 import com.wafflestudio.snutt2.lib.network.dto.*
-import com.wafflestudio.snutt2.lib.network.dto.core.RemoteConfigDto
 import com.wafflestudio.snutt2.lib.toOptional
 import com.wafflestudio.snutt2.lib.unwrap
 import com.wafflestudio.snutt2.model.TableTrimParam
 import com.wafflestudio.snutt2.ui.ThemeMode
 import com.wafflestudio.snutt2.views.logged_in.home.popups.PopupState
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -41,8 +39,6 @@ class UserRepositoryImpl @Inject constructor(
     override val compactMode = storage.compactMode.asStateFlow()
 
     override val firstBookmarkAlert = storage.firstBookmarkAlert.asStateFlow()
-
-    override val remoteConfig = MutableStateFlow<RemoteConfigDto>(RemoteConfigDto())
 
     override suspend fun postSignIn(id: String, password: String) {
         val response = api._postSignIn(PostSignInParams(id, password))
@@ -285,10 +281,6 @@ class UserRepositoryImpl @Inject constructor(
                 }
             )
         }
-    }
-
-    override suspend fun fetchRemoteConfig() {
-        remoteConfig.emit(api._getRemoteConfig())
     }
 
     companion object {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -4,12 +4,12 @@ import androidx.compose.material.DrawerState
 import androidx.compose.material.DrawerValue
 import androidx.compose.runtime.compositionLocalOf
 import androidx.navigation.NavController
+import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.components.compose.BottomSheet
 import com.wafflestudio.snutt2.components.compose.ModalState
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.lib.network.ApiOnError
 import com.wafflestudio.snutt2.lib.network.ApiOnProgress
-import com.wafflestudio.snutt2.lib.network.dto.core.RemoteConfigDto
 import com.wafflestudio.snutt2.ui.ThemeMode
 import com.wafflestudio.snutt2.views.logged_in.home.HomePageController
 import com.wafflestudio.snutt2.views.logged_in.home.popups.PopupState
@@ -63,6 +63,6 @@ val LocalTableState = compositionLocalOf<TableState> {
     throw RuntimeException("")
 }
 
-val LocalRemoteConfig = compositionLocalOf<RemoteConfigDto> {
+val LocalRemoteConfig = compositionLocalOf<RemoteConfig> {
     throw RuntimeException("")
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.views
 import androidx.compose.material.DrawerState
 import androidx.compose.material.DrawerValue
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.navigation.NavController
 import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.components.compose.BottomSheet
@@ -63,6 +64,6 @@ val LocalTableState = compositionLocalOf<TableState> {
     throw RuntimeException("")
 }
 
-val LocalRemoteConfig = compositionLocalOf<RemoteConfig> {
+val LocalRemoteConfig = staticCompositionLocalOf<RemoteConfig> {
     throw RuntimeException("")
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -33,6 +33,7 @@ import com.google.accompanist.navigation.animation.navigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.wafflestudio.snutt2.BuildConfig
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.components.compose.*
 import com.wafflestudio.snutt2.lib.network.ApiOnError
 import com.wafflestudio.snutt2.lib.network.ApiOnProgress
@@ -68,6 +69,9 @@ class RootActivity : AppCompatActivity() {
 
     @Inject
     lateinit var apiOnError: ApiOnError
+
+    @Inject
+    lateinit var remoteConfig: RemoteConfig
 
     private var isInitialRefreshFinished = false
 
@@ -141,7 +145,6 @@ class RootActivity : AppCompatActivity() {
         val navController = rememberAnimatedNavController()
         val homePageController = remember { HomePageController() }
         val compactMode by userViewModel.compactMode.collectAsState()
-        val remoteConfig by homeViewModel.remoteConfig.collectAsState()
 
         val bottomSheet = bottomSheet()
         val dialogState = rememberModalState()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -24,9 +24,6 @@ class HomeViewModel @Inject constructor(
     private val _unCheckedNotificationExist = MutableStateFlow(false)
     val unCheckedNotificationExist = _unCheckedNotificationExist.asStateFlow()
 
-    val remoteConfig
-        get() = userRepository.remoteConfig
-
     suspend fun refreshData() {
         try {
             coroutineScope {
@@ -37,7 +34,6 @@ class HomeViewModel @Inject constructor(
                         } ?: tableRepository.fetchDefaultTable()
                     },
                     async { userRepository.fetchUserInfo() },
-                    async { userRepository.fetchRemoteConfig() },
                 )
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -263,7 +263,7 @@ fun SettingItem(
                 color = titleColor
             )
         )
-        if (LocalRemoteConfig.current.settingsBadgeConfig.new.contains(title)) {
+        if (LocalRemoteConfig.current.settingPageNewBadgeTitles.contains(title)) {
             NewBadge(Modifier.padding(start = 5.dp))
         }
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -45,7 +45,7 @@ fun TimetablePage() {
     val newSemesterNotify by tableListViewModel.newSemesterNotify.collectAsState(false)
     val firstBookmarkAlert by userViewModel.firstBookmarkAlert.collectAsState()
     val vacancyBannerOpened by vacancyViewModel.vacancyBannerOpened.collectAsState()
-    val shouldShowVacancyBanner = remoteConfig.vacancyBannerConfig.visible && vacancyBannerOpened
+    val shouldShowVacancyBanner = remoteConfig.vacancyNotificationBannerEnabled && vacancyBannerOpened
 
     var timetableHeight by remember { mutableStateOf(0) }
     var topBarHeight by remember { mutableStateOf(0) }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
@@ -266,11 +266,8 @@ fun VacancyPage(
                 },
                 contentColor = SNUTTColors.SNUTTVacancy,
                 onClick = {
-                    remoteConfig.vacancyUrlConfig.url?.let {
-                        val intent =
-                            Intent(Intent.ACTION_VIEW, Uri.parse(it))
-                        context.startActivity(intent)
-                    }
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(remoteConfig.sugangSNUUrl))
+                    context.startActivity(intent)
                 },
                 elevation = FloatingActionButtonDefaults.elevation(3.dp, 3.dp)
             )


### PR DESCRIPTION
config야말로 최초 실행 시 fetch하고 나면 앱 실행 주기 동안 바뀌지 않는 정적인 값이고, 모든 UI에서 사용하는 정보니까 compositionLocal로 쓰는 건 아주 적절한 것 같음

근데 UserRepository에 넣으면 뭔가 애매하고(독립되었으면 좋겠음), 단순히 RemoteConfigDTO의 StateFlow로 갖고 있기에는 여러가지 문제가 있다고 보이는데...
우선 Network DTO를 모든 UI에 전파해서 필드에 접근하게 하는 건 너무 이상하고, 적절히 클래스로 래핑해서 쓰는 게 맞다고 생각함.
만약 필드 a, b가 있는데 a, b의 값 둘 다를 보고 판단하는 어떤 것이 있으면 그 클래스 내에서 a, b값을 계산해서 최종 결과만 public하게 get할 수 있게 해야지, UI에서 a랑 b 가져와서 계산하고 있는 건 넌센스 (UI가 네트워크 DTO의 json 구조를 알고 있는 건데...)

그래서 싱글톤으로 주입받아서 생성하고, 생성 시 token을 collect해서 토큰이 생기면 GET /v1/config API 찌르고, 결과 DTO는 StateFlow로 객체 내부에 가지고 있게 한 다음 적절히 필요한 정보들에 대해 getter만 public하게 주는 형태로 만들어 봤음

UI단에 전파는 compositonLocal을 쓰는데,어차피 앱 중간중간 config를 다시 찌를 거 아니기 때문에 staticCompositionLocal 한번 써봤음
