### PR TITLE
targetSDK 34 대응

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId = "com.wafflestudio.snutt2"
         minSdk = 24
-        targetSdk = 33
+        targetSdk = 34
     }
 
     compileOptions {

--- a/app/src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt
@@ -1,7 +1,12 @@
 package com.wafflestudio.snutt2
 
 import android.app.Application
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.res.Configuration
+import android.os.Build
 import androidx.compose.animation.ExperimentalAnimationApi
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactApplication
@@ -64,6 +69,15 @@ class SNUTTApplication : Application(), ReactApplication {
             override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory {
                 return HermesExecutorFactory()
             }
+        }
+    }
+
+    // targerSDK 34 대응 (https://github.com/joltup/rn-fetch-blob/issues/866#issuecomment-2227436658)
+    override fun registerReceiver(receiver: BroadcastReceiver?, filter: IntentFilter?): Intent? {
+        return if (Build.VERSION.SDK_INT >= 34 && applicationInfo.targetSdkVersion >= 34) {
+            super.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+        } else {
+            super.registerReceiver(receiver, filter)
         }
     }
 


### PR DESCRIPTION
## 올리는 이유
플레이스토어가 34 하라고 협박한다.
<img width="973" alt="image" src="https://github.com/user-attachments/assets/c12c61cf-5ddf-4924-8b79-838921ade6c2">

## 문제 발생
targetSDK를 34로 올리면 RN에서 크래시가 발생하는 이슈가 있다.
```
FATAL EXCEPTION: main
	Process: com.wafflestudio.snutt2.staging, PID: 6337
	java.lang.SecurityException: com.wafflestudio.snutt2.staging: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
		at android.os.Parcel.createExceptionOrNull(Parcel.java:3057)
		at android.os.Parcel.createException(Parcel.java:3041)
		at android.os.Parcel.readException(Parcel.java:3024)
		at android.os.Parcel.readException(Parcel.java:2966)
		at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:5684)
		at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1852)
		at android.app.ContextImpl.registerReceiver(ContextImpl.java:1792)
		at android.app.ContextImpl.registerReceiver(ContextImpl.java:1780)
		at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
		at com.wafflestudio.snutt2.SNUTTApplication.registerReceiver(SNUTTApplication.kt:79)
		at com.facebook.react.devsupport.DevSupportManagerBase.reload(DevSupportManagerBase.java:1145)
		at com.facebook.react.devsupport.DevSupportManagerBase.-$$Nest$mreload(Unknown Source:0)
		at com.facebook.react.devsupport.DevSupportManagerBase$17.run(DevSupportManagerBase.java:750)
		at android.os.Handler.handleCallback(Handler.java:958)
		at android.os.Handler.dispatchMessage(Handler.java:99)
		at android.os.Looper.loopOnce(Looper.java:205)
		at android.os.Looper.loop(Looper.java:294)
		at android.app.ActivityThread.main(ActivityThread.java:8177)
		at java.lang.reflect.Method.invoke(Native Method)
		at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
		at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
	Caused by: android.os.RemoteException: Remote stack trace:
		at com.android.server.am.ActivityManagerService.registerReceiverWithFeature(ActivityManagerService.java:13908)
		at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2570)
		at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2720)
		at android.os.Binder.execTransactInternal(Binder.java:1339)
		at android.os.Binder.execTransact(Binder.java:1275)
```

## 원인과 해결
한 RN 라이브러리에 이슈가 올라와 있다. (코드에 링크)
원인을 요약하면, 안드로이드 33부터는 registerReceiver에 플래그를 명시적으로 지정하도록 되었다. 하지만 RN 소스코드 내에서 이 부분이 갱신되지 않았고, 내부적으로 registerReceiver 를 사용하는데 플래그가 없어서 크래시가 난다.
따라서 플래그를 달아주도록 SNUTTApplication을 override해 준다. 이때 RECEIVER_EXPORTED 로 해야 할지 RECEIVER_NOT_EXPORTED로 해야 할지 잘 모르겠지만 우리의 activity는 exported=true 로 되어있긴 하니 그냥 이슈 말대로 RECEIVER_EXPORTED로 넣어 준다.