### PR TITLE
[멀티 모듈 리팩토링] product flavor 설정 커스텀 플러그인으로 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,18 +45,6 @@ android {
             )
         }
     }
-
-    flavorDimensions.add("mode")
-
-    productFlavors {
-        create("staging") {
-            isDefault = true
-            applicationIdSuffix = ".staging"
-        }
-        create("live") {
-            applicationIdSuffix = ".live"
-        }
-    }
 }
 
 dependencies {

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFlavorsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFlavorsConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.ApplicationExtension
+import com.wafflestudio.snutt2.configureFlavors
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -7,7 +8,7 @@ class AndroidApplicationFlavorsConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             extensions.configure<ApplicationExtension> {
-//                configureFlavors(this)
+                configureFlavors(this)
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/com/wafflestudio/snutt2/SNUTTFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/com/wafflestudio/snutt2/SNUTTFlavor.kt
@@ -1,0 +1,37 @@
+package com.wafflestudio.snutt2
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.ApplicationProductFlavor
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.ProductFlavor
+
+@Suppress("EnumEntryName")
+enum class FlavorDimension {
+    mode
+}
+
+@Suppress("EnumEntryName")
+enum class SNUTTFlavor(val dimension: FlavorDimension, val applicationIdSuffix: String) {
+    // TODO: dev, prod 로 변경
+    staging(FlavorDimension.mode, applicationIdSuffix = ".demo"),
+    live(FlavorDimension.mode, applicationIdSuffix = ".live")
+}
+
+fun configureFlavors(
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
+    flavorConfigurationBlock: ProductFlavor.(flavor: SNUTTFlavor) -> Unit = {}
+) {
+    commonExtension.apply {
+        flavorDimensions += FlavorDimension.mode.name
+        productFlavors {
+            SNUTTFlavor.values().forEach {
+                create(it.name) {
+                    dimension = it.dimension.name
+                    flavorConfigurationBlock(this, it)
+                    if (this@apply is ApplicationExtension && this is ApplicationProductFlavor) {
+                        applicationIdSuffix = it.applicationIdSuffix
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
정확한 이유는 모르겠지만, build.gradle.kts(:app) 에서 
```
    productFlavors {
        create("staging") {
            isDefault = true
            applicationIdSuffix = ".staging"
        }
        create("live") {
            applicationIdSuffix = ".live"
        }
    }
```
이걸 적용하면 뭔가 product flavor가 적용이 안 돼서, `stagingImplementation` 같은 걸 사용할 수 없다.
지피티 피셜로는 커스텀 플러그인으로 하면 순서가 반드시 지켜져서 스크립트가 적용이 되고, app의 build.gradle.kts 에 선언하는 건 순서가 지켜지는 걸 보장할 수 없어서라는데 더 찾아보진 않았다

나중에 prod, dev 바꿀 때 여기 바꾸기