### PR TITLE
Preview에서 SNUTTTheme 사용 시 렌더링 실패 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.ui
 
-import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -10,10 +9,6 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
-import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.views.LocalThemeState
 
 private val LightThemeColors @Composable get() = lightColors(
@@ -88,22 +83,6 @@ fun isSystemDarkMode(context: Context): Boolean {
 fun SNUTTTheme(
     content: @Composable () -> Unit,
 ) {
-    /* <다크모드에서 내비게이션 시 흰색 깜빡이는 이슈 해결>
-     * 내비게이션 시 액티비티 배경색인 흰색(styles.xml에서 android:windowBackground 로 지정된 색)이 잠깐 노출된다.
-     * 원래는 values-night/styles.xml를 통해 다크모드의 색을 지정하지만, 우리는 시스템의 테마와 앱의 테마를
-     * 다르게 설정할 수 있기 때문에 여기서 직접 설정해 준다.
-     */
-    val window = (LocalContext.current as Activity).window
-    val primaryColor = LocalContext.current.getColor(if (isDarkMode()) R.color.black_dark else R.color.white)
-    window.apply {
-        setBackgroundDrawableResource(if (isDarkMode()) R.color.black_dark else R.color.white)
-        statusBarColor = primaryColor
-        navigationBarColor = primaryColor
-    }
-    WindowCompat.getInsetsController(window, LocalView.current).apply {
-        isAppearanceLightStatusBars = isDarkMode().not()
-        isAppearanceLightNavigationBars = isDarkMode().not()
-    }
     MaterialTheme(
         colors = if (isDarkMode()) DarkThemeColors else LightThemeColors,
         typography = SNUTTTypography,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -50,8 +50,8 @@ val LocalPopupState = compositionLocalOf<PopupState> {
     throw RuntimeException("")
 }
 
-val LocalThemeState = compositionLocalOf<ThemeMode> {
-    throw RuntimeException("")
+val LocalThemeState = compositionLocalOf {
+    ThemeMode.AUTO
 }
 
 val LocalModalState = compositionLocalOf<ModalState> {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.core.animation.doOnEnd
+import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NamedNavArgument
@@ -53,6 +55,7 @@ import com.wafflestudio.snutt2.lib.network.ApiOnProgress
 import com.wafflestudio.snutt2.react_native.ReactNativeBundleManager
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTheme
+import com.wafflestudio.snutt2.ui.isDarkMode
 import com.wafflestudio.snutt2.views.logged_in.home.HomeItem
 import com.wafflestudio.snutt2.views.logged_in.home.HomePage
 import com.wafflestudio.snutt2.views.logged_in.home.HomePageController
@@ -124,6 +127,7 @@ class RootActivity : AppCompatActivity() {
             },
         )
         setUpSplashScreen(composeRoot)
+        setWindowAppearance()
         checkNotificationPermission()
         startUpdatingPushToken()
     }
@@ -447,6 +451,29 @@ class RootActivity : AppCompatActivity() {
         return when (regex.find(intent.data.toString())?.groupValues?.get(1)) {
             NavigationDestination.Friends -> HomeItem.Friends
             else -> null
+        }
+    }
+
+    private fun setWindowAppearance() {
+        lifecycleScope.launch {
+            userViewModel.themeMode.collect { themeMode ->
+                /* <다크모드에서 내비게이션 시 흰색 깜빡이는 이슈 해결>
+                 * 내비게이션 시 액티비티 배경색인 흰색(styles.xml에서 android:windowBackground 로 지정된 색)이 잠깐 노출된다.
+                 * 원래는 values-night/styles.xml를 통해 다크모드의 색을 지정하지만, 우리는 시스템의 테마와 앱의 테마를
+                 * 다르게 설정할 수 있기 때문에 여기서 직접 설정해 준다.
+                 */
+                val isDarkMode = isDarkMode(this@RootActivity, themeMode)
+                val primaryColor = ContextCompat.getColor(this@RootActivity, if (isDarkMode) R.color.black_dark else R.color.white)
+                window.apply {
+                    setBackgroundDrawableResource(if (isDarkMode) R.color.black_dark else R.color.white)
+                    statusBarColor = primaryColor
+                    navigationBarColor = primaryColor
+                }
+                WindowInsetsControllerCompat(window, window.decorView).apply {
+                    isAppearanceLightStatusBars = isDarkMode.not()
+                    isAppearanceLightNavigationBars = isDarkMode.not()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# 문제 상황
Preview함수에 SNUTTTheme {} 이 있으면 프리뷰 렌더링이 실패하고 있었다.

# 원인
SNUTTTheme()에서 사용하는 다음 두 가지 CompositionLocal 때문이었다.
- LocalThemeState
  - 다크테마 색상을 적용하기 위해 isDarkMode() 함수를 만들어 사용하고, 그 isDarkMode()는 LocalTableTheme.current를 이용한다.
  - GlobalContext.kt에 보면 LocalThemeState가 provide되지 않은 경우 기본값을 따로 지정하지 않고 런타임 에러를 발생시키게 되어있다.
- LocalContext
  - window의 배경, 상태바, 내비바 색 설정을 위해 LocalContext.current를 Activity로 형변환하고 window를 가져온다.
  - LocalContext.current까진 문제가 없는데, 형변환에서 ClassCastException이 발생한다. 프리뷰에서 사용하는 Context는 BridgeContext란 친구로, Activity가 아니기 때문!

이렇게 프리뷰 렌더링 과정에서 런타임에러가 났기 때문에 프리뷰가 보이지 않았다.

# 해결
- LocalThemeState의 기본값을 ThemeMode.AUTO로 지정
- window 관련 로직을 RootActivity로 옮김