### PR TITLE
폴드에서 컬러피커가 너무 크던 점 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ColorPicker.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ColorPicker.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.toRect
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.SNUTTUtils.px2dp
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.isDarkMode
@@ -390,7 +389,6 @@ fun showColorPickerDialog(
     initialColor: Color,
     onColorPicked: (Color) -> Unit,
 ) {
-    val screenWidthInDp = context.px2dp(context.resources.displayMetrics.widthPixels.toFloat())
     var currentColor = initialColor
     modalState.setOkCancel(
         context = context,
@@ -402,7 +400,7 @@ fun showColorPickerDialog(
             modalState.hide()
         },
         title = context.getString(R.string.color_picker_dialog_title),
-        width = if (screenWidthInDp - 50 > 400) 400.dp else null,
+        width = 400.dp,
     ) {
         ColorPicker(
             initialColor = initialColor,

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ColorPicker.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ColorPicker.kt
@@ -400,7 +400,6 @@ fun showColorPickerDialog(
             modalState.hide()
         },
         title = context.getString(R.string.color_picker_dialog_title),
-        width = 400.dp,
     ) {
         ColorPicker(
             initialColor = initialColor,

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ColorPicker.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ColorPicker.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.toRect
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.SNUTTUtils.px2dp
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.isDarkMode
@@ -107,6 +108,9 @@ fun ColorPicker(
                 hexCode = hsvToString(hsv)
                 onColorChanged(Color.hsv(hsv.first, hsv.second, hsv.third))
             },
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
         )
         HueBar(
             hue = hsv.first,
@@ -115,6 +119,9 @@ fun ColorPicker(
                 hexCode = hsvToString(hsv)
                 onColorChanged(Color.hsv(hsv.first, hsv.second, hsv.third))
             },
+            modifier = Modifier
+                .height(20.dp)
+                .fillMaxWidth(),
         )
         Row(
             modifier = Modifier.height(30.dp),
@@ -198,11 +205,10 @@ fun ColorPicker(
 fun HueBar(
     hue: Float,
     onHueChanged: (Float) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier
-            .height(20.dp)
-            .fillMaxWidth()
+        modifier = modifier
             .clip(CircleShape),
     ) {
         HueBackground( // hue에 따라 변하는 부분과 변하지 않는 부분을 분리하여 recompose 최적화
@@ -287,11 +293,10 @@ fun SatValPanel(
     hue: Float,
     satVal: Pair<Float, Float>,
     onSatValChanged: (Float, Float) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(1f)
+        modifier = modifier
             .clip(RoundedCornerShape(12.dp)),
     ) {
         SatValBackground( // sat, val에 따라 변하는 부분과 변하지 않는 부분을 분리하여 recompose 최적화
@@ -385,6 +390,7 @@ fun showColorPickerDialog(
     initialColor: Color,
     onColorPicked: (Color) -> Unit,
 ) {
+    val screenWidthInDp = context.px2dp(context.resources.displayMetrics.widthPixels.toFloat())
     var currentColor = initialColor
     modalState.setOkCancel(
         context = context,
@@ -396,6 +402,7 @@ fun showColorPickerDialog(
             modalState.hide()
         },
         title = context.getString(R.string.color_picker_dialog_title),
+        width = if (screenWidthInDp - 50 > 400) 400.dp else null,
     ) {
         ColorPicker(
             initialColor = initialColor,

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/Modal.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/Modal.kt
@@ -62,6 +62,7 @@ class ModalState {
         onDismiss: () -> Unit,
         onConfirm: () -> Unit,
         title: String,
+        width: Dp? = null,
         content: @Composable () -> Unit,
     ): ModalState {
         return this.apply {
@@ -70,7 +71,7 @@ class ModalState {
             this.title = title
             this.positiveButtonText = context.getString(R.string.common_ok)
             this.negativeButtonText = context.getString(R.string.common_cancel)
-            this.width = null
+            this.width = width
             this.content = content
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ProgressDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ProgressDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.wafflestudio.snutt2.R
@@ -64,6 +65,7 @@ fun CustomDialog(
     content: @Composable () -> Unit,
 ) {
     val screenWidthInDp = with(LocalDensity.current) { LocalView.current.width.toDp() }
+    val dialogWidth = min(width ?: Int.MAX_VALUE.dp, screenWidthInDp - 50.dp)
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -74,7 +76,7 @@ fun CustomDialog(
         ) {
             Column(
                 modifier = Modifier
-                    .width(width ?: (screenWidthInDp - 50.dp))
+                    .width(dialogWidth)
                     .background(SNUTTColors.White900),
             ) {
                 title?.let {

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/ProgressDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/ProgressDialog.kt
@@ -65,7 +65,7 @@ fun CustomDialog(
     content: @Composable () -> Unit,
 ) {
     val screenWidthInDp = with(LocalDensity.current) { LocalView.current.width.toDp() }
-    val dialogWidth = min(width ?: Int.MAX_VALUE.dp, screenWidthInDp - 50.dp)
+    val dialogWidth = width ?: min(400.dp, screenWidthInDp - 50.dp)
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),


### PR DESCRIPTION
# 원인
CustomDialog()는 usePlatformDefaultWidth = false로 하고, screenWidth - 50dp로 커스텀 너비를 쓰고 있다.
컬러피커도 이걸 아무 생각없이 갖다 썼다. width를 screenWidth - 50dp로 하고, height는 그에 맞게 결정되는 것.
그런데 height가 width보다 길다 보니, 폴드처럼 가로가 무지막지 긴 디바이스에서는 '확인', '취소'버튼이 화면 밖으로 나가버리는 이슈가 있었다.

# 해결
- 너비를 min(400dp, screenWidth - 50dp)로 했다.
- 400dp는 폴드에서 너무 작아보이지 않도록 대충 잡은 너비
- CustomDialog의 width 로직을 조금 고쳤다

|Before|After|
|------|-------|
|<img width = "450" alt="image" src="https://github.com/wafflestudio/snutt-android/assets/68140623/b5139ffa-e568-4e2f-9424-8b611105c6d5">|<img width="450" alt="image" src="https://github.com/wafflestudio/snutt-android/assets/68140623/1b8c0d9f-5a96-4479-a121-066e0e597a6d">|