### PR TITLE
로컬 아이디 생성 후 유저 정보를 업데이트 하지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
@@ -46,11 +46,6 @@ fun UserConfigPage() {
 
     val viewModel = hiltViewModel<UserViewModel>()
     val user: UserDto? by viewModel.userInfo.collectAsState()
-    val userId by remember(user?.localId) {
-        mutableStateOf(
-            user?.localId ?: "",
-        )
-    }
 
     var addIdPasswordDialogState by remember { mutableStateOf(false) }
     var passwordChangeDialogState by remember { mutableStateOf(false) }
@@ -108,13 +103,13 @@ fun UserConfigPage() {
             }
             Margin(height = 10.dp)
             SettingColumn {
-                if (userId.isNotEmpty()) {
+                if (user?.localId.isNullOrEmpty().not()) {
                     SettingItem(
                         title = stringResource(R.string.settings_user_config_id),
                         hasNextPage = false,
                     ) {
                         Text(
-                            text = userId,
+                            text = user?.localId.toString(),
                             style = SNUTTTypography.body1.copy(
                                 color = SNUTTColors.Black500,
                             ),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
@@ -51,12 +51,6 @@ fun UserConfigPage() {
     var passwordChangeDialogState by remember { mutableStateOf(false) }
     var leaveDialogState by remember { mutableStateOf(false) }
 
-    val facebookConnected by remember(user?.fbName) { // TODO: 페이스북 연동만 가능하기 때문에 임시로 필요, 나중에 삭제
-        mutableStateOf(
-            user?.fbName.isNullOrEmpty().not(),
-        )
-    }
-
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -119,7 +113,7 @@ fun UserConfigPage() {
                         title = stringResource(R.string.settings_user_config_change_password),
                         onClick = { passwordChangeDialogState = true },
                     )
-                } else if (facebookConnected) {
+                } else {
                     SettingItem(
                         title = stringResource(R.string.settings_user_config_add_local_id),
                         onClick = { addIdPasswordDialogState = true },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
@@ -46,6 +46,11 @@ fun UserConfigPage() {
 
     val viewModel = hiltViewModel<UserViewModel>()
     val user: UserDto? by viewModel.userInfo.collectAsState()
+    val userId by remember(user?.localId) {
+        mutableStateOf(
+            user?.localId?:"",
+        )
+    }
 
     var addIdPasswordDialogState by remember { mutableStateOf(false) }
     var passwordChangeDialogState by remember { mutableStateOf(false) }
@@ -97,13 +102,13 @@ fun UserConfigPage() {
             }
             Margin(height = 10.dp)
             SettingColumn {
-                if (user?.localId.isNullOrEmpty().not()) {
+                if (userId.isNotEmpty()) {
                     SettingItem(
                         title = stringResource(R.string.settings_user_config_id),
                         hasNextPage = false,
                     ) {
                         Text(
-                            text = user?.localId.toString(),
+                            text = userId,
                             style = SNUTTTypography.body1.copy(
                                 color = SNUTTColors.Black500,
                             ),
@@ -162,6 +167,8 @@ fun UserConfigPage() {
                         launchSuspendApi(apiOnProgress, apiOnError) {
                             viewModel.addNewLocalId(id, password)
                             context.toast(context.getString(R.string.settings_user_config_add_local_id_success))
+                            viewModel.fetchUserInfo()
+                            addIdPasswordDialogState = false
                         }
                     }
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
@@ -48,13 +48,19 @@ fun UserConfigPage() {
     val user: UserDto? by viewModel.userInfo.collectAsState()
     val userId by remember(user?.localId) {
         mutableStateOf(
-            user?.localId?:"",
+            user?.localId ?: "",
         )
     }
 
     var addIdPasswordDialogState by remember { mutableStateOf(false) }
     var passwordChangeDialogState by remember { mutableStateOf(false) }
     var leaveDialogState by remember { mutableStateOf(false) }
+
+    val facebookConnected by remember(user?.fbName) { // TODO: 페이스북 연동만 가능하기 때문에 임시로 필요, 나중에 삭제
+        mutableStateOf(
+            user?.fbName.isNullOrEmpty().not(),
+        )
+    }
 
     Column(
         modifier = Modifier
@@ -118,7 +124,7 @@ fun UserConfigPage() {
                         title = stringResource(R.string.settings_user_config_change_password),
                         onClick = { passwordChangeDialogState = true },
                     )
-                } else {
+                } else if (facebookConnected) {
                     SettingItem(
                         title = stringResource(R.string.settings_user_config_add_local_id),
                         onClick = { addIdPasswordDialogState = true },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserViewModel.kt
@@ -40,6 +40,10 @@ class UserViewModel @Inject constructor(
         userRepository.setTableTrim(isAuto = enable)
     }
 
+    suspend fun fetchUserInfo() {
+        userRepository.fetchUserInfo()
+    }
+
     suspend fun loginLocal(id: String, password: String) {
         userRepository.postSignIn(id, password)
     }


### PR DESCRIPTION
페이스북 로그인 이후 로컬 아이디를 생성하면, 다이얼로그가 닫히고 설정 화면의 UI도 이를 반영하도록 변경