### PR TITLE
웹뷰 페이지 영역 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
@@ -5,9 +5,14 @@ import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.LinearProgressIndicator
@@ -17,14 +22,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.widget.NestedScrollView
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.TimetableIcon
 import com.wafflestudio.snutt2.components.compose.TopBar
@@ -53,11 +56,11 @@ fun ReviewPage() {
         onBackPressed()
     }
 
-    ReviewWebView(page = true)
+    ReviewWebView()
 }
 
 @Composable
-fun ReviewWebView(height: Float = 1.0f, page: Boolean = false) {
+fun ReviewWebView(height: Float = 1.0f) {
     val webViewContainer = LocalReviewWebView.current
     val scope = rememberCoroutineScope()
 
@@ -72,18 +75,20 @@ fun ReviewWebView(height: Float = 1.0f, page: Boolean = false) {
                 modifier = Modifier.fillMaxSize(),
                 onRetry = { scope.launch { webViewContainer.reload() } },
             )
+
             is LoadState.InitialLoading -> WebViewLoading(
                 modifier = Modifier.fillMaxSize(),
                 progress = loadState.progress / 100.0f,
             )
+
             is LoadState.Loading -> WebViewLoading(
                 modifier = Modifier.fillMaxSize(),
                 progress = loadState.progress / 100.0f,
             )
+
             LoadState.Success -> WebViewSuccess(
                 modifier = Modifier.fillMaxSize(),
                 webView = webViewContainer.webView,
-                page = page,
             )
         }
     }
@@ -148,10 +153,7 @@ private fun WebViewErrorPage(modifier: Modifier, onRetry: () -> Unit) {
 }
 
 @Composable
-private fun WebViewSuccess(modifier: Modifier, webView: WebView, page: Boolean) {
-    val context = LocalContext.current
-    val scrollState = rememberScrollState()
-
+private fun WebViewSuccess(modifier: Modifier, webView: WebView) {
     Column(modifier = modifier.fillMaxSize()) {
         AndroidView(
             factory = {
@@ -161,26 +163,7 @@ private fun WebViewSuccess(modifier: Modifier, webView: WebView, page: Boolean) 
                         ViewGroup.LayoutParams.MATCH_PARENT,
                     )
                 }
-                if (!page) {
-                    NestedScrollView(context).apply {
-                        if (webView.parent != null) {
-                            (webView.parent as ViewGroup).removeView(
-                                webView,
-                            )
-                        }
-                        addView(webView)
-                    }
-                } else {
-                    webView
-                }
             },
-            modifier =
-            if (page) {
-                Modifier
-            } else {
-                Modifier.verticalScroll(scrollState)
-            },
-
         )
     }
 }


### PR DESCRIPTION
강의평 웹뷰 버그 수정 
https://wafflestudio.slack.com/archives/C8M9NUBBR/p1721387434489299?thread_ts=1721384575.692069&cid=C8M9NUBBR

옛날에 모달 바텀시트 드래그해서 닫을 수 있을 시절에 nested scroll 돼야 돼서 복잡하게 꼬아놓다가 생겼고 심각하지 않다 생각해서 방치했던 버그였는데 이젠 드래그해서 닫는 거 없앴으니까 원상복구함