### PR TITLE
앱 최초 실행 시 토큰 있을 때만 refreshData API 쏘기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -85,11 +85,11 @@ class RootActivity : AppCompatActivity() {
         setContentView(R.layout.activity_root)
         parseDeeplinkExtra()
 
+        val token = userViewModel.accessToken.value
         lifecycleScope.launch {
-            homeViewModel.refreshData()
+            if (token.isNotEmpty()) homeViewModel.refreshData()
             isInitialRefreshFinished = true
         }
-        val token = userViewModel.accessToken.value
         setUpContents(
             if (token.isEmpty()) NavigationDestination.Onboard
             else NavigationDestination.Home


### PR DESCRIPTION
이전에 별 생각 없이 400 처리하면 되니까~  라는 생각으로 로그인 돼있든 아니든 앱 켜면 최초 정보 가져오는 API들을 쐈는데, token이 있을 때만 진행한다.

로컬 로그인, 페북 로그인, 회원가입 시 `refreshData()` 꼭 쓰기 (로그인 수단이 더 생기면 꼭 추가하기)