### PR TITLE
빈자리 배너 닫기 버튼 삭제

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/SNUTTStorage.kt
@@ -158,16 +158,6 @@ class SNUTTStorage @Inject constructor(
         )
     )
 
-    val vacancyBannerOpenTime = PrefValue<Long>(
-        prefContext,
-        PrefValueMetaData(
-            domain = DOMAIN_SCOPE_LOGIN,
-            key = "vacancy_banner_open_time",
-            type = Long::class.java,
-            defaultValue = 0
-        )
-    )
-
     fun clearLoginScope() {
         prefContext.clear(DOMAIN_SCOPE_LOGIN)
         prefContext.clear(DOMAIN_SCOPE_CURRENT_VERSION)

--- a/app/src/main/java/com/wafflestudio/snutt2/data/vacancy_noti/VacancyRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/vacancy_noti/VacancyRepository.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.flow.StateFlow
 interface VacancyRepository {
     val firstVacancyVisit: StateFlow<Boolean>
 
-    val vacancyBannerOpenTime: StateFlow<Long>
-
     suspend fun getVacancyLectures(): List<LectureDto>
 
     suspend fun addVacancyLecture(lectureId: String)
@@ -15,6 +13,4 @@ interface VacancyRepository {
     suspend fun removeVacancyLecture(lectureId: String)
 
     suspend fun setVacancyVisited()
-
-    suspend fun updateVacancyBannerOpenTime()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/vacancy_noti/VacancyRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/vacancy_noti/VacancyRepositoryImpl.kt
@@ -3,9 +3,7 @@ package com.wafflestudio.snutt2.data.vacancy_noti
 import com.wafflestudio.snutt2.data.SNUTTStorage
 import com.wafflestudio.snutt2.lib.network.SNUTTRestApi
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
-import kotlinx.coroutines.flow.StateFlow
 import java.util.*
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,8 +14,6 @@ class VacancyRepositoryImpl @Inject constructor(
 ) : VacancyRepository {
 
     override val firstVacancyVisit = storage.firstVacancyVisit.asStateFlow()
-
-    override val vacancyBannerOpenTime: StateFlow<Long> = storage.vacancyBannerOpenTime.asStateFlow()
 
     override suspend fun getVacancyLectures(): List<LectureDto> {
         return api._getVacancyLectures().lectures
@@ -33,9 +29,5 @@ class VacancyRepositoryImpl @Inject constructor(
 
     override suspend fun setVacancyVisited() {
         storage.firstVacancyVisit.update(false)
-    }
-
-    override suspend fun updateVacancyBannerOpenTime() {
-        storage.vacancyBannerOpenTime.update(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1))
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -26,7 +25,6 @@ import com.wafflestudio.snutt2.views.*
 import com.wafflestudio.snutt2.views.logged_in.home.TableListViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.showTitleChangeDialog
-import com.wafflestudio.snutt2.views.logged_in.vacancy_noti.VacancyViewModel
 import kotlinx.coroutines.launch
 
 @Composable
@@ -41,11 +39,8 @@ fun TimetablePage() {
     val composableStates = ComposableStatesWithScope(scope)
     val tableListViewModel = hiltViewModel<TableListViewModel>()
     val userViewModel = hiltViewModel<UserViewModel>()
-    val vacancyViewModel = hiltViewModel<VacancyViewModel>()
     val newSemesterNotify by tableListViewModel.newSemesterNotify.collectAsState(false)
     val firstBookmarkAlert by userViewModel.firstBookmarkAlert.collectAsState()
-    val vacancyBannerOpened by vacancyViewModel.vacancyBannerOpened.collectAsState()
-    val shouldShowVacancyBanner = remoteConfig.vacancyNotificationBannerEnabled && vacancyBannerOpened
 
     var timetableHeight by remember { mutableStateOf(0) }
     var topBarHeight by remember { mutableStateOf(0) }
@@ -103,7 +98,7 @@ fun TimetablePage() {
                                 view,
                                 context,
                                 topBarHeight,
-                                if (shouldShowVacancyBanner) bannerHeight else 0,
+                                if (remoteConfig.vacancyNotificationBannerEnabled) bannerHeight else 0,
                                 timetableHeight
                             )
                         },
@@ -121,15 +116,10 @@ fun TimetablePage() {
                 }
             }
         )
-        if (shouldShowVacancyBanner) {
+        if (remoteConfig.vacancyNotificationBannerEnabled) {
             VacancyBanner(
                 onClick = {
                     navController.navigate(NavigationDestination.VacancyNotification)
-                },
-                onClose = {
-                    scope.launch {
-                        vacancyViewModel.closeVacancyBanner()
-                    }
                 },
                 modifier = Modifier
                     .onGloballyPositioned { bannerHeight = it.size.height }
@@ -149,7 +139,6 @@ fun TimetablePage() {
 @Composable
 fun VacancyBanner(
     onClick: () -> Unit,
-    onClose: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -183,15 +172,6 @@ fun VacancyBanner(
                 )
             )
         }
-        Spacer(
-            modifier = Modifier.weight(1f)
-        )
-        TipCloseIcon(
-            modifier = Modifier
-                .size(11.dp)
-                .clicks { onClose() },
-            colorFilter = ColorFilter.tint(SNUTTColors.AllWhite)
-        )
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyViewModel.kt
@@ -30,10 +30,6 @@ class VacancyViewModel @Inject constructor(
     val firstVacancyVisit
         get() = vacancyRepository.firstVacancyVisit
 
-    val vacancyBannerOpened = vacancyRepository.vacancyBannerOpenTime.map { nextOpenTime ->
-        System.currentTimeMillis() >= nextOpenTime
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
-
     @Inject
     lateinit var apiOnError: ApiOnError
 
@@ -95,9 +91,5 @@ class VacancyViewModel @Inject constructor(
         if (firstVacancyVisit.value) {
             vacancyRepository.setVacancyVisited()
         }
-    }
-
-    suspend fun closeVacancyBanner() {
-        vacancyRepository.updateVacancyBannerOpenTime()
     }
 }


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C8M9NUBBR/p1691988515518239
유저가 배너를 닫을 수 없고, remoteConfig에 의해서만 배너의 on/off가 결정된다

- 빈자리 배너 닫기 버튼 삭제
- 배너가 열릴 다음 날짜 관련 로직 삭제