### PR TITLE
RemoteConfig / ReactBundleManager 리액티브하게 리팩토링

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.di
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.net.ConnectivityManager
 import android.os.Build
 import android.provider.Settings.Secure
 import com.squareup.moshi.Moshi
@@ -132,4 +133,11 @@ object NetworkModule {
     private const val SIZE_OF_CACHE = (
         10 * 1024 * 1024 // 10 MB
         ).toLong()
+
+    @Provides
+    fun provideConnectivityManager(
+        @ApplicationContext context: Context,
+    ): ConnectivityManager {
+        return (context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/NetworkConnectivityManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/NetworkConnectivityManager.kt
@@ -1,0 +1,47 @@
+package com.wafflestudio.snutt2.lib.network
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.shareIn
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NetworkConnectivityManager @Inject constructor(
+    connectivityManager: ConnectivityManager,
+) {
+    private val _networkConnectivity = MutableStateFlow<Boolean?>(null)
+    val networkConnectivity = _networkConnectivity.filterNotNull()
+        .shareIn(
+            CoroutineScope(Dispatchers.Main),
+            SharingStarted.Eagerly,
+            replay = 1,
+        )
+
+    init {
+        connectivityManager.registerNetworkCallback(
+            NetworkRequest.Builder().apply {
+                addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            }.build(),
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    _networkConnectivity.value = false
+                }
+
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    _networkConnectivity.value = true
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
@@ -17,73 +17,86 @@ import com.swmansion.reanimated.ReanimatedPackage
 import com.th3rdwave.safeareacontext.SafeAreaContextPackage
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.RemoteConfig
-import com.wafflestudio.snutt2.ui.ThemeMode
-import com.wafflestudio.snutt2.ui.isSystemDarkMode
+import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.lib.network.NetworkConnectivityManager
+import com.wafflestudio.snutt2.ui.isDarkMode
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.qualifiers.ActivityContext
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
+import javax.inject.Inject
 
-class ReactNativeBundleManager(
-    private val context: Context,
-    private val remoteConfig: RemoteConfig,
-    private val token: StateFlow<String>,
-    private val themeMode: StateFlow<ThemeMode>,
+@Module
+@InstallIn(ActivityComponent::class)
+class ReactNativeBundleManager @Inject constructor(
+    @ApplicationContext private val applicationContext: Context,
+    @ActivityContext private val activityContext: Context,
+    remoteConfig: RemoteConfig,
+    userRepository: UserRepository,
+    networkConnectivityManager: NetworkConnectivityManager,
 ) {
-    private val rnBundleFileSrc: String
-        get() = if (USE_LOCAL_BUNDLE) LOCAL_BUNDLE_URL else remoteConfig.friendBundleSrc
     private var myReactInstanceManager: ReactInstanceManager? = null
     var reactRootView = mutableStateOf<ReactRootView?>(null)
+    private val reloadSignal = MutableSharedFlow<Unit>()
 
     init {
         CoroutineScope(Dispatchers.IO).launch {
-            remoteConfig.waitForFetchConfig()
-            token.filter { it.isNotEmpty() }.collectLatest {
-                val jsBundleFile = getExistingFriendsBundleFileOrNull() ?: return@collectLatest
-                withContext(Dispatchers.Main) {
-                    myReactInstanceManager = ReactInstanceManager.builder()
-                        .setApplication(context.applicationContext as Application)
-                        .setCurrentActivity(context as Activity)
-                        .setJavaScriptExecutorFactory(HermesExecutorFactory())
-                        .setJSBundleFile(jsBundleFile.absolutePath)
-                        .addPackages(
-                            listOf(MainReactPackage(), RNGestureHandlerPackage(), ReanimatedPackage(), SafeAreaContextPackage(), RNCPickerPackage(), SvgPackage()),
-                        )
-                        .setInitialLifecycleState(LifecycleState.RESUMED)
-                        .build()
-                    themeMode.collectLatest {
-                        val isDarkMode = when (it) {
-                            ThemeMode.AUTO -> isSystemDarkMode(context)
-                            else -> (it == ThemeMode.DARK)
-                        }
-                        reactRootView.value = ReactRootView(context).apply {
+            combine(
+                if (USE_LOCAL_BUNDLE) MutableStateFlow(LOCAL_BUNDLE_URL) else remoteConfig.friendsBundleSrc,
+                userRepository.accessToken.filter { it.isNotEmpty() },
+                userRepository.themeMode,
+                networkConnectivityManager.networkConnectivity.filter { it },
+                reloadSignal.onStart { emit(Unit) },
+            ) { bundleSrc, token, theme, _, _ ->
+                getExistingBundleFileOrNull(applicationContext, bundleSrc)?.let { bundleFile ->
+                    withContext(Dispatchers.Main) {
+                        myReactInstanceManager = ReactInstanceManager.builder()
+                            .setApplication(applicationContext as Application)
+                            .setCurrentActivity(activityContext as Activity)
+                            .setJavaScriptExecutorFactory(HermesExecutorFactory())
+                            .setJSBundleFile(bundleFile.absolutePath)
+                            .addPackages(
+                                listOf(MainReactPackage(), RNGestureHandlerPackage(), ReanimatedPackage(), SafeAreaContextPackage(), RNCPickerPackage(), SvgPackage()),
+                            )
+                            .setInitialLifecycleState(LifecycleState.RESUMED)
+                            .build()
+
+                        reactRootView.value = ReactRootView(activityContext).apply {
                             startReactApplication(
                                 myReactInstanceManager ?: return@apply,
                                 FRIENDS_MODULE_NAME,
                                 Bundle().apply {
-                                    putString("x-access-token", token.value)
+                                    putString("x-access-token", token)
                                     putString("x-access-apikey", context.getString(R.string.api_key))
-                                    putString("theme", if (isDarkMode) "dark" else "light")
+                                    putString("theme", if (isDarkMode(activityContext, theme)) "dark" else "light")
                                     putBoolean("allowFontScaling", true)
                                 },
                             )
                         }
                     }
                 }
-            }
+            }.collect()
         }
     }
 
     // 번들 파일을 저장할 폴더 (없으면 만들기, 실패하면 null)
-    private fun bundlesBaseFolder(): File? {
-        val baseDir = File(context.applicationContext.dataDir.absolutePath, BUNDLE_BASE_FOLDER)
+    private fun bundlesBaseFolder(context: Context): File? {
+        val baseDir = File(context.dataDir.absolutePath, BUNDLE_BASE_FOLDER)
         return if (baseDir.isDirectory && baseDir.exists()) {
             baseDir
         } else if (baseDir.mkdir()) {
@@ -93,9 +106,13 @@ class ReactNativeBundleManager(
         }
     }
 
-    private fun getExistingFriendsBundleFileOrNull(): File? {
-        val baseDir = bundlesBaseFolder() ?: return null
-        val friendsBaseDir = File(baseDir, FRIENDS_MODULE_NAME)
+    private fun getExistingBundleFileOrNull(
+        context: Context,
+        rnBundleFileSrc: String,
+        moduleName: String = FRIENDS_MODULE_NAME, // 나중에 다른 모듈 추가되면 이 파라미터 사용
+    ): File? {
+        val baseDir = bundlesBaseFolder(context) ?: return null
+        val friendsBaseDir = File(baseDir, moduleName)
         if (friendsBaseDir.exists().not() && friendsBaseDir.mkdir().not()) return null
 
         // Config에서 가져온 bundle name대로 fileName을 만든다.
@@ -133,6 +150,11 @@ class ReactNativeBundleManager(
             }
         }
         return targetFile
+    }
+
+    // 수동으로 번들 reload하고 싶을 때 사용
+    suspend fun reloadBundle() {
+        reloadSignal.emit(Unit)
     }
 
     // 번들 파일들은 $rootDir/data/ReactNativeBundles 폴더에 각 모듈별로 저장된다.

--- a/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
@@ -44,8 +44,8 @@ import javax.inject.Inject
 @Module
 @InstallIn(ActivityComponent::class)
 class ReactNativeBundleManager @Inject constructor(
-    @ApplicationContext private val applicationContext: Context,
-    @ActivityContext private val activityContext: Context,
+    @ApplicationContext applicationContext: Context,
+    @ActivityContext activityContext: Context,
     remoteConfig: RemoteConfig,
     userRepository: UserRepository,
     networkConnectivityManager: NetworkConnectivityManager,

--- a/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
@@ -65,16 +65,18 @@ class ReactNativeBundleManager @Inject constructor(
             ) { bundleSrc, token, theme, _, _ ->
                 getExistingBundleFileOrNull(applicationContext, bundleSrc)?.let { bundleFile ->
                     withContext(Dispatchers.Main) {
-                        myReactInstanceManager = ReactInstanceManager.builder()
-                            .setApplication(applicationContext as Application)
-                            .setCurrentActivity(activityContext as Activity)
-                            .setJavaScriptExecutorFactory(HermesExecutorFactory())
-                            .setJSBundleFile(bundleFile.absolutePath)
-                            .addPackages(
-                                listOf(MainReactPackage(), RNGestureHandlerPackage(), ReanimatedPackage(), SafeAreaContextPackage(), RNCPickerPackage(), SvgPackage()),
-                            )
-                            .setInitialLifecycleState(LifecycleState.RESUMED)
-                            .build()
+                        if (myReactInstanceManager == null) {
+                            myReactInstanceManager = ReactInstanceManager.builder()
+                                .setApplication(applicationContext as Application)
+                                .setCurrentActivity(activityContext as Activity)
+                                .setJavaScriptExecutorFactory(HermesExecutorFactory())
+                                .setJSBundleFile(bundleFile.absolutePath)
+                                .addPackages(
+                                    listOf(MainReactPackage(), RNGestureHandlerPackage(), ReanimatedPackage(), SafeAreaContextPackage(), RNCPickerPackage(), SvgPackage()),
+                                )
+                                .setInitialLifecycleState(LifecycleState.RESUMED)
+                                .build()
+                        }
 
                         reactRootView.value = ReactRootView(activityContext).apply {
                             startReactApplication(

--- a/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
@@ -20,11 +20,9 @@ import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.lib.network.NetworkConnectivityManager
 import com.wafflestudio.snutt2.ui.isDarkMode
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ActivityScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -41,8 +39,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import javax.inject.Inject
 
-@Module
-@InstallIn(ActivityComponent::class)
+@ActivityScoped
 class ReactNativeBundleManager @Inject constructor(
     @ApplicationContext applicationContext: Context,
     @ActivityContext activityContext: Context,

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
@@ -55,6 +55,16 @@ fun isDarkMode(): Boolean {
     }
 }
 
+fun isDarkMode(
+    context: Context,
+    theme: ThemeMode,
+): Boolean {
+    return when (theme) {
+        ThemeMode.AUTO -> isSystemDarkMode(context)
+        else -> (theme == ThemeMode.DARK)
+    }
+}
+
 fun isSystemDarkMode(context: Context): Boolean {
     return when (context.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)) {
         Configuration.UI_MODE_NIGHT_YES -> true

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -76,13 +76,12 @@ class RootActivity : AppCompatActivity() {
     @Inject
     lateinit var remoteConfig: RemoteConfig
 
+    @Inject
+    lateinit var friendBundleManager: ReactNativeBundleManager
+
     private var isInitialRefreshFinished = false
 
     private val composeRoot by lazy { findViewById<ComposeView>(R.id.compose_root) }
-
-    private val friendBundleManager by lazy {
-        ReactNativeBundleManager(this, remoteConfig, userViewModel.accessToken, userViewModel.themeMode)
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -206,7 +205,7 @@ class RootActivity : AppCompatActivity() {
             ) {
                 onboardGraph()
 
-                composableRoot(NavigationDestination.Home) { HomePage(friendBundleManager) }
+                composableRoot(NavigationDestination.Home) { HomePage() }
 
                 composable2(NavigationDestination.Notification) { NotificationPage() }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -18,7 +18,6 @@ import com.wafflestudio.snutt2.layouts.ModalDrawerWithBottomSheetLayout
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
 import com.wafflestudio.snutt2.provider.TimetableWidgetProvider
-import com.wafflestudio.snutt2.react_native.ReactNativeBundleManager
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.isDarkMode
 import com.wafflestudio.snutt2.views.*
@@ -39,7 +38,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun HomePage(reactNativeBundleManager: ReactNativeBundleManager) {
+fun HomePage() {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val pageController = LocalHomePageController.current
@@ -130,7 +129,7 @@ fun HomePage(reactNativeBundleManager: ReactNativeBundleManager) {
                             ReviewPage()
                         }
                     }
-                    HomeItem.Friends -> FriendsPage(reactNativeBundleManager)
+                    HomeItem.Friends -> FriendsPage()
                     HomeItem.Settings -> SettingsPage(uncheckedNotification)
                 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -36,7 +36,6 @@ class HomeViewModel @Inject constructor(
                         } ?: tableRepository.fetchDefaultTable()
                     },
                     async { userRepository.fetchUserInfo() },
-                    async { remoteConfig.waitForFetchConfig() },
                 )
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.home.friend
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -10,10 +11,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -21,16 +22,19 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.PeopleIcon
 import com.wafflestudio.snutt2.components.compose.TopBar
-import com.wafflestudio.snutt2.react_native.ReactNativeBundleManager
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
+import com.wafflestudio.snutt2.views.RootActivity
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun FriendsPage(reactNativeBundleManager: ReactNativeBundleManager) {
-    reactNativeBundleManager.reactRootView.value?.let { reactRootView ->
+fun FriendsPage() {
+    val reactRootView = (LocalContext.current as RootActivity).friendBundleManager.reactRootView
+
+    reactRootView.value?.let { view ->
         AndroidView(
             modifier = Modifier.fillMaxSize(),
-            factory = { reactRootView },
+            factory = { view },
         )
     } ?: FriendsPagePlaceholder()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -264,6 +264,7 @@ fun SettingItem(
     onClick: (() -> Unit)? = null,
     content: @Composable () -> Unit = {},
 ) {
+    val newSettingItems by LocalRemoteConfig.current.settingPageNewBadgeTitles.collectAsState(emptyList())
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -280,7 +281,7 @@ fun SettingItem(
                 color = titleColor,
             ),
         )
-        if (LocalRemoteConfig.current.settingPageNewBadgeTitles.contains(title)) {
+        if (newSettingItems.contains(title)) {
             NewBadge(Modifier.padding(start = 5.dp))
         }
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -41,6 +41,7 @@ fun TimetablePage() {
     val userViewModel = hiltViewModel<UserViewModel>()
     val newSemesterNotify by tableListViewModel.newSemesterNotify.collectAsState(false)
     val firstBookmarkAlert by userViewModel.firstBookmarkAlert.collectAsState()
+    val vacancyNotificationBannerEnabled by remoteConfig.vacancyNotificationBannerEnabled.collectAsState(false)
 
     var timetableHeight by remember { mutableStateOf(0) }
     var topBarHeight by remember { mutableStateOf(0) }
@@ -61,7 +62,12 @@ fun TimetablePage() {
                     modifier = Modifier
                         .weight(1f, fill = false)
                         .clicks {
-                            showTitleChangeDialog(table.title, table.id, composableStates, tableListViewModel::changeTableName)
+                            showTitleChangeDialog(
+                                table.title,
+                                table.id,
+                                composableStates,
+                                tableListViewModel::changeTableName,
+                            )
                         },
                 )
                 Spacer(modifier = Modifier.width(8.dp))
@@ -98,7 +104,7 @@ fun TimetablePage() {
                                 view,
                                 context,
                                 topBarHeight,
-                                if (remoteConfig.vacancyNotificationBannerEnabled) bannerHeight else 0,
+                                if (vacancyNotificationBannerEnabled) bannerHeight else 0,
                                 timetableHeight,
                             )
                         },
@@ -116,7 +122,7 @@ fun TimetablePage() {
                 }
             },
         )
-        if (remoteConfig.vacancyNotificationBannerEnabled) {
+        if (vacancyNotificationBannerEnabled) {
             VacancyBanner(
                 onClick = {
                     navController.navigate(NavigationDestination.VacancyNotification)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
@@ -79,6 +79,7 @@ fun VacancyPage(
     val scrollWithButtonAppearing by remember {
         derivedStateOf { vacancyViewModel.isEditMode && lazyListState.isScrolledToEnd() }
     }
+    val sugangSNUUrl by remoteConfig.sugangSNUUrl.collectAsState("")
 
     val onBackPressed = {
         if (vacancyViewModel.isEditMode) {
@@ -271,7 +272,7 @@ fun VacancyPage(
                 },
                 contentColor = SNUTTColors.SNUTTVacancy,
                 onClick = {
-                    remoteConfig.sugangSNUUrl.takeIf { it.isNotEmpty() }?.let {
+                    sugangSNUUrl.takeIf { it.isNotEmpty() }?.let {
                         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(it)))
                     }
                 },


### PR DESCRIPTION
## NetworkConnectivityManager
네트워크 상태를 리액티브하게 받아올 수 있도록 [NetworkConnectivityManager](https://github.com/wafflestudio/snutt-android/commit/98a81f67bfffa86f89a09021d2845eb16c86cb62) 를 추가했다.

## RemoteConfig
RemoteConfig는 NetworkConnectivityManager를 inject받아서, 최초에 네트워크가 있을 때 or 네트워크가 끊겼다가 돌아왔을 때 config를 fetch해 온다. (한번 성공적으로 받아왔으면 fetch 안하게 해도 될듯?)
그리고 `friendsBundleSrc`, `sugangSNUUrl`, `settingPageNewBadgeTitles` 같은 것들 전부 flow로 변경해서, 새로 fetch해온 config에 따라 리액티브하게 변할 수 있도록 했다. (원래 이렇게 하고싶었는데 못했었다)

## ReactNativeBundleManager
ActivityComponent로 RootActivity에 Inject시켰다. DI시킬 객체에 context를 전달하는 법을 몰랐어서 lazy로 생성해서 했는데, `@ApplicationContext` 를 이용하면 Hilt가 applicationContext를 주입해 주고, `@InstallIn(ActivityComponent::class)`와 `@ActivityContext`를 이용하면 Activity도 주입시킬 수 있다. ReactInstanceManager를 만들 때 Activity랑 Application이 필요하기 때문에 어려웠는데 싹다 시원하게 해결.

아래 5가지 flow를 combine해서 리액티브하게 ReactRootView를 그린다.
1. config의 friendsBundleSrc
2. 토큰
3. 테마 모드
4. 네트워크 연결
5. 수동 reload

이것들이 emit될 때마다 bundle을 받아와서(물론 bundleSrc가 바뀐 게 아니면 dataDir에 있는 File을 그냥 다시 가져온다) reactRootView를 새로 만들어 주고, FriendsPage에서는 이게 바뀌면 새로 UI를 그린다 (mutableState라서).

이렇게 하면 다음과 같이 자동으로 인터넷이 연결되면 화면이 바뀐다.

| RN 번들 | 설정화면 뱃지 (config) |
| ----- | ----- |
| <video src="https://github.com/wafflestudio/snutt-android/assets/88367636/d6ab2550-1672-4694-8381-cb5cff394c08" /> | <video src="https://github.com/wafflestudio/snutt-android/assets/88367636/7cc70bc8-3092-4e51-a398-69e94885580f" />


## TODO
다른 기존 GET API들 (관심강좌, 검색필터, TableMap) 이런것들 네트워크 끊길 때 앱 켰다가 네트워크 뒤늦게 연결되면 즉시 fetch가 안 되는데, NetworkConnectivityManager 사용하면 쉽게 바로바로 뜨게 할 수 있다.





