### PR TITLE
상태바 및 내비게이션 바 색 변경

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.views.LocalThemeState
 
@@ -82,13 +84,17 @@ fun SNUTTTheme(
      * 원래는 values-night/styles.xml를 통해 다크모드의 색을 지정하지만, 우리는 시스템의 테마와 앱의 테마를
      * 다르게 설정할 수 있기 때문에 여기서 직접 설정해 준다.
      */
-    (LocalContext.current as Activity).window.setBackgroundDrawableResource(
-        if (isDarkMode()) {
-            R.color.black_dark
-        } else {
-            R.color.white
-        },
-    )
+    val window = (LocalContext.current as Activity).window
+    val primaryColor = LocalContext.current.getColor(if (isDarkMode()) R.color.black_dark else R.color.white)
+    window.apply {
+        setBackgroundDrawableResource(if (isDarkMode()) R.color.black_dark else R.color.white)
+        statusBarColor = primaryColor
+        navigationBarColor = primaryColor
+    }
+    WindowCompat.getInsetsController(window, LocalView.current).apply {
+        isAppearanceLightStatusBars = isDarkMode().not()
+        isAppearanceLightNavigationBars = isDarkMode().not()
+    }
     MaterialTheme(
         colors = if (isDarkMode()) DarkThemeColors else LightThemeColors,
         typography = SNUTTTypography,


### PR DESCRIPTION
## 변경사항
- 원래 새까맣던 status bar 색을 primary 색으로 수정
- navigation bar도 새까만색(시스템 다크) or 새하얀색(시스템 라이트)서 마찬가지로 수정

| Before | After |
|-----|-----|
|<img src=https://github.com/wafflestudio/snutt-android/assets/68140623/defe0211-1180-483d-a8af-f8145b30e1be width=200/> | <img src=https://github.com/wafflestudio/snutt-android/assets/68140623/5d4d57c1-7be4-4c8a-b912-2187a52762ec width=200/> <img src=https://github.com/wafflestudio/snutt-android/assets/68140623/ff6f48ca-4953-4043-bfa7-11eb8010fc47 width=200/> |

## 단점
<img src=https://github.com/wafflestudio/snutt-android/assets/68140623/d4d2dab9-4d0e-416e-b2c8-0ab8a832694a width=200/> <img src=https://github.com/wafflestudio/snutt-android/assets/68140623/d51594a0-0116-4265-af88-2f09e2c21caa width=200/>
scrim 때문에 status bar 바로 아래 색이 어두워져도 status bar 색은 그대로다... scrim 감지해서 색 바꿔주는건 뇌절일 것 같은데 어때
사소하면 이대로 가도 좋고

사진만 봐선 별 차이가 없어보이네 직접 실행하면 좀 더 체감돼