### PR TITLE
NetworkModule에서의 싱글톤 주입 오류 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
@@ -26,6 +26,7 @@ import retrofit2.Retrofit
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.io.File
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -33,6 +34,7 @@ object NetworkModule {
 
     @SuppressLint("HardwareIds")
     @Provides
+    @Singleton
     fun provideOkHttpClient(
         @ApplicationContext context: Context,
         snuttStorage: SNUTTStorage,
@@ -126,6 +128,7 @@ object NetworkModule {
     }
 
     @Provides
+    @Singleton
     fun provideSNUTTRestApi(retrofit: Retrofit): SNUTTRestApi {
         return retrofit.create(SNUTTRestApi::class.java)
     }
@@ -135,6 +138,7 @@ object NetworkModule {
         ).toLong()
 
     @Provides
+    @Singleton
     fun provideConnectivityManager(
         @ApplicationContext context: Context,
     ): ConnectivityManager {


### PR DESCRIPTION
NetworkModule에 @Singleton만 붙어있으면 싱글턴이 주입되는 줄 알았는데 @Provides 함수마다 @Singleton을 붙여줘야 했다... 로그 찍어보니 레포지토리마다 각자 다른 SNUTTRestApi 쓰고있었음......