### PR TITLE
Firebase app distribution gradle 설정을 별도 플러그인으로 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.snutt.android.application.flavors)
     alias(libs.plugins.snutt.android.hilt)
     alias(libs.plugins.snutt.android.application.firebase)
+    alias(libs.plugins.snutt.android.application.firebase.app.distribution)
     alias(libs.plugins.snutt.semantic.versioning)
 
 //    id("dagger.hilt.android.plugin")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,8 +8,6 @@ plugins {
 
 //    id("dagger.hilt.android.plugin")
 //    id("kotlin-kapt")
-//    id("com.google.firebase.appdistribution")
-//    id("com.google.firebase.crashlytics")
 }
 
 
@@ -53,19 +51,9 @@ android {
         create("staging") {
             isDefault = true
             applicationIdSuffix = ".staging"
-//            configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
-//                artifactType = "APK"
-//                testers = "urban"
-//                serviceCredentialsFile = "gcp-service-account-staging.json"
-//            }
         }
-
         create("live") {
             applicationIdSuffix = ".live"
-//            configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
-//                artifactType = "AAB"
-//                serviceCredentialsFile = "gcp-service-account-live.json"
-//            }
         }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     compileOnly(libs.android.tools.common)
     compileOnly(libs.compose.gradlePlugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
+    compileOnly(libs.firebase.app.distribution.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -57,6 +57,10 @@ gradlePlugin {
             id = "snutt.android.application.firebase"
             implementationClass = "AndroidApplicationFirebaseConventionPlugin"
         }
+        register("androidFirebaseAppDistibution") {
+            id = "snutt.android.application.firebase.app.distribution"
+            implementationClass = "AndroidApplicationFirebaseAppDistributionConventionPlugin"
+        }
         register("semanticVersioning") {
             id = "snutt.semantic.versioning"
             implementationClass = "SemanticVersioningConventionPlugin"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     `kotlin-dsl`
 }
 
-group = "com.wafflestidio.snutt2.buildlogic"
+group = "com.wafflestudio.snutt2.build-logic"
 
 // Configure the build-logic plugins to target JDK 17
 // This matches the JDK used to build the project, and is not related to what is running on device.

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseAppDistributionConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseAppDistributionConventionPlugin.kt
@@ -1,0 +1,7 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class AndroidApplicationFirebaseAppDistributionConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseAppDistributionConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseAppDistributionConventionPlugin.kt
@@ -1,7 +1,31 @@
+import com.android.build.gradle.AppExtension
+import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
 
 class AndroidApplicationFirebaseAppDistributionConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.google.firebase.appdistribution")
+            extensions.configure<AppExtension> {
+                productFlavors.all {
+                    if (name == "staging") {
+                        firebaseAppDistribution {
+                            artifactType = "APK"
+                            testers = "android-user"
+                            serviceCredentialsFile = "gcp-service-account-staging.json"
+                        }
+                    }
+                    if (name == "live") {
+                        firebaseAppDistribution {
+                            artifactType = "AAB"
+                            testers = "android-user"
+                            serviceCredentialsFile = "gcp-service-account-live.json"
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     alias(libs.plugins.compose) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.firebase.app.distribution) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.firebase.perf) apply false
     alias(libs.plugins.gms) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidxNavigation = "2.8.0-alpha06"
 coil = "2.6.0"
 facebook = "15.0.1"
 firebaseBom = "32.4.0"
+firebaseAppdistributionPlugin = "5.0.0"
 firebaseCrashlyticsPlugin = "2.9.9"
 firebasePerfPlugin = "1.4.2"
 gmsPlugin = "4.4.1"
@@ -106,6 +107,7 @@ android-application = { id = "com.android.application", version.ref = "androidGr
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
 compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+firebase-app-distribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppdistributionPlugin" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
 gms = { id = "com.google.gms.google-services", version.ref = "gmsPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 snutt-android-application = { id = "snutt.android.application", version = "unspecified" }
 snutt-android-application-compose = { id = "snutt.android.application.compose", version = "unspecified" }
 snutt-android-application-firebase = { id = "snutt.android.application.firebase", version = "unspecified" }
+snutt-android-application-firebase-app-distribution = { id = "snutt.android.application.firebase.app.distribution", version = "unspecified" }
 snutt-android-application-flavors = { id = "snutt.android.application.flavors", version = "unspecified" }
 snutt-android-feature = { id = "snutt.android.feature", version = "unspecified" }
 snutt-android-hilt = { id = "snutt.android.hilt", version = "unspecified" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,6 +98,7 @@ moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.re
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 android-tools-common = { group = "com.android.tools", name = "common", version.ref = "androidTools" }
 compose-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+firebase-app-distribution-gradlePlugin = { group = "com.google.firebase", name = "firebase-appdistribution-gradle", version.ref = "firebaseAppdistributionPlugin" }
 firebase-crashlytics-gradlePlugin = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsPlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }


### PR DESCRIPTION
사실 그냥 build.gradle.kts(:app)에 계속 있어도 아무 상관 없는데 그냥 ConventionPlugin에 옮겨보고 싶었다.
근데 옮기니까 안되네? -> 각종 삽질 후, google-services:4.4.0 이랑 appdistribution:4.0.0이랑 뭔가 안 맞아서 깨지는 [이슈가](https://wafflestudio.slack.com/archives/C0454H4PDS8/p1718988284892949?thread_ts=1718983960.209499&cid=C0454H4PDS8) 있었다. 버전 올려서 해결


## 변경사항
firebase.app.distribution 관련해서 여러 종류를 곳곳에 선언해야 돼서 매우 헷갈린다.

1. com.google.firebase.appdistribution 5.0.0 (classpath)
toml에서는 `#Dependencies of the included build-logic` 섹션에 `firebase-app-distribution`라는 이름으로 선언해 놓았고, 프로젝트 수준의 gradle 파일에 종속 항목으로 추가한다.

2. com.google.firebase.appdistribution (apply)
실제 플러그인을 사용하는 모듈에서 적용해 주어야 한다.
기존의 build.gradle.kts(:app)에서는 plugins { id("com.google.firebase.appdistribution") } 로 적용했었고, 커스텀 플러그인으로 이사 오면서 target.pluginManager.apply("com.google.firebase.appdistribution") 으로 적용한다.

1번과 2번에 대해서는 이 [공식 문서](https://firebase.google.com/docs/app-distribution/android/distribute-gradle?hl=ko&apptype=aab#kotlin)에 가이드가 나와 있다.

3. com.google.firebase.firebase-appdistribution-gradle
toml에서는 `# Plugins defined by this project` 섹션에 `firebase-app-distribution-gradlePlugin`라는 이름으로 선언해 놓았다.
이 의존성은 dsl 문법을 쓰기 위한 것이다. 따라서 해당 스크립트를 작성하는 build-logic 모듈에 의존성을 넣어 줘야 하고, 런타임에 쓰는 게 아니기 때문에 compileOnly로 넣어 준다.