### PR TITLE
웹뷰 사용하는 페이지에서 코루틴 위치 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/PersonalInformationPolicyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/PersonalInformationPolicyPage.kt
@@ -20,12 +20,10 @@ import com.wafflestudio.snutt2.views.LocalNavController
 fun PersonalInformationPolicyPage() {
     val navController = LocalNavController.current
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val userViewModel = hiltViewModel<UserViewModel>()
     val webViewClient = WebViewClient()
     val themeMode by userViewModel.themeMode.collectAsState()
 
-    var accessToken: String
     val url = stringResource(R.string.api_server) + stringResource(R.string.privacy)
     val headers = HashMap<String, String>()
     headers["x-access-apikey"] = stringResource(R.string.api_key)
@@ -41,26 +39,16 @@ fun PersonalInformationPolicyPage() {
         }
     }
 
-    var webViewUrlReady by remember { mutableStateOf(false) }
-
-    LaunchedEffect(Unit) {
-        accessToken = userViewModel.getAccessToken()
-        headers["x-access-token"] = accessToken
-        webViewUrlReady = true
-    }
-
     Column(modifier = Modifier.fillMaxSize()) {
         SimpleTopBar(
             title = stringResource(R.string.settings_personal_information_policy),
             onClickNavigateBack = { navController.popBackStack() },
         )
-        if (webViewUrlReady) {
-            AndroidView(factory = {
-                WebView(context).apply {
-                    this.webViewClient = webViewClient
-                    this.loadUrl(url, headers)
-                }
-            },)
-        }
+        AndroidView(factory = {
+            WebView(context).apply {
+                this.webViewClient = WebViewClient()
+                loadUrl(url, headers)
+            }
+        },)
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/PersonalInformationPolicyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/PersonalInformationPolicyPage.kt
@@ -15,7 +15,6 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.ThemeMode
 import com.wafflestudio.snutt2.views.LocalNavController
-import kotlinx.coroutines.launch
 
 @Composable
 fun PersonalInformationPolicyPage() {
@@ -44,6 +43,12 @@ fun PersonalInformationPolicyPage() {
 
     var webViewUrlReady by remember { mutableStateOf(false) }
 
+    LaunchedEffect(Unit) {
+        accessToken = userViewModel.getAccessToken()
+        headers["x-access-token"] = accessToken
+        webViewUrlReady = true
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         SimpleTopBar(
             title = stringResource(R.string.settings_personal_information_policy),
@@ -56,11 +61,6 @@ fun PersonalInformationPolicyPage() {
                     this.loadUrl(url, headers)
                 }
             },)
-        }
-        scope.launch {
-            accessToken = userViewModel.getAccessToken()
-            headers["x-access-token"] = accessToken
-            webViewUrlReady = true
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/ServiceInfoPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/ServiceInfoPage.kt
@@ -25,7 +25,6 @@ fun ServiceInfoPage() {
     val webViewClient = WebViewClient()
     val themeMode by userViewModel.themeMode.collectAsState()
 
-    var accessToken: String
     val url = stringResource(R.string.api_server) + stringResource(R.string.terms)
     val headers = HashMap<String, String>()
     headers["x-access-apikey"] = stringResource(R.string.api_key)
@@ -41,27 +40,17 @@ fun ServiceInfoPage() {
         }
     }
 
-    var webViewUrlReady by remember { mutableStateOf(false) }
-
-    LaunchedEffect(Unit) {
-        accessToken = userViewModel.getAccessToken()
-        headers["x-access-token"] = accessToken
-        webViewUrlReady = true
-    }
-
     Column(modifier = Modifier.fillMaxSize()) {
         SimpleTopBar(
             title = stringResource(R.string.settings_service_info),
             onClickNavigateBack = { navController.popBackStack() },
         )
-        if (webViewUrlReady) {
-            AndroidView(factory = {
-                WebView(context).apply {
-                    this.webViewClient = webViewClient
-                    this.loadUrl(url, headers)
-                }
-            },)
-        }
+        AndroidView(factory = {
+            WebView(context).apply {
+                this.webViewClient = webViewClient
+                loadUrl(url, headers)
+            }
+        },)
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/ServiceInfoPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/ServiceInfoPage.kt
@@ -16,13 +16,11 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.ThemeMode
 import com.wafflestudio.snutt2.views.LocalNavController
-import kotlinx.coroutines.launch
 
 @Composable
 fun ServiceInfoPage() {
     val navController = LocalNavController.current
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val userViewModel = hiltViewModel<UserViewModel>()
     val webViewClient = WebViewClient()
     val themeMode by userViewModel.themeMode.collectAsState()
@@ -45,6 +43,12 @@ fun ServiceInfoPage() {
 
     var webViewUrlReady by remember { mutableStateOf(false) }
 
+    LaunchedEffect(Unit) {
+        accessToken = userViewModel.getAccessToken()
+        headers["x-access-token"] = accessToken
+        webViewUrlReady = true
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         SimpleTopBar(
             title = stringResource(R.string.settings_service_info),
@@ -57,11 +61,6 @@ fun ServiceInfoPage() {
                     this.loadUrl(url, headers)
                 }
             },)
-        }
-        scope.launch {
-            accessToken = userViewModel.getAccessToken()
-            headers["x-access-token"] = accessToken
-            webViewUrlReady = true
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/TeamInfoPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/TeamInfoPage.kt
@@ -16,13 +16,11 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.ThemeMode
 import com.wafflestudio.snutt2.views.LocalNavController
-import kotlinx.coroutines.launch
 
 @Composable
 fun TeamInfoPage() {
     val navController = LocalNavController.current
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val userViewModel = hiltViewModel<UserViewModel>()
     val webViewClient = WebViewClient()
     val themeMode by userViewModel.themeMode.collectAsState()
@@ -45,6 +43,12 @@ fun TeamInfoPage() {
 
     var webViewUrlReady by remember { mutableStateOf(false) }
 
+    LaunchedEffect(Unit) {
+        accessToken = userViewModel.getAccessToken()
+        headers["x-access-token"] = accessToken
+        webViewUrlReady = true
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         SimpleTopBar(
             title = stringResource(R.string.settings_team_info),
@@ -57,11 +61,6 @@ fun TeamInfoPage() {
                     this.loadUrl(url, headers)
                 }
             },)
-        }
-        scope.launch {
-            accessToken = userViewModel.getAccessToken()
-            headers["x-access-token"] = accessToken
-            webViewUrlReady = true
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/TeamInfoPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/TeamInfoPage.kt
@@ -25,7 +25,6 @@ fun TeamInfoPage() {
     val webViewClient = WebViewClient()
     val themeMode by userViewModel.themeMode.collectAsState()
 
-    var accessToken: String
     val url = stringResource(R.string.api_server) + stringResource(R.string.member)
     val headers = HashMap<String, String>()
     headers["x-access-apikey"] = stringResource(R.string.api_key)
@@ -41,27 +40,17 @@ fun TeamInfoPage() {
         }
     }
 
-    var webViewUrlReady by remember { mutableStateOf(false) }
-
-    LaunchedEffect(Unit) {
-        accessToken = userViewModel.getAccessToken()
-        headers["x-access-token"] = accessToken
-        webViewUrlReady = true
-    }
-
     Column(modifier = Modifier.fillMaxSize()) {
         SimpleTopBar(
             title = stringResource(R.string.settings_team_info),
             onClickNavigateBack = { navController.popBackStack() },
         )
-        if (webViewUrlReady) {
-            AndroidView(factory = {
-                WebView(context).apply {
-                    this.webViewClient = webViewClient
-                    this.loadUrl(url, headers)
-                }
-            },)
-        }
+        AndroidView(factory = {
+            WebView(context).apply {
+                this.webViewClient = webViewClient
+                loadUrl(url, headers)
+            }
+        },)
     }
 }
 


### PR DESCRIPTION
실수로 ./gradlew lint를 해서 안 건데, 개인정보처리방침, 서비스 약관, 개발자 정보 페이지에서 헤더에 access token을 넣는 코루틴이 composable 함수 안에서 launch되고 있어서 LaunchedEffect로 옮겼다.