### PR TITLE
깡통 웹뷰로 번들 한번 컴파일시켜보고 실행하기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
@@ -67,34 +67,32 @@ class ReactNativeBundleManager @Inject constructor(
                 reloadSignal.onStart { emit(Unit) },
             ) { bundleSrc, token, theme, _, _ ->
                 getExistingBundleFileOrNull(applicationContext, bundleSrc)?.let { bundleFile ->
-                    withContext(Dispatchers.Main) {
-                        checkBundleIntegrity(bundleFile, activityContext) {
-                            if (myReactInstanceManager == null) {
-                                myReactInstanceManager = ReactInstanceManager.builder()
-                                    .setApplication(applicationContext as Application)
-                                    .setCurrentActivity(activityContext as Activity)
-                                    .setJavaScriptExecutorFactory(HermesExecutorFactory())
-                                    .setJSBundleFile(bundleFile.absolutePath)
-                                    .addPackages(
-                                        listOf(MainReactPackage(), RNGestureHandlerPackage(), ReanimatedPackage(), SafeAreaContextPackage(), RNCPickerPackage(), SvgPackage(), AsyncStoragePackage()),
-                                    )
-                                    .setInitialLifecycleState(LifecycleState.RESUMED)
-                                    .build()
-                            }
-
-                            reactRootView.value = ReactRootView(activityContext).apply {
-                                startReactApplication(
-                                    myReactInstanceManager ?: return@apply,
-                                    FRIENDS_MODULE_NAME,
-                                    Bundle().apply {
-                                        putString("x-access-token", token)
-                                        putString("x-access-apikey", context.getString(R.string.api_key))
-                                        putString("theme", if (isDarkMode(activityContext, theme)) "dark" else "light")
-                                        putBoolean("allowFontScaling", true)
-                                        putStringArrayList("feature", arrayListOf("ASYNC_STORAGE"))
-                                    },
+                    checkBundleIntegrity(bundleFile, activityContext) {
+                        if (myReactInstanceManager == null) {
+                            myReactInstanceManager = ReactInstanceManager.builder()
+                                .setApplication(applicationContext as Application)
+                                .setCurrentActivity(activityContext as Activity)
+                                .setJavaScriptExecutorFactory(HermesExecutorFactory())
+                                .setJSBundleFile(bundleFile.absolutePath)
+                                .addPackages(
+                                    listOf(MainReactPackage(), RNGestureHandlerPackage(), ReanimatedPackage(), SafeAreaContextPackage(), RNCPickerPackage(), SvgPackage(), AsyncStoragePackage()),
                                 )
-                            }
+                                .setInitialLifecycleState(LifecycleState.RESUMED)
+                                .build()
+                        }
+
+                        reactRootView.value = ReactRootView(activityContext).apply {
+                            startReactApplication(
+                                myReactInstanceManager ?: return@apply,
+                                FRIENDS_MODULE_NAME,
+                                Bundle().apply {
+                                    putString("x-access-token", token)
+                                    putString("x-access-apikey", context.getString(R.string.api_key))
+                                    putString("theme", if (isDarkMode(activityContext, theme)) "dark" else "light")
+                                    putBoolean("allowFontScaling", true)
+                                    putStringArrayList("feature", arrayListOf("ASYNC_STORAGE"))
+                                },
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/react_native/ReactNativeBundleManager.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/fd08383ee741eec4d13d09707a5cfee3?hl=ko&time=last-seven-days&types=crash&sessionEventKey=65DEC2CA011200012E9CE6F445E5D1E2_1918964226012818812

이거 좀 막아보자!

깡통 웹뷰를 만들고, 거기에서 evaluateJavascript를 통해 Bundle 파일의 JS 코드를 실행시켜본다.
JS 코드 마지막줄에는 브릿지 post 하는 코드를 넣어 놓는데, 만약 컴파일이 깨지면 이 라인이 불리지 않는다.
정상적으로 브릿지가 도착했을 때만 ReactRootView를 생성하여 사용한다.

임시로 이 브랜치를 10% 정도로 배포해보고 경과를 지켜보자!