### PR TITLE
flipper 제거

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,8 +189,4 @@ dependencies {
     implementation("com.facebook.react:react-android:0.72.3")
     implementation("com.facebook.react:hermes-android:0.72.3")
     implementation(fileTree(mapOf("dir" to "$rootDir/libs", "include" to listOf("*.aar"))))
-
-    // flipper
-    implementation("com.facebook.flipper:flipper:0.213.0")
-    implementation("com.facebook.soloader:soloader:0.10.5")
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt
@@ -3,17 +3,12 @@ package com.wafflestudio.snutt2
 import android.app.Application
 import android.content.res.Configuration
 import androidx.compose.animation.ExperimentalAnimationApi
-import com.facebook.flipper.android.AndroidFlipperClient
-import com.facebook.flipper.android.utils.FlipperUtils
-import com.facebook.flipper.plugins.inspector.DescriptorMapping
-import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.shell.MainReactPackage
-import com.facebook.soloader.SoLoader
 import com.horcrux.svg.SvgPackage
 import com.reactnativecommunity.picker.RNCPickerPackage
 import com.swmansion.gesturehandler.RNGestureHandlerPackage
@@ -33,13 +28,6 @@ class SNUTTApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
-        SoLoader.init(this, false)
-
-        if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(this)) {
-            val client = AndroidFlipperClient.getInstance(this)
-            client.addPlugin(InspectorFlipperPlugin(this, DescriptorMapping.withDefaults()))
-            client.start()
-        }
     }
 
     @OptIn(ExperimentalAnimationApi::class)


### PR DESCRIPTION
[가이드](https://fbflipper.com/docs/getting-started/android-native/) 보면 

```kotlin
dependencies {
  debugImplementation 'com.facebook.flipper:flipper:0.216.0'
  debugImplementation 'com.facebook.soloader:soloader:0.10.5'

  releaseImplementation 'com.facebook.flipper:flipper-noop:0.216.0'
}
```
로 하라고 돼있는데, release 빌드 할 때 터져서 (다른 사람들도 이슈 있다고 글 많음..) 그냥 빼기

이슈 없이 할라면 `/debug/SNUTTApplication.kt`랑 `/release/SNUTTApplication.kt` 따로 만들고 해야되는것같은데 극혐이니까 안함

어차피 컴포즈앱에서 볼 수 있는 정보는 별로 없고, 전혀 다른 이유로 해결된 RN 이슈에서 레이아웃 볼라고 추가했던 거니까 필요할 때 추가해서 쓰기 (30초면 하니까)