### PR TITLE
뒤로가기 콜백 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/bookmark/BookmarkPage.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.bookmark
 
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -74,21 +73,16 @@ fun BookmarkPage(
     }
 
     /* 뒤로가기 핸들링 */
-    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
-    val onBackPressedCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                if (bottomSheet.isVisible) {
-                    scope.launch { bottomSheet.hide() }
-                } else if (navController.currentDestination?.route == NavigationDestination.Bookmark) {
-                    navController.popBackStack()
-                }
-            }
+    val onBackPressed: () -> Unit = {
+        if (bottomSheet.isVisible) {
+            scope.launch { bottomSheet.hide() }
+        } else if (navController.currentDestination?.route == NavigationDestination.Bookmark) {
+            navController.popBackStack()
         }
     }
-    DisposableEffect(Unit) {
-        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(onBackPressedCallback)
-        onDispose { onBackPressedCallback.remove() }
+
+    BackHandler {
+        onBackPressed()
     }
 
     val selectedLecture by searchViewModel.selectedLecture.collectAsState()
@@ -113,7 +107,7 @@ fun BookmarkPage(
                     .background(SNUTTColors.White900)
                     .fillMaxWidth()
             ) {
-                SimpleTopBar(title = stringResource(R.string.bookmark_page_title), onClickNavigateBack = { onBackPressedCallback.handleOnBackPressed() })
+                SimpleTopBar(title = stringResource(R.string.bookmark_page_title), onClickNavigateBack = { onBackPressed() })
                 Box(
                     modifier = Modifier
                         .weight(1f)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
@@ -2,8 +2,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.reviews
 
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -14,8 +13,6 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,23 +40,17 @@ import kotlinx.coroutines.launch
 fun ReviewPage() {
     val webViewContainer = LocalReviewWebView.current
     val homePageController = LocalHomePageController.current
-    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
 
-    val onBackPressedCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                if (webViewContainer.webView.canGoBack()) {
-                    webViewContainer.webView.goBack()
-                } else {
-                    homePageController.update(HomeItem.Timetable)
-                }
-            }
+    val onBackPressed: () -> Unit = {
+        if (webViewContainer.webView.canGoBack()) {
+            webViewContainer.webView.goBack()
+        } else {
+            homePageController.update(HomeItem.Timetable)
         }
     }
 
-    DisposableEffect(Unit) {
-        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(onBackPressedCallback)
-        onDispose { onBackPressedCallback.remove() }
+    BackHandler {
+        onBackPressed()
     }
 
     ReviewWebView(page = true)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -56,6 +57,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.search.*
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.vacancy_noti.VacancyViewModel
 import kotlinx.coroutines.*
+import timber.log.Timber
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -126,9 +128,12 @@ fun LectureDetailPage(
             }
         }
     }
-    DisposableEffect(Unit) {
-        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(onBackPressedCallback)
-        onDispose { onBackPressedCallback.remove() }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(lifecycleOwner, onBackPressedCallback)
+        onDispose {
+            onBackPressedCallback.remove()
+        }
     }
     /* TODO (진행중)
      * 시간 및 장소 item 추가했을 때 애니메이션 적용하기 (LazyColumn 의 기능 모방)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -2,8 +2,7 @@ package com.wafflestudio.snutt2.views.logged_in.lecture_detail
 
 import android.content.Intent
 import android.net.Uri
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.expandVertically
@@ -24,7 +23,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -57,7 +55,6 @@ import com.wafflestudio.snutt2.views.logged_in.home.search.*
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.vacancy_noti.VacancyViewModel
 import kotlinx.coroutines.*
-import timber.log.Timber
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -100,41 +97,34 @@ fun LectureDetailPage(
     val bottomSheet = bottomSheet()
 
     /* 뒤로가기 핸들링 */
-    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
-    val onBackPressedCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                if (bottomSheet.isVisible) {
-                    scope.launch { bottomSheet.hide() }
-                } else when (modeType) {
-                    ModeType.Normal -> {
-                        if (navController.currentDestination?.route == NavigationDestination.LectureDetail) {
-                            navController.popBackStack()
-                        }
-                    }
-                    is ModeType.Editing -> {
-                        if ((modeType as ModeType.Editing).adding) {
-                            navController.popBackStack()
-                        } else {
-                            showExitEditModeDialog(composableStates, onConfirm = {
-                                vm.abandonEditingLectureDetail()
-                            })
-                        }
-                    }
-                    ModeType.Viewing -> {
-                        onCloseViewMode(scope)
-                    }
+    val onBackPressed: () -> Unit = {
+        if (bottomSheet.isVisible) {
+            scope.launch { bottomSheet.hide() }
+        } else when (modeType) {
+            ModeType.Normal -> {
+                if (navController.currentDestination?.route == NavigationDestination.LectureDetail) {
+                    navController.popBackStack()
                 }
+            }
+            is ModeType.Editing -> {
+                if ((modeType as ModeType.Editing).adding) {
+                    navController.popBackStack()
+                } else {
+                    showExitEditModeDialog(composableStates, onConfirm = {
+                        vm.abandonEditingLectureDetail()
+                    })
+                }
+            }
+            ModeType.Viewing -> {
+                onCloseViewMode(scope)
             }
         }
     }
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(lifecycleOwner, onBackPressedCallback)
-        onDispose {
-            onBackPressedCallback.remove()
-        }
+
+    BackHandler {
+        onBackPressed()
     }
+
     /* TODO (진행중)
      * 시간 및 장소 item 추가했을 때 애니메이션 적용하기 (LazyColumn 의 기능 모방)
      * 추가시 애니메이션은 되는데 삭제시는 방법을 고민중
@@ -181,7 +171,7 @@ fun LectureDetailPage(
                         modifier = Modifier
                             .size(30.dp)
                             .clicks {
-                                onBackPressedCallback.handleOnBackPressed()
+                                onBackPressed()
                             },
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/EmailVerificationPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/EmailVerificationPage.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_out
 
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
@@ -43,7 +42,6 @@ fun EmailVerificationPage() {
     val apiOnError = LocalApiOnError.current
     val context = LocalContext.current
     val keyboardManager = LocalSoftwareKeyboardController.current
-    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
     val coroutineScope = rememberCoroutineScope()
     val userViewModel = hiltViewModel<UserViewModel>()
 
@@ -75,24 +73,19 @@ fun EmailVerificationPage() {
         }
     }
 
-    val onBackPressedCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                when (flowState) {
-                    VerifyEmailState.AskContinue -> navController.navigateAsOrigin(NavigationDestination.Home)
-                    VerifyEmailState.SendCode -> {
-                        flowState = VerifyEmailState.AskContinue
-                        codeField = ""
-                        timerState.reset()
-                    }
-                }
+    val onBackPressed: () -> Unit = {
+        when (flowState) {
+            VerifyEmailState.AskContinue -> navController.navigateAsOrigin(NavigationDestination.Home)
+            VerifyEmailState.SendCode -> {
+                flowState = VerifyEmailState.AskContinue
+                codeField = ""
+                timerState.reset()
             }
         }
     }
 
-    DisposableEffect(Unit) {
-        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(onBackPressedCallback)
-        onDispose { onBackPressedCallback.remove() }
+    BackHandler {
+        onBackPressed()
     }
 
     Column(
@@ -102,7 +95,7 @@ fun EmailVerificationPage() {
     ) {
         SimpleTopBar(
             title = stringResource(R.string.verify_email_app_bar_title),
-            onClickNavigateBack = { onBackPressedCallback.handleOnBackPressed() }
+            onClickNavigateBack = { onBackPressed() }
         )
         AnimatedContent(targetState = flowState) { targetState ->
             Column(modifier = Modifier.padding(horizontal = 25.dp)) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/FindPasswordPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/FindPasswordPage.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_out
 
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -124,25 +124,20 @@ fun FindPasswordPage() {
         }
     }
 
-    val onBackPressedCallback = remember {
-        object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                when (flowState) {
-                    FlowState.CheckEmail -> navController.popBackStack()
-                    FlowState.SendCode -> {
-                        flowState = FlowState.CheckEmail
-                        codeField = ""
-                        timerState.reset()
-                    }
-                    FlowState.ResetPassword -> flowState = FlowState.SendCode
-                }
+    val onBackPressed: () -> Unit = {
+        when (flowState) {
+            FlowState.CheckEmail -> navController.popBackStack()
+            FlowState.SendCode -> {
+                flowState = FlowState.CheckEmail
+                codeField = ""
+                timerState.reset()
             }
+            FlowState.ResetPassword -> flowState = FlowState.SendCode
         }
     }
 
-    DisposableEffect(Unit) {
-        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.addCallback(onBackPressedCallback)
-        onDispose { onBackPressedCallback.remove() }
+    BackHandler {
+        onBackPressed()
     }
 
     Column(
@@ -151,9 +146,7 @@ fun FindPasswordPage() {
             .background(SNUTTColors.White900)
             .clicks { focusManager.clearFocus() }
     ) {
-        SimpleTopBar(title = stringResource(R.string.find_password_title), onClickNavigateBack = {
-            onBackPressedCallback.handleOnBackPressed()
-        })
+        SimpleTopBar(title = stringResource(R.string.find_password_title), onClickNavigateBack = { onBackPressed() })
         AnimatedContent(targetState = flowState) { targetState ->
             Column(modifier = Modifier.padding(horizontal = 25.dp)) {
                 when (targetState) {


### PR DESCRIPTION
앱이 백그라운드로 들어가고(onStop()) 나서 다시 켜지면 뒤로가기 콜백이 작동하지 않았다. 탑바의 navigateUp 버튼을 통한 뒤로가기는 정상 작동하는데, 시스템 버튼을 통한 뒤로가기는 콜백이 작동하지 않았다.

- 강의 상세 페이지: 편집 상태에서 뒤로가기하면 '편집을 취소하시겠습니까?' 다이얼로그 없이 바로 navigateUp
- 관심강좌 페이지: 강의평 바텀시트가 올라온 상태에서 뒤로가기하면 바텀시트가 닫히지 않고 바로 navigateUp
- 강의평 페이지: 웹뷰에서의 뒤로가기가 실행되지 않고 바로 navigateUp
- 아이디, 비번 찾기 페이지: 이전 플로우로 돌아가지 않고 바로 navigateUp

onBackPressedDispatcher.addCallback()에 lifecycleOwner가 함께 전달되지 않았기 때문이었다!
`public void addCallback(@NonNull OnBackPressedCallback onBackPressedCallback)`은 lifeCycle을 고려하지 않은 함수이며, cancellable(해당 콜백을 골라서 삭제할 때 쓰는 친구? 잘모르겠...)으로 `OnBackPressedCancellable`을 사용한다.
`public void addCallback(@NonNull LifecycleOwner owner, @NonNull OnBackPressedCallback onBackPressedCallback)`은 lifeCycle을 고려한 함수이며, cancellable으로 `LifecycleOnBackPressedCancellable`을 사용한다.

전자를 사용하면, 앱이 백그라운드로 갈 때 `OnBackPressedCancellable`의 `cancel()`이 실행되어 콜백이 바로 삭제된다.
후자를 사용하면, 앱이 백그라운드로 가면 콜백을 삭제했다가, 다시 포어그라운드로 올라오면 콜백을 다시 등록해준다!
```
public void onStateChanged(@NonNull LifecycleOwner source,
                @NonNull Lifecycle.Event event) {
            if (event == Lifecycle.Event.ON_START) {
                mCurrentCancellable = addCancellableCallback(mOnBackPressedCallback);
            } else if (event == Lifecycle.Event.ON_STOP) {
                // Should always be non-null
                if (mCurrentCancellable != null) {
                    mCurrentCancellable.cancel();
                }
            } else if (event == Lifecycle.Event.ON_DESTROY) {
                cancel();
            }
        }
```
(`LifecycleOnBackPressedCancellable`의 관련 코드. 라이프사이클을 관찰하며 그에 맞게 콜백을 등록/해제한다)

`LocalLifecycleOwner.current`를 `addCallback()`에 파라미터로 함께 전달했더니 잘 작동했다. 

그런데 컴포즈에서 뒤로가기 핸들링을 해주는 BackHandler라는 친구가 이미 있고, 더 많은 상황을 커버하며 코드 복붙도 줄어들기 때문에 그냥 이거 쓰면 될 것 같다

100퍼센트 이해하고 정리한 게 아니라 조금 애매... 틀린 내용이나 표현 있을 가능성 농후