### PR TITLE
기본 테마 지정 시 alert 삭제

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/ChangeThemeBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/ChangeThemeBottomSheet.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -41,12 +40,9 @@ import com.wafflestudio.snutt2.model.TableTheme
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.isDarkMode
-import com.wafflestudio.snutt2.views.LocalApiOnError
-import com.wafflestudio.snutt2.views.LocalApiOnProgress
 import com.wafflestudio.snutt2.views.LocalBottomSheetState
 import com.wafflestudio.snutt2.views.LocalNavController
 import com.wafflestudio.snutt2.views.NavigationDestination
-import com.wafflestudio.snutt2.views.launchSuspendApi
 import com.wafflestudio.snutt2.views.logged_in.home.settings.theme.AddThemeItem
 import com.wafflestudio.snutt2.views.logged_in.home.settings.theme.ThemeListViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimetableViewModel
@@ -61,17 +57,9 @@ fun ChangeThemeBottomSheet(
 ) {
     val navController = LocalNavController.current
     val bottomSheet = LocalBottomSheetState.current
-    val apiOnError = LocalApiOnError.current
-    val apiOnProgress = LocalApiOnProgress.current
     val customThemes by themeListViewModel.customThemes.collectAsState()
     val builtInThemes by themeListViewModel.builtInThemes.collectAsState()
     val previewTheme by timetableViewModel.previewTheme.collectAsState()
-
-    LaunchedEffect(Unit) {
-        launchSuspendApi(apiOnProgress, apiOnError) {
-            themeListViewModel.fetchThemes()
-        }
-    }
 
     if (bottomSheet.isVisible) {
         DisposableEffect(LocalLifecycleOwner.current) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigPage.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -89,12 +88,6 @@ fun ThemeConfigPage(
 
     BackHandler {
         onBackPressed()
-    }
-
-    LaunchedEffect(Unit) {
-        launchSuspendApi(apiOnProgress, apiOnError) {
-            themeListViewModel.fetchThemes()
-        }
     }
 
     ModalBottomSheetLayout(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeDetailPage.kt
@@ -167,15 +167,16 @@ fun ThemeDetailPage(
                         .clicks {
                             if (isDefault != editingTheme.isDefault) {
                                 when (isDefault) {
-                                    true -> showSetDefaultDialog(
-                                        composableStates = composableStates,
-                                        onConfirm = {
-                                            themeDetailViewModel.saveTheme(themeName)
-                                            themeDetailViewModel.setThemeDefault()
-                                            onClickSave()
-                                            navController.popBackStack()
-                                        },
-                                    )
+                                    true -> {
+                                        scope.launch {
+                                            launchSuspendApi(apiOnProgress, apiOnError) {
+                                                themeDetailViewModel.saveTheme(themeName)
+                                                themeDetailViewModel.setThemeDefault()
+                                                onClickSave()
+                                                navController.popBackStack()
+                                            }
+                                        }
+                                    }
                                     false -> showUnsetDefaultDialog(
                                         composableStates = composableStates,
                                         onConfirm = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeDetailPageDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeDetailPageDialogs.kt
@@ -8,37 +8,6 @@ import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.views.launchSuspendApi
 import kotlinx.coroutines.launch
 
-fun showSetDefaultDialog(
-    composableStates: ComposableStates,
-    onConfirm: suspend () -> Unit,
-) {
-    val modalState = composableStates.modalState
-    val context = composableStates.context
-    val apiOnError = composableStates.apiOnError
-    val apiOnProgress = composableStates.apiOnProgress
-    val scope = composableStates.scope
-
-    modalState.setOkCancel(
-        context = context,
-        onDismiss = { modalState.hide() },
-        onConfirm = {
-            scope.launch {
-                launchSuspendApi(apiOnProgress, apiOnError) {
-                    onConfirm()
-                    modalState.hide()
-                }
-            }
-        },
-        title = context.getString(R.string.theme_detail_dialog_set_default_title),
-        content = {
-            Text(
-                text = stringResource(R.string.theme_detail_dialog_set_default_body),
-                style = SNUTTTypography.body1,
-            )
-        },
-    ).show()
-}
-
 fun showUnsetDefaultDialog(
     composableStates: ComposableStates,
     onConfirm: suspend () -> Unit,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,8 +344,6 @@
     <string name="theme_detail_app_bar_title_builtin">제공 테마</string>
     <string name="theme_detail_dialog_cancel_edit_title">테마 편집 취소</string>
     <string name="theme_detail_dialog_cancel_edit_body">테마 편집을 취소하시겠습니까?</string>
-    <string name="theme_detail_dialog_set_default_title">기본 테마 지정</string>
-    <string name="theme_detail_dialog_set_default_body">기본 테마로 지정하시겠습니까?\n새로 만드는 시간표에 적용됩니다.</string>
     <string name="theme_detail_dialog_unset_default_title">기본 테마 해제</string>
     <string name="theme_detail_dialog_unset_default_body">기본 테마 적용을 취소하시겠습니까?\n\'SNUTT\' 테마가 기본 적용됩니다.</string>
     <string name="theme_detail_theme_name">테마명</string>


### PR DESCRIPTION
- 기본 테마 지정 시 alert 삭제([2024.01.31 스크럼](https://www.notion.so/wafflestudio/2024-01-31-370c4eddadd8480889c7cdd71d3501f3?pvs=4))
- GET /themes 호출을 HomePage의 LaunchedEffect만 남기고 삭제
  - 전반적으로 api 호출 더 줄이고 싶은데... 일단 이렇게