### PR TITLE
리팩토링 브랜치에서 targetSdk 34일때 RN 런타임 크래시 발생하는 것 임시 해결

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -14,7 +14,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
-                defaultConfig.targetSdk = 34
+                defaultConfig.targetSdk = 33
             }
         }
     }


### PR DESCRIPTION
일단 33으로 내려버려!
RN에서는 고쳐졌다는데, 일부 라이브러리에서 아직 해결되지 않은 것으로 보인다 (검색하면 깃헙 이슈 바로 나옴)
RN 버전 몇에서 고쳐졌는지도 확인해야됨 나중에 RN 손볼차례에 다시 리비짓하기