### PR TITLE
auto-assign을 위한 CI 변경 Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
       - 'develop'
 
 jobs:
-  add-reviews:
+  add-assignees-and-reviewers:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Automatically Assign Reviewers and Assignees


### PR DESCRIPTION
새로 추가한 add-assignees-and-reviewers 부분은
push 때는 돌면 안되고 pull request 때만 돌아야 한다.