### PR TITLE
다른 기기에서 시간표 삭제 시 404 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -6,7 +6,6 @@ import com.wafflestudio.snutt2.data.current_table.CurrentTableRepository
 import com.wafflestudio.snutt2.data.notifications.NotificationRepository
 import com.wafflestudio.snutt2.data.tables.TableRepository
 import com.wafflestudio.snutt2.data.user.UserRepository
-import com.wafflestudio.snutt2.lib.network.ErrorCode
 import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomeViewModel.kt
@@ -6,6 +6,8 @@ import com.wafflestudio.snutt2.data.current_table.CurrentTableRepository
 import com.wafflestudio.snutt2.data.notifications.NotificationRepository
 import com.wafflestudio.snutt2.data.tables.TableRepository
 import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.lib.network.ErrorCode
+import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -32,7 +34,11 @@ class HomeViewModel @Inject constructor(
                 awaitAll(
                     async {
                         currentTableRepository.currentTable.value?.let {
-                            tableRepository.fetchTableById(it.id)
+                            try {
+                                tableRepository.fetchTableById(it.id)
+                            } catch (e: ErrorParsedHttpException) {
+                                tableRepository.fetchDefaultTable()
+                            }
                         } ?: tableRepository.fetchDefaultTable()
                     },
                     async { userRepository.fetchUserInfo() },


### PR DESCRIPTION
A기기의 현재 선택된 시간표를 B기기에서 삭제할 경우, A기기에서 앱을 켜면 404에러가 발생한다. 그러나 별도의 에러메시지가 출력되지 않고, 올바른 시간표를 다시 가져오지 않아 강의 추가 등을 할 경우 404 에러가 계속해서 발생했다.

try catch로 감싸서 대응했다. runCatching을 쓰려 했는데, 단순한 코드고 굳이 Result 객체를 만들 필요가 없어보여서 try catch로 했다
runCatching으로 더 이쁘게 할 수 있나..?