### PR TITLE
바텀내비게이션 더보기 탭 red dot 삭제

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/BottomNavigation.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/BottomNavigation.kt
@@ -13,7 +13,6 @@ import com.wafflestudio.snutt2.ui.SNUTTColors
 internal fun BottomNavigation(
     pageState: HomeItem,
     onUpdatePageState: (HomeItem) -> Unit,
-    uncheckedNotification: Boolean,
 ) {
     Row(
         modifier = Modifier
@@ -94,13 +93,11 @@ internal fun BottomNavigation(
                 onUpdatePageState(HomeItem.Settings)
             },
         ) {
-            IconWithAlertDot(uncheckedNotification && pageState != HomeItem.Settings) { centerAlignedModifier ->
-                HorizontalMoreIcon(
-                    modifier = centerAlignedModifier.size(30.dp),
-                    isSelected = pageState == HomeItem.Settings,
-                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                )
-            }
+            HorizontalMoreIcon(
+                modifier = Modifier.size(30.dp),
+                isSelected = pageState == HomeItem.Settings,
+                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+            )
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -153,7 +153,6 @@ fun HomePage() {
             BottomNavigation(
                 pageState = pageController.homePageState.value,
                 onUpdatePageState = { pageController.update(it) },
-                uncheckedNotification = uncheckedNotification,
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/table_lectures/LecturesOfTablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/table_lectures/LecturesOfTablePage.kt
@@ -45,7 +45,11 @@ fun LecturesOfTablePage() {
     val currentTable: TableDto? by viewModel.currentTable.collectAsState()
     val lectureList = currentTable?.lectureList ?: emptyList()
 
-    Column(modifier = Modifier.background(SNUTTColors.White900)) {
+    Column(
+        modifier = Modifier
+            .background(SNUTTColors.White900)
+            .fillMaxSize()
+    ) {
         SimpleTopBar(
             title = stringResource(R.string.timetable_app_bar_title),
             onClickNavigateBack = { navController.popBackStack() },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/table_lectures/LecturesOfTablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/table_lectures/LecturesOfTablePage.kt
@@ -48,7 +48,7 @@ fun LecturesOfTablePage() {
     Column(
         modifier = Modifier
             .background(SNUTTColors.White900)
-            .fillMaxSize()
+            .fillMaxSize(),
     ) {
         SimpleTopBar(
             title = stringResource(R.string.timetable_app_bar_title),


### PR DESCRIPTION
- 알림 아이콘이 TimetablePage로 넘어갔는데 uncheckedNotification reddot이 바텀내비게이션 더보기탭에 남아있었다....
  - [여기](https://github.com/wafflestudio/snutt-android/pull/228)서 놓쳤던 내용
- 다른 이야기인데, LecturesOfTablePage에 fillMaxSize가 없어서 내비게이션이 어색한 점 발견하여 수정