### PR TITLE
중복되는 lectureBuilding 리스트 지우고 v1/buildings api 이용하도록 변경

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/embed_map/EmbedMap.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/embed_map/EmbedMap.kt
@@ -51,7 +51,7 @@ fun EmbedMap(
 
     /* 지도 카메라 */
     val cameraPositionState = rememberCameraPositionState()
-    LaunchedEffect(Unit, buildings) {
+    LaunchedEffect(buildings) {
         cameraPositionState.move(
             EmbedMapUtils.getCameraUpdateFromLatLngList(
                 buildings.map { it.locationInDMS.toLatLng() },

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/embed_map/EmbedMap.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/embed_map/EmbedMap.kt
@@ -51,7 +51,7 @@ fun EmbedMap(
 
     /* 지도 카메라 */
     val cameraPositionState = rememberCameraPositionState()
-    LaunchedEffect(Unit) {
+    LaunchedEffect(Unit, buildings) {
         cameraPositionState.move(
             EmbedMapUtils.getCameraUpdateFromLatLngList(
                 buildings.map { it.locationInDMS.toLatLng() },

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepository.kt
@@ -25,7 +25,7 @@ interface LectureSearchRepository {
 
     suspend fun getSearchTags(year: Long, semester: Long): List<TagDto>
 
-    suspend fun getLectureBuildings(
+    suspend fun getBuildings(
         places: String,
     ): List<LectureBuildingDto>
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepository.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.data.lecture_search
 
 import androidx.paging.PagingData
+import com.wafflestudio.snutt2.lib.network.dto.core.LectureBuildingDto
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.model.SearchTimeDto
 import com.wafflestudio.snutt2.model.TagDto
@@ -23,4 +24,8 @@ interface LectureSearchRepository {
     ): String
 
     suspend fun getSearchTags(year: Long, semester: Long): List<TagDto>
+
+    suspend fun getLectureBuildings(
+        places: String,
+    ): List<LectureBuildingDto>
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.wafflestudio.snutt2.lib.SnuttUrls
 import com.wafflestudio.snutt2.lib.network.SNUTTRestApi
+import com.wafflestudio.snutt2.lib.network.dto.core.LectureBuildingDto
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.model.SearchTimeDto
 import com.wafflestudio.snutt2.model.TagDto
@@ -62,6 +63,11 @@ class LectureSearchRepositoryImpl @Inject constructor(
             addAll(response.category.map { TagDto(TagType.CATEGORY, it) })
         }
         return list
+    }
+
+    override suspend fun getLectureBuildings(places: String): List<LectureBuildingDto> {
+        val response = api._getBuildings(places)
+        return response.content
     }
 
     companion object {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
@@ -65,7 +65,7 @@ class LectureSearchRepositoryImpl @Inject constructor(
         return list
     }
 
-    override suspend fun getLectureBuildings(places: String): List<LectureBuildingDto> {
+    override suspend fun getBuildings(places: String): List<LectureBuildingDto> {
         val response = api._getBuildings(places)
         return response.content
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/SNUTTRestApi.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/SNUTTRestApi.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.lib.network
 
 import com.wafflestudio.snutt2.lib.network.dto.*
+import com.wafflestudio.snutt2.lib.network.dto.core.BuildingsResponse
 import retrofit2.http.*
 
 /**
@@ -288,4 +289,9 @@ interface SNUTTRestApi {
     suspend fun _postCopyTheme(
         @Path("themeId") themeId: String,
     ): PostCopyThemeResults
+
+    @GET("/v1/buildings")
+    suspend fun _getBuildings(
+        @Query("places") places: String,
+    ): BuildingsResponse
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/BuildingsResponse.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/BuildingsResponse.kt
@@ -7,5 +7,4 @@ import com.squareup.moshi.JsonClass
 data class BuildingsResponse(
     @Json(name = "content") val content: List<LectureBuildingDto>,
     @Json(name = "totalCount") val totalCount: Int,
-    @Json(name = "nextPageToken") val nextPageToken: String?,
 )

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/BuildingsResponse.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/BuildingsResponse.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.snutt2.lib.network.dto.core
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class BuildingsResponse(
+    @Json(name = "content") val content: List<LectureBuildingDto>,
+    @Json(name = "totalCount") val totalCount: Int,
+    @Json(name = "nextPageToken") val nextPageToken: String?,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/ClassTimeDto.kt
@@ -10,7 +10,6 @@ data class ClassTimeDto(
     @Json(name = "_id") val id: String? = null,
     @Json(name = "startMinute") val startMinute: Int = 0,
     @Json(name = "endMinute") val endMinute: Int = 0,
-    @Json(name = "lectureBuildings") val lectureBuildings: List<LectureBuildingDto>? = null,
 ) {
 
     val startTimeInFloat: Float

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/LectureDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/LectureDto.kt
@@ -29,9 +29,6 @@ data class LectureDto(
     val isCustom: Boolean
         get() = course_number.isNullOrBlank() && lecture_number.isNullOrEmpty()
 
-    val buildings: List<LectureBuildingDto>
-        get() = class_time_json.flatMap { it.lectureBuildings.orEmpty() }.distinct()
-
     companion object {
         val Default = LectureDto(
             id = "",

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -82,6 +82,7 @@ fun LectureDetailPage(
     val userViewModel = hiltViewModel<UserViewModel>()
     val modeType by vm.modeType.collectAsState()
     val editingLectureDetail by vm.editingLectureDetail.collectAsState()
+    val editingLectureBuildings by vm.editingLectureBuildings.collectAsState()
     val tableColorTheme by vm.currentTableTheme.collectAsState()
     val isCustom = editingLectureDetail.isCustom
     val bookmarkList by searchViewModel.bookmarkList.collectAsState()
@@ -90,12 +91,17 @@ fun LectureDetailPage(
     val vacancyRegistered = vacancyList.map { it.id }.contains(editingLectureDetail.lecture_id ?: editingLectureDetail.id)
     val disableMapFeature by LocalRemoteConfig.current.disableMapFeature.collectAsState(true) // NOTE: config를 받아오기 전까지는 지도를 숨긴다.
     var creditText by remember { mutableStateOf(editingLectureDetail.credit.toString()) }
+    var buildingLoaded by remember { mutableStateOf(false) }
     /* 현재 LectureDto 타입의 editingLectureDetail 플로우를 변경해 가면서 API 부를 때도 쓰고 화면에 정보 표시할 때도 쓰고 있는데,
      * credit은 Long 타입이라서 학점 입력하는 editText에 빈 문자열을 넣었을 때(=다 지웠을 때) 문제가 발생한다. 그래서 credit만 별도의 MutableState<String>을 둬서 운용한다.
      * 이때 다른 정보들은 editingLectureDetail 따라서 바뀌니까 모드가 바뀌어도 따로 할 게 없는데, 얘는 편집모드->일반모드로 바뀔 때 따로 변경해 줘야 한다. 그것이 아래의 코드.
      */
     LaunchedEffect(modeType) {
         if (modeType !is ModeType.Editing) creditText = editingLectureDetail.credit.toString()
+        CoroutineScope(Dispatchers.Main).launch {
+            vm.getLectureBuildingsFromPlaces()
+            buildingLoaded = true
+        }
     }
 
     /* 바텀시트 관련 */
@@ -126,6 +132,7 @@ fun LectureDetailPage(
                 }
             }
         }
+        buildingLoaded = false
     }
 
     BackHandler {
@@ -149,470 +156,487 @@ fun LectureDetailPage(
             }
         }
 
-    ModalBottomSheetLayout(
-        sheetContent = bottomSheet.content,
-        sheetState = bottomSheet.state,
-        sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
-        scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
-//        onDismissScrim = {
-//            scope.launch { bottomSheet.hide() }
-//        }
-        // gesturesEnabled 가 없다! 그래서 드래그해서도 닫아진다..
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(SNUTTColors.Gray100),
-//                    .clicks { focusManager.clearFocus() }
+    if (buildingLoaded) {
+        ModalBottomSheetLayout(
+            sheetContent = bottomSheet.content,
+            sheetState = bottomSheet.state,
+            sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
+            scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
+            //        onDismissScrim = {
+            //            scope.launch { bottomSheet.hide() }
+            //        }
+            // gesturesEnabled 가 없다! 그래서 드래그해서도 닫아진다..
         ) {
-            TopBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.lecture_detail_app_bar_title),
-                        style = SNUTTTypography.h2,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                },
-                navigationIcon = {
-                    ArrowBackIcon(
-                        modifier = Modifier
-                            .size(30.dp)
-                            .clicks {
-                                onBackPressed()
-                            },
-                        colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                    )
-                },
-                actions = {
-                    if (isCustom.not() && (modeType !is ModeType.Editing)) {
-                        RingingAlarmIcon(
-                            modifier = Modifier
-                                .size(30.dp)
-                                .clicks {
-                                    scope.launch {
-                                        launchSuspendApi(apiOnProgress, apiOnError) {
-                                            if (vacancyRegistered) {
-                                                vacancyViewModel.removeVacancyLecture(
-                                                    editingLectureDetail.lecture_id
-                                                        ?: editingLectureDetail.id,
-                                                )
-                                            } else {
-                                                vacancyViewModel.addVacancyLecture(
-                                                    editingLectureDetail.lecture_id
-                                                        ?: editingLectureDetail.id,
-                                                )
-                                            }
-                                        }
-                                    }
-                                },
-                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                            marked = vacancyRegistered,
-                        )
-                        BookmarkIcon(
-                            modifier = Modifier
-                                .size(30.dp)
-                                .clicks {
-                                    scope.launch {
-                                        launchSuspendApi(apiOnProgress, apiOnError) {
-                                            if (isBookmarked) {
-                                                searchViewModel.deleteBookmark(
-                                                    editingLectureDetail,
-                                                )
-                                            } else {
-                                                searchViewModel.addBookmark(editingLectureDetail)
-                                            }
-                                            searchViewModel.getBookmarkList()
-                                        }
-                                    }
-                                },
-                            marked = isBookmarked,
-                        )
-                    }
-                    if (modeType != ModeType.Viewing) {
-                        Text(
-                            text = when (modeType) {
-                                is ModeType.Editing -> stringResource(R.string.lecture_detail_top_bar_complete)
-                                else -> stringResource(R.string.lecture_detail_top_bar_edit)
-                            },
-                            style = SNUTTTypography.body1,
-                            modifier = Modifier
-                                .clicks {
-                                    focusManager.clearFocus()
-                                    if (modeType == ModeType.Normal) {
-                                        vm.setEditMode()
-                                    } else {
-                                        checkLectureOverlap(
-                                            composableStates,
-                                            api = {
-                                                if ((modeType as ModeType.Editing).adding) {
-                                                    vm.createLecture()
-                                                    scope.launch(Dispatchers.Main) { navController.popBackStack() }
-                                                } else {
-                                                    vm.updateLecture()
-                                                }
-                                            },
-                                            onLectureOverlap = { message ->
-                                                showLectureOverlapDialog(composableStates, message, forceAddApi = {
-                                                    if ((modeType as ModeType.Editing).adding) {
-                                                        vm.createLecture(is_forced = true)
-                                                        scope.launch(Dispatchers.Main) { navController.popBackStack() }
-                                                    } else {
-                                                        vm.updateLecture(is_forced = true)
-                                                    }
-                                                },)
-                                            },
-                                        )
-                                    }
-                                },
-                        )
-                    }
-                },
-            )
             Column(
                 modifier = Modifier
-                    .verticalScroll(scrollState)
-                    .padding(vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
+                    .fillMaxSize()
+                    .background(SNUTTColors.Gray100),
+                //                    .clicks { focusManager.clearFocus() }
             ) {
-                Column(
-                    modifier = Modifier
-                        .background(SNUTTColors.White900)
-                        .padding(vertical = 4.dp),
-                ) {
-                    LectureDetailItem(
-                        title = stringResource(R.string.lecture_detail_lecture_title),
-                        value = editingLectureDetail.course_title,
-                        onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(course_title = it)) },
-                        hint = if (modeType is ModeType.Editing) stringResource(R.string.lecture_detail_lecture_title_hint) else stringResource(R.string.lecture_detail_hint_nothing),
-                        enabled = modeType is ModeType.Editing,
-                    )
-                    LectureDetailItem(
-                        title = stringResource(R.string.lecture_detail_instructor),
-                        value = editingLectureDetail.instructor,
-                        onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(instructor = it)) },
-                        hint = if (modeType is ModeType.Editing) stringResource(R.string.lecture_detail_instructor_hint) else stringResource(R.string.lecture_detail_hint_nothing),
-                        enabled = modeType is ModeType.Editing,
-                    )
-                    if (modeType != ModeType.Viewing) {
-                        LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_color),
-                        ) {
-                            Row(
-                                modifier = Modifier.clicks(enabled = modeType != ModeType.Normal) {
-                                    navController.navigate(NavigationDestination.LectureColorSelector)
+                TopBar(
+                    title = {
+                        Text(
+                            text = stringResource(R.string.lecture_detail_app_bar_title),
+                            style = SNUTTTypography.h2,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                    navigationIcon = {
+                        ArrowBackIcon(
+                            modifier = Modifier
+                                .size(30.dp)
+                                .clicks {
+                                    onBackPressed()
                                 },
-                            ) {
-                                ColorBox(
-                                    if (tableColorTheme is CustomTheme) {
-                                        editingLectureDetail.color
-                                    } else {
-                                        if (editingLectureDetail.colorIndex == 0L) {
-                                            editingLectureDetail.color
+                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                        )
+                    },
+                    actions = {
+                        if (isCustom.not() && (modeType !is ModeType.Editing)) {
+                            RingingAlarmIcon(
+                                modifier = Modifier
+                                    .size(30.dp)
+                                    .clicks {
+                                        scope.launch {
+                                            launchSuspendApi(apiOnProgress, apiOnError) {
+                                                if (vacancyRegistered) {
+                                                    vacancyViewModel.removeVacancyLecture(
+                                                        editingLectureDetail.lecture_id
+                                                            ?: editingLectureDetail.id,
+                                                    )
+                                                } else {
+                                                    vacancyViewModel.addVacancyLecture(
+                                                        editingLectureDetail.lecture_id
+                                                            ?: editingLectureDetail.id,
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    },
+                                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                                marked = vacancyRegistered,
+                            )
+                            BookmarkIcon(
+                                modifier = Modifier
+                                    .size(30.dp)
+                                    .clicks {
+                                        scope.launch {
+                                            launchSuspendApi(apiOnProgress, apiOnError) {
+                                                if (isBookmarked) {
+                                                    searchViewModel.deleteBookmark(
+                                                        editingLectureDetail,
+                                                    )
+                                                } else {
+                                                    searchViewModel.addBookmark(editingLectureDetail)
+                                                }
+                                                searchViewModel.getBookmarkList()
+                                            }
+                                        }
+                                    },
+                                marked = isBookmarked,
+                            )
+                        }
+                        if (modeType != ModeType.Viewing) {
+                            Text(
+                                text = when (modeType) {
+                                    is ModeType.Editing -> stringResource(R.string.lecture_detail_top_bar_complete)
+                                    else -> stringResource(R.string.lecture_detail_top_bar_edit)
+                                },
+                                style = SNUTTTypography.body1,
+                                modifier = Modifier
+                                    .clicks {
+                                        focusManager.clearFocus()
+                                        if (modeType == ModeType.Normal) {
+                                            vm.setEditMode()
                                         } else {
-                                            ColorDto(
-                                                fgColor = 0xffffff,
-                                                bgColor = (tableColorTheme as BuiltInTheme).getColorByIndex(
-                                                    context,
-                                                    editingLectureDetail.colorIndex,
-                                                ),
+                                            checkLectureOverlap(
+                                                composableStates,
+                                                api = {
+                                                    if ((modeType as ModeType.Editing).adding) {
+                                                        vm.createLecture()
+                                                        scope.launch(Dispatchers.Main) { navController.popBackStack() }
+                                                    } else {
+                                                        vm.updateLecture()
+                                                    }
+                                                },
+                                                onLectureOverlap = { message ->
+                                                    showLectureOverlapDialog(
+                                                        composableStates, message,
+                                                        forceAddApi = {
+                                                            if ((modeType as ModeType.Editing).adding) {
+                                                                vm.createLecture(is_forced = true)
+                                                                scope.launch(Dispatchers.Main) { navController.popBackStack() }
+                                                            } else {
+                                                                vm.updateLecture(is_forced = true)
+                                                            }
+                                                        },
+                                                    )
+                                                },
                                             )
                                         }
                                     },
-                                )
-                                Spacer(modifier = Modifier.weight(1f))
-                                AnimatedVisibility(visible = modeType is ModeType.Editing) {
-                                    ArrowRight(
-                                        modifier = Modifier.size(16.dp),
-                                        colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                            )
+                        }
+                    },
+                )
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(scrollState)
+                        .padding(vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .background(SNUTTColors.White900)
+                            .padding(vertical = 4.dp),
+                    ) {
+                        LectureDetailItem(
+                            title = stringResource(R.string.lecture_detail_lecture_title),
+                            value = editingLectureDetail.course_title,
+                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(course_title = it)) },
+                            hint = if (modeType is ModeType.Editing) stringResource(R.string.lecture_detail_lecture_title_hint) else stringResource(R.string.lecture_detail_hint_nothing),
+                            enabled = modeType is ModeType.Editing,
+                        )
+                        LectureDetailItem(
+                            title = stringResource(R.string.lecture_detail_instructor),
+                            value = editingLectureDetail.instructor,
+                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(instructor = it)) },
+                            hint = if (modeType is ModeType.Editing) stringResource(R.string.lecture_detail_instructor_hint) else stringResource(R.string.lecture_detail_hint_nothing),
+                            enabled = modeType is ModeType.Editing,
+                        )
+                        if (modeType != ModeType.Viewing) {
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_color),
+                            ) {
+                                Row(
+                                    modifier = Modifier.clicks(enabled = modeType != ModeType.Normal) {
+                                        navController.navigate(NavigationDestination.LectureColorSelector)
+                                    },
+                                ) {
+                                    ColorBox(
+                                        if (tableColorTheme is CustomTheme) {
+                                            editingLectureDetail.color
+                                        } else {
+                                            if (editingLectureDetail.colorIndex == 0L) {
+                                                editingLectureDetail.color
+                                            } else {
+                                                ColorDto(
+                                                    fgColor = 0xffffff,
+                                                    bgColor = (tableColorTheme as BuiltInTheme).getColorByIndex(
+                                                        context,
+                                                        editingLectureDetail.colorIndex,
+                                                    ),
+                                                )
+                                            }
+                                        },
                                     )
+                                    Spacer(modifier = Modifier.weight(1f))
+                                    AnimatedVisibility(visible = modeType is ModeType.Editing) {
+                                        ArrowRight(
+                                            modifier = Modifier.size(16.dp),
+                                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                Column(
-                    modifier = Modifier
-                        .background(SNUTTColors.White900)
-                        .padding(vertical = 4.dp),
-                ) {
-                    if (isCustom.not()) {
+                    Column(
+                        modifier = Modifier
+                            .background(SNUTTColors.White900)
+                            .padding(vertical = 4.dp),
+                    ) {
+                        if (isCustom.not()) {
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_department),
+                                value = editingLectureDetail.department ?: "",
+                                onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(department = it)) },
+                                enabled = modeType is ModeType.Editing,
+                            )
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_academic_year),
+                                value = editingLectureDetail.academic_year ?: "",
+                                onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(academic_year = it)) },
+                                enabled = modeType is ModeType.Editing,
+                            )
+                        }
                         LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_department),
-                            value = editingLectureDetail.department ?: "",
-                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(department = it)) },
+                            title = stringResource(R.string.lecture_detail_credit),
+                            value = creditText,
+                            onValueChange = {
+                                creditText = it
+                                vm.editLectureDetail(editingLectureDetail.copy(credit = it.creditStringToLong()))
+                            },
                             enabled = modeType is ModeType.Editing,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
+                            hint = "0",
                         )
+                        if (isCustom.not()) {
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_classification),
+                                value = editingLectureDetail.classification ?: "",
+                                onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(classification = it)) },
+                                enabled = modeType is ModeType.Editing,
+                            )
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_category),
+                                value = editingLectureDetail.category ?: "",
+                                onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(category = it)) },
+                                enabled = modeType is ModeType.Editing,
+                            )
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_course_number),
+                                value = editingLectureDetail.course_number ?: "",
+                                textStyle = SNUTTTypography.body1.copy(
+                                    fontSize = 15.sp,
+                                    color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
+                                ),
+                            )
+                            LectureDetailItem(
+                                title = stringResource(R.string.lecture_detail_lecture_number),
+                                value = editingLectureDetail.lecture_number ?: "",
+                                textStyle = SNUTTTypography.body1.copy(
+                                    fontSize = 15.sp,
+                                    color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
+                                ),
+                            )
+                            LectureDetailItem(
+                                title = editingLectureDetail.getQuotaTitle(context),
+                                value = editingLectureDetail.getFullQuota(),
+                                textStyle = SNUTTTypography.body1.copy(
+                                    fontSize = 15.sp,
+                                    color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
+                                ),
+                            )
+                        }
                         LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_academic_year),
-                            value = editingLectureDetail.academic_year ?: "",
-                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(academic_year = it)) },
+                            title = stringResource(R.string.lecture_detail_remark),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = 40.dp)
+                                .padding(vertical = 10.dp),
+                            value = editingLectureDetail.remark,
+                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(remark = it)) },
                             enabled = modeType is ModeType.Editing,
+                            singleLine = false,
+                            keyboardOptions = KeyboardOptions.Default,
+                            keyboardActions = KeyboardActions.Default,
+                            hint = if (modeType is ModeType.Editing) stringResource(R.string.lecture_detail_remark_hint) else stringResource(R.string.lecture_detail_hint_nothing),
+                            labelVerticalAlignment = Alignment.Top,
                         )
                     }
-                    LectureDetailItem(
-                        title = stringResource(R.string.lecture_detail_credit),
-                        value = creditText,
-                        onValueChange = {
-                            creditText = it
-                            vm.editLectureDetail(editingLectureDetail.copy(credit = it.creditStringToLong()))
-                        },
-                        enabled = modeType is ModeType.Editing,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
-                        hint = "0",
-                    )
-                    if (isCustom.not()) {
-                        LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_classification),
-                            value = editingLectureDetail.classification ?: "",
-                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(classification = it)) },
-                            enabled = modeType is ModeType.Editing,
-                        )
-                        LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_category),
-                            value = editingLectureDetail.category ?: "",
-                            onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(category = it)) },
-                            enabled = modeType is ModeType.Editing,
-                        )
-                        LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_course_number),
-                            value = editingLectureDetail.course_number ?: "",
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
-                            ),
-                        )
-                        LectureDetailItem(
-                            title = stringResource(R.string.lecture_detail_lecture_number),
-                            value = editingLectureDetail.lecture_number ?: "",
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
-                            ),
-                        )
-                        LectureDetailItem(
-                            title = editingLectureDetail.getQuotaTitle(context),
-                            value = editingLectureDetail.getFullQuota(),
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
-                            ),
-                        )
-                    }
-                    LectureDetailItem(
-                        title = stringResource(R.string.lecture_detail_remark),
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(min = 40.dp)
-                            .padding(vertical = 10.dp),
-                        value = editingLectureDetail.remark,
-                        onValueChange = { vm.editLectureDetail(editingLectureDetail.copy(remark = it)) },
-                        enabled = modeType is ModeType.Editing,
-                        singleLine = false,
-                        keyboardOptions = KeyboardOptions.Default,
-                        keyboardActions = KeyboardActions.Default,
-                        hint = if (modeType is ModeType.Editing) stringResource(R.string.lecture_detail_remark_hint) else stringResource(R.string.lecture_detail_hint_nothing),
-                        labelVerticalAlignment = Alignment.Top,
-                    )
-                }
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(SNUTTColors.White900),
-                ) {
-                    Text(
-                        text = stringResource(R.string.lecture_detail_class_time),
-                        modifier = Modifier
-                            .padding(start = 20.dp, top = 10.dp, bottom = 14.dp),
-                        style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
-                    )
-                    editingLectureDetail.class_time_json.forEachIndexed { idx, classTime ->
-                        LectureDetailTimeAndLocation(
-                            timeText = SNUTTStringUtils.getClassTimeText(classTime),
-                            locationText = classTime.place,
-                            editTime = {
-                                bottomSheet.setSheetContent {
-                                    DayTimePickerSheet(
-                                        bottomSheet = bottomSheet,
-                                        classTime = classTime,
-                                        onDismiss = { scope.launch { bottomSheet.hide() } },
-                                        onConfirm = { editedClassTime ->
-                                            vm.editLectureDetail(
-                                                editingLectureDetail.copy(
-                                                    class_time_json = editingLectureDetail.class_time_json.toMutableList()
-                                                        .also {
-                                                            it[idx] = editedClassTime
-                                                        },
-                                                ),
-                                            )
-                                            scope.launch { bottomSheet.hide() }
-                                        },
-                                    )
-                                }
-                                scope.launch {
-                                    focusManager.clearFocus()
-                                    bottomSheet.show()
-                                }
-                            },
-                            onLocationTextChange = { changedLocation ->
-                                vm.editLectureDetail(
-                                    editingLectureDetail.copy(
-                                        class_time_json = editingLectureDetail.class_time_json.toMutableList()
-                                            .also {
-                                                it[idx] =
-                                                    classTime.copy(place = changedLocation)
+                            .background(SNUTTColors.White900),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.lecture_detail_class_time),
+                            modifier = Modifier
+                                .padding(start = 20.dp, top = 10.dp, bottom = 14.dp),
+                            style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
+                        )
+                        editingLectureDetail.class_time_json.forEachIndexed { idx, classTime ->
+                            LectureDetailTimeAndLocation(
+                                timeText = SNUTTStringUtils.getClassTimeText(classTime),
+                                locationText = classTime.place,
+                                editTime = {
+                                    bottomSheet.setSheetContent {
+                                        DayTimePickerSheet(
+                                            bottomSheet = bottomSheet,
+                                            classTime = classTime,
+                                            onDismiss = { scope.launch { bottomSheet.hide() } },
+                                            onConfirm = { editedClassTime ->
+                                                vm.editLectureDetail(
+                                                    editingLectureDetail.copy(
+                                                        class_time_json = editingLectureDetail.class_time_json.toMutableList()
+                                                            .also {
+                                                                it[idx] = editedClassTime
+                                                            },
+                                                    ),
+                                                )
+                                                scope.launch { bottomSheet.hide() }
                                             },
-                                    ),
-                                )
-                            },
-                            onClickDeleteIcon = {
-                                showDeleteClassTimeDialog(composableStates, onConfirm = {
+                                        )
+                                    }
+                                    scope.launch {
+                                        focusManager.clearFocus()
+                                        bottomSheet.show()
+                                    }
+                                },
+                                onLocationTextChange = { changedLocation ->
                                     vm.editLectureDetail(
                                         editingLectureDetail.copy(
                                             class_time_json = editingLectureDetail.class_time_json.toMutableList()
                                                 .also {
-                                                    it.removeAt(idx)
-                                                },
-                                        ),
-                                    )
-                                },)
-                            },
-                            editMode = modeType is ModeType.Editing,
-                            visible = if (idx == editingLectureDetail.class_time_json.lastIndex) {
-                                classTimeAnimationState
-                            } else {
-                                MutableTransitionState(true)
-                            },
-                        )
-                    }
-                    AnimatedVisibility(
-                        visible = modeType is ModeType.Editing,
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(32.dp)
-                                .clicks {
-                                    classTimeAnimationState =
-                                        MutableTransitionState(false).apply {
-                                            targetState = true
-                                        }
-                                    vm.editLectureDetail(
-                                        editingLectureDetail.copy(
-                                            class_time_json = editingLectureDetail.class_time_json
-                                                .toMutableList()
-                                                .also {
-                                                    it.add(it.lastOrNull() ?: ClassTimeDto.Default)
+                                                    it[idx] =
+                                                        classTime.copy(place = changedLocation)
                                                 },
                                         ),
                                     )
                                 },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = stringResource(R.string.lecture_detail_add_class_time),
-                                textAlign = TextAlign.Center,
-                                style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
+                                onClickDeleteIcon = {
+                                    showDeleteClassTimeDialog(
+                                        composableStates,
+                                        onConfirm = {
+                                            vm.editLectureDetail(
+                                                editingLectureDetail.copy(
+                                                    class_time_json = editingLectureDetail.class_time_json.toMutableList()
+                                                        .also {
+                                                            it.removeAt(idx)
+                                                        },
+                                                ),
+                                            )
+                                        },
+                                    )
+                                },
+                                editMode = modeType is ModeType.Editing,
+                                visible = if (idx == editingLectureDetail.class_time_json.lastIndex) {
+                                    classTimeAnimationState
+                                } else {
+                                    MutableTransitionState(true)
+                                },
                             )
                         }
-                    }
-                    if (disableMapFeature.not()) {
                         AnimatedVisibility(
-                            visible = modeType !is ModeType.Editing,
+                            visible = modeType is ModeType.Editing,
                         ) {
-                            FoldableEmbedMap(
-                                modifier = Modifier.padding(vertical = 8.dp),
-                                buildings = editingLectureDetail.buildings,
-                            )
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(32.dp)
+                                    .clicks {
+                                        classTimeAnimationState =
+                                            MutableTransitionState(false).apply {
+                                                targetState = true
+                                            }
+                                        vm.editLectureDetail(
+                                            editingLectureDetail.copy(
+                                                class_time_json = editingLectureDetail.class_time_json
+                                                    .toMutableList()
+                                                    .also {
+                                                        it.add(it.lastOrNull() ?: ClassTimeDto.Default)
+                                                    },
+                                            ),
+                                        )
+                                    },
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.lecture_detail_add_class_time),
+                                    textAlign = TextAlign.Center,
+                                    style = SNUTTTypography.body1.copy(color = SNUTTColors.Black600),
+                                )
+                            }
+                        }
+                        if (disableMapFeature.not()) {
+                            AnimatedVisibility(
+                                visible = modeType !is ModeType.Editing,
+                            ) {
+                                FoldableEmbedMap(
+                                    modifier = Modifier.padding(vertical = 8.dp),
+                                    buildings = editingLectureBuildings,
+                                )
+                            }
                         }
                     }
-                }
-                AnimatedVisibility(
-                    visible = modeType !is ModeType.Editing,
-                ) {
-                    Column {
-                        if (isCustom) {
-                            Box(modifier = Modifier.background(Color.White)) {
-                                LectureDetailButton(
-                                    title = stringResource(R.string.lecture_detail_delete_button),
-                                    textStyle = SNUTTTypography.body1.copy(
-                                        fontSize = 15.sp,
-                                        color = SNUTTColors.Red,
-                                    ),
-                                ) {
-                                    showDeleteLectureDialog(composableStates, onConfirm = {
-                                        vm.removeLecture()
-                                        scope.launch(Dispatchers.Main) {
-                                            navController.popBackStack()
-                                        }
-                                    },)
+                    AnimatedVisibility(
+                        visible = modeType !is ModeType.Editing,
+                    ) {
+                        Column {
+                            if (isCustom) {
+                                Box(modifier = Modifier.background(Color.White)) {
+                                    LectureDetailButton(
+                                        title = stringResource(R.string.lecture_detail_delete_button),
+                                        textStyle = SNUTTTypography.body1.copy(
+                                            fontSize = 15.sp,
+                                            color = SNUTTColors.Red,
+                                        ),
+                                    ) {
+                                        showDeleteLectureDialog(
+                                            composableStates,
+                                            onConfirm = {
+                                                vm.removeLecture()
+                                                scope.launch(Dispatchers.Main) {
+                                                    navController.popBackStack()
+                                                }
+                                            },
+                                        )
+                                    }
                                 }
-                            }
-                        } else {
-                            Column(modifier = Modifier.background(SNUTTColors.White900)) {
-                                LectureDetailButton(title = stringResource(R.string.lecture_detail_syllabus_button)) {
-                                    scope.launch {
-                                        launchSuspendApi(apiOnProgress, apiOnError) {
-                                            vm.getCourseBookUrl().let { url ->
-                                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                                                context.startActivity(intent)
+                            } else {
+                                Column(modifier = Modifier.background(SNUTTColors.White900)) {
+                                    LectureDetailButton(title = stringResource(R.string.lecture_detail_syllabus_button)) {
+                                        scope.launch {
+                                            launchSuspendApi(apiOnProgress, apiOnError) {
+                                                vm.getCourseBookUrl().let { url ->
+                                                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                                    context.startActivity(intent)
+                                                }
                                             }
                                         }
                                     }
+                                    LectureDetailButton(title = stringResource(R.string.lecture_detail_review_button)) {
+                                        verifyEmailBeforeApi(
+                                            composableStates,
+                                            api = {
+                                                val url = vm.getReviewContentsUrl()
+                                                openReviewBottomSheet(
+                                                    url,
+                                                    reviewBottomSheetWebViewContainer,
+                                                    bottomSheet,
+                                                )
+                                            },
+                                            onUnverified = {
+                                                onCloseViewMode(scope)
+                                                navController.navigateAsOrigin(NavigationDestination.Home)
+                                                pageController.update(HomeItem.Review())
+                                            },
+                                        )
+                                    }
                                 }
-                                LectureDetailButton(title = stringResource(R.string.lecture_detail_review_button)) {
-                                    verifyEmailBeforeApi(
+                            }
+                        }
+                    }
+                    if (isCustom.not() && modeType != ModeType.Viewing) {
+                        Box(modifier = Modifier.background(Color.White)) {
+                            LectureDetailButton(
+                                title = if (modeType is ModeType.Editing) {
+                                    stringResource(R.string.lecture_detail_reset_button)
+                                } else {
+                                    stringResource(
+                                        R.string.lecture_detail_delete_button,
+                                    )
+                                },
+                                textStyle = SNUTTTypography.body1.copy(
+                                    fontSize = 15.sp,
+                                    color = SNUTTColors.Red,
+                                ),
+                            ) {
+                                if (modeType is ModeType.Editing) {
+                                    showResetLectureDialog(
                                         composableStates,
-                                        api = {
-                                            val url = vm.getReviewContentsUrl()
-                                            openReviewBottomSheet(
-                                                url,
-                                                reviewBottomSheetWebViewContainer,
-                                                bottomSheet,
-                                            )
+                                        onConfirm = {
+                                            vm.resetLecture()
                                         },
-                                        onUnverified = {
-                                            onCloseViewMode(scope)
-                                            navController.navigateAsOrigin(NavigationDestination.Home)
-                                            pageController.update(HomeItem.Review())
+                                    )
+                                } else {
+                                    showDeleteLectureDialog(
+                                        composableStates,
+                                        onConfirm = {
+                                            vm.removeLecture()
+                                            scope.launch(Dispatchers.Main) {
+                                                navController.popBackStack()
+                                            }
                                         },
                                     )
                                 }
                             }
                         }
                     }
+                    Margin(height = 30.dp)
                 }
-                if (isCustom.not() && modeType != ModeType.Viewing) {
-                    Box(modifier = Modifier.background(Color.White)) {
-                        LectureDetailButton(
-                            title = if (modeType is ModeType.Editing) {
-                                stringResource(R.string.lecture_detail_reset_button)
-                            } else {
-                                stringResource(
-                                    R.string.lecture_detail_delete_button,
-                                )
-                            },
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = SNUTTColors.Red,
-                            ),
-                        ) {
-                            if (modeType is ModeType.Editing) {
-                                showResetLectureDialog(composableStates, onConfirm = {
-                                    vm.resetLecture()
-                                },)
-                            } else {
-                                showDeleteLectureDialog(composableStates, onConfirm = {
-                                    vm.removeLecture()
-                                    scope.launch(Dispatchers.Main) {
-                                        navController.popBackStack()
-                                    }
-                                },)
-                            }
-                        }
-                    }
-                }
-                Margin(height = 30.dp)
             }
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -46,6 +46,7 @@ import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getFullQuota
 import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getQuotaTitle
 import com.wafflestudio.snutt2.lib.network.dto.core.ClassTimeDto
 import com.wafflestudio.snutt2.lib.network.dto.core.ColorDto
+import com.wafflestudio.snutt2.lib.network.dto.core.LectureBuildingDto
 import com.wafflestudio.snutt2.model.BuiltInTheme
 import com.wafflestudio.snutt2.model.CustomTheme
 import com.wafflestudio.snutt2.ui.SNUTTColors
@@ -82,7 +83,7 @@ fun LectureDetailPage(
     val userViewModel = hiltViewModel<UserViewModel>()
     val modeType by vm.modeType.collectAsState()
     val editingLectureDetail by vm.editingLectureDetail.collectAsState()
-    val editingLectureBuildings by vm.editingLectureBuildings.collectAsState()
+    val editingLectureBuildings by vm.editingLectureBuildings.collectAsState(emptyList<LectureBuildingDto>())
     val tableColorTheme by vm.currentTableTheme.collectAsState()
     val isCustom = editingLectureDetail.isCustom
     val bookmarkList by searchViewModel.bookmarkList.collectAsState()
@@ -97,7 +98,6 @@ fun LectureDetailPage(
      */
     LaunchedEffect(modeType) {
         if (modeType !is ModeType.Editing) creditText = editingLectureDetail.credit.toString()
-        vm.getLectureBuildingsFromPlaces()
     }
 
     /* 바텀시트 관련 */

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailViewModel.kt
@@ -44,7 +44,7 @@ class LectureDetailViewModel @Inject constructor(
 
     val editingLectureBuildings = editingLectureDetail.map { lecture ->
         val places = lecture.class_time_json.map { it.place }.distinct().joinToString(",")
-        lectureSearchRepository.getLectureBuildings(places)
+        lectureSearchRepository.getBuildings(places)
     }
 
     fun setEditMode(adding: Boolean = false) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailViewModel.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.snutt2.data.lecture_search.LectureSearchRepository
 import com.wafflestudio.snutt2.data.themes.ThemeRepository
 import com.wafflestudio.snutt2.lib.network.dto.PostCustomLectureParams
 import com.wafflestudio.snutt2.lib.network.dto.PutLectureParams
+import com.wafflestudio.snutt2.lib.network.dto.core.LectureBuildingDto
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
 import com.wafflestudio.snutt2.model.TableTheme
@@ -37,8 +38,12 @@ class LectureDetailViewModel @Inject constructor(
     val modeType = _modeType.asStateFlow()
 
     private var fixedLectureDetail = LectureDto.Default
+
     private val _editingLectureDetail = MutableStateFlow(fixedLectureDetail)
     val editingLectureDetail = _editingLectureDetail.asStateFlow()
+
+    private val _editingLectureBuildings = MutableStateFlow(emptyList<LectureBuildingDto>())
+    val editingLectureBuildings = _editingLectureBuildings.asStateFlow()
 
     fun setEditMode(adding: Boolean = false) {
         viewModelScope.launch { _modeType.emit(ModeType.Editing(adding)) }
@@ -95,6 +100,11 @@ class LectureDetailViewModel @Inject constructor(
             courseNumber = editingLectureDetail.value.course_number ?: return null,
             instructor = editingLectureDetail.value.instructor,
         )
+    }
+
+    suspend fun getLectureBuildingsFromPlaces() {
+        val places = _editingLectureDetail.value.class_time_json.map { it.place }.distinct().joinToString(",")
+        _editingLectureBuildings.emit(lectureSearchRepository.getLectureBuildings(places))
     }
 
     private fun buildPutLectureParams(): PutLectureParams {


### PR DESCRIPTION
일단 작동은 잘 하는데 아래 써놓은거 위주로 review 해주시면 됩니당

1. api를 전혀 상관없어보이는 LectrueSearchRepository에서 호출하고 있음. 근데 여기밖에 할만한 곳이 없긴 해서...

2. 처음에 해봤더니 FoldableEmbedMap에 isEmbedMapFoldedSaved가 true로 고정되어 있어서, 301동 강의 detail 들어갔다가 좀 멀리있는 1동 강의 들어가면 지도가 펼쳐진 상태 + 지도 mark는 1동으로 바뀌는데 그 위치는 301동인 이상한 상황 발생 (api로 불러오는데 걸리는 시간 때문인 듯?)
    -> 그래서 buildingLoaded라는 새로운 state를 만들고 api 호출 부분을 coroutine으로 감싼 뒤 ModalBottomSheetLayout 전체를 
          buildingLoaded가 true일때만 그리도록 매우매우 이상하게 바꿔놓았습니다

혹시 더 좋은 방법 있나요