### PR TITLE
default build flavor를 stagingDebug로 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ android {
 
     buildTypes {
         getByName("debug") {
+            isDefault = true
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android.txt"))
         }
@@ -77,6 +78,7 @@ android {
 
     productFlavors {
         create("staging") {
+            isDefault = true
             applicationIdSuffix = ".staging"
 
             val propertyVersionName = versionProps.getProperty("snuttVersionName")


### PR DESCRIPTION
default build flavor를 stagingDebug로 바꿨습니다

team-snutt-android-crashylistics에서의 머쓱한 '이거나야'를 방지하기 위함