### PR TITLE
[멀티 모듈 리팩토링] versionCode, versionName 관련 설정 및 serializedCode 생성 로직을 별도 플러그인으로 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,3 @@
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.snutt.android.application)
     alias(libs.plugins.snutt.android.application.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.Properties
-import java.io.FileInputStream
 
 plugins {
     alias(libs.plugins.snutt.android.application)
@@ -7,6 +8,7 @@ plugins {
     alias(libs.plugins.snutt.android.application.flavors)
     alias(libs.plugins.snutt.android.hilt)
     alias(libs.plugins.snutt.android.application.firebase)
+    alias(libs.plugins.snutt.semantic.versioning)
 
 //    id("dagger.hilt.android.plugin")
 //    id("kotlin-kapt")
@@ -14,17 +16,20 @@ plugins {
 //    id("com.google.firebase.crashlytics")
 }
 
-//val versionProps = Properties().apply {
-//    load(FileInputStream(File(rootProject.rootDir, "version.properties")))
-//}
+val versionProps = Properties().apply {
+    load(Files.newBufferedReader(Paths.get(rootProject.rootDir.toString(), "version.properties")))
+}
 
 android {
     namespace = "com.wafflestudio.snutt2"
 
     defaultConfig {
         applicationId = "com.wafflestudio.snutt2"
-        versionCode = 1
-        versionName = "3.6.0"
+
+        val propertyVersionName = versionProps.getProperty("snuttVersionName")
+        versionName = propertyVersionName
+        versionCode = extensions.getByType<SemanticVersioningUtils>()
+            .semanticVersionToSerializedCode(propertyVersionName).toInt()
     }
 
     signingConfigs {
@@ -60,10 +65,6 @@ android {
         create("staging") {
             isDefault = true
             applicationIdSuffix = ".staging"
-
-//            val propertyVersionName = versionProps.getProperty("snuttVersionName")
-//            versionCode = SemVer.sementicVersionToSerializedCode(propertyVersionName).toInt()
-//            versionName = propertyVersionName
 //            configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
 //                artifactType = "APK"
 //                testers = "urban"
@@ -73,10 +74,6 @@ android {
 
         create("live") {
             applicationIdSuffix = ".live"
-
-//            val propertyVersionName = versionProps.getProperty("snuttVersionName")
-//            versionCode = SemVer.sementicVersionToSerializedCode(propertyVersionName).toInt()
-//            versionName = propertyVersionName
 //            configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
 //                artifactType = "AAB"
 //                serviceCredentialsFile = "gcp-service-account-live.json"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,20 +16,12 @@ plugins {
 //    id("com.google.firebase.crashlytics")
 }
 
-val versionProps = Properties().apply {
-    load(Files.newBufferedReader(Paths.get(rootProject.rootDir.toString(), "version.properties")))
-}
 
 android {
     namespace = "com.wafflestudio.snutt2"
 
     defaultConfig {
         applicationId = "com.wafflestudio.snutt2"
-
-        val propertyVersionName = versionProps.getProperty("snuttVersionName")
-        versionName = propertyVersionName
-        versionCode = extensions.getByType<SemanticVersioningUtils>()
-            .semanticVersionToSerializedCode(propertyVersionName).toInt()
     }
 
     signingConfigs {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,16 +37,16 @@ android {
     }
 
     buildTypes {
-        getByName("debug") {
+        debug {
             isDefault = true
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android.txt"))
         }
 
-        getByName("release") {
+        release {
             isMinifyEnabled = true
             isShrinkResources = true
-            signingConfig = signingConfigs.getByName("release")
+            signingConfig = signingConfigs.named("release").get()
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -57,5 +57,9 @@ gradlePlugin {
             id = "snutt.android.application.firebase"
             implementationClass = "AndroidApplicationFirebaseConventionPlugin"
         }
+        register("semanticVersioning") {
+            id = "snutt.semantic.versioning"
+            implementationClass = "SemanticVersioningConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/SemanticVersioningConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/SemanticVersioningConventionPlugin.kt
@@ -1,10 +1,28 @@
+import com.android.build.gradle.AppExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.Properties
 
 class SemanticVersioningConventionPlugin: Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             extensions.create("versioning", SemanticVersioningUtils::class.java)
+            extensions.configure<AppExtension> {
+                val versionProps = Properties().apply {
+                    load(Files.newBufferedReader(Paths.get(rootProject.rootDir.toString(), "version.properties")))
+                }
+
+                defaultConfig {
+                    val propertyVersionName = versionProps.getProperty("snuttVersionName")
+                    versionName = propertyVersionName
+                    versionCode = extensions.getByType<SemanticVersioningUtils>()
+                        .semanticVersionToSerializedCode(propertyVersionName)
+                }
+            }
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/SemanticVersioningConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/SemanticVersioningConventionPlugin.kt
@@ -1,0 +1,26 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class SemanticVersioningConventionPlugin: Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            extensions.create("versioning", SemanticVersioningUtils::class.java)
+        }
+    }
+}
+
+open class SemanticVersioningUtils {
+    fun semanticVersionToSerializedCode(semanticVersion: String): Int {
+
+        val semVerRegex = Regex("(\\d+).(\\d+).(\\d+)(-rc.(\\d+))?")
+
+        val major = semVerRegex.find(semanticVersion)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+        val minor = semVerRegex.find(semanticVersion)?.groupValues?.get(2)?.toIntOrNull() ?: 0
+        val patch = semVerRegex.find(semanticVersion)?.groupValues?.get(3)?.toIntOrNull() ?: 0
+
+        return listOf(major, minor, patch)
+            .fold(0) { acc, next ->
+                acc * 100 + next
+            } + 2010000000
+    }
+}

--- a/build-logic/convention/src/main/kotlin/SemanticVersioningConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/SemanticVersioningConventionPlugin.kt
@@ -10,7 +10,6 @@ import java.util.Properties
 class SemanticVersioningConventionPlugin: Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            extensions.create("versioning", SemanticVersioningUtils::class.java)
             extensions.configure<AppExtension> {
                 val versionProps = Properties().apply {
                     load(Files.newBufferedReader(Paths.get(rootProject.rootDir.toString(), "version.properties")))
@@ -19,16 +18,13 @@ class SemanticVersioningConventionPlugin: Plugin<Project> {
                 defaultConfig {
                     val propertyVersionName = versionProps.getProperty("snuttVersionName")
                     versionName = propertyVersionName
-                    versionCode = extensions.getByType<SemanticVersioningUtils>()
-                        .semanticVersionToSerializedCode(propertyVersionName)
+                    versionCode = semanticVersionToSerializedCode(propertyVersionName)
                 }
             }
         }
     }
-}
 
-open class SemanticVersioningUtils {
-    fun semanticVersionToSerializedCode(semanticVersion: String): Int {
+    private fun semanticVersionToSerializedCode(semanticVersion: String): Int {
 
         val semVerRegex = Regex("(\\d+).(\\d+).(\\d+)(-rc.(\\d+))?")
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,3 +123,5 @@ snutt-android-feature = { id = "snutt.android.feature", version = "unspecified" 
 snutt-android-hilt = { id = "snutt.android.hilt", version = "unspecified" }
 snutt-android-library = { id = "snutt.android.library", version = "unspecified" }
 snutt-android-library-compose = { id = "snutt.android.library.compose", version = "unspecified" }
+snutt-semantic-versioning = { id = "snutt.semantic.versioning", version = "unspecified" }
+


### PR DESCRIPTION
## 변경사항
build.gradle.kts (:app)과 기존 BuildSrc에서 하던 일을 build-logic의 ConventionPlugin으로 분리&통합 

- version.properties 에 버전을 명시하는 건 유지 (딱히 더 나은 방법을 못 찾았음)
- SemanticVersioningConventionPlugin 커스텀 플러그인을 만들고, 여기에서
    - version.properties을 읽어오고,
    - versionName 설정하고,
    - 플레이스토어에서 사용되는 SerializedCode를 계산하고,
    - 계산한 code를 versionCode로 설정한다.

build.gradle.kts(:app)에서는 alias(libs.plugins.snutt.semantic.versioning)로 플러그인을 적용만 해주면 끝
