### PR TITLE
빈자리알림 FAB이 리스트 마지막 아이템의 글자를 가리지 않도록 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -458,7 +457,7 @@ private fun SugangSnuFloatingActionButton(
         elevation = FloatingActionButtonDefaults.elevation(3.dp, 3.dp).elevation(interactionSource).value,
     ) {
         Box(
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = stringResource(R.string.vacancy_floating_button),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
@@ -8,11 +8,13 @@ import androidx.compose.animation.core.animateDp
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -20,6 +22,7 @@ import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -28,6 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -38,6 +42,7 @@ import com.google.accompanist.pager.rememberPagerState
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.*
 import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.ui.SNUTTTheme
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.isDarkMode
 import com.wafflestudio.snutt2.views.*
@@ -259,24 +264,15 @@ fun VacancyPage(
                 with(density) { 10.dp.roundToPx() }
             } + fadeOut(),
         ) {
-            ExtendedFloatingActionButton(
-                modifier = Modifier
-                    .padding(end = 20.dp, bottom = 30.dp)
-                    .height(45.dp),
-                text = {
-                    Text(
-                        text = stringResource(R.string.vacancy_floating_button),
-                        style = SNUTTTypography.h4.copy(color = SNUTTColors.AllWhite),
-                        maxLines = 1,
-                    )
-                },
-                contentColor = SNUTTColors.SNUTTVacancy,
+            SugangSnuFloatingActionButton(
                 onClick = {
                     sugangSNUUrl.takeIf { it.isNotEmpty() }?.let {
                         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(it)))
                     }
                 },
-                elevation = FloatingActionButtonDefaults.elevation(3.dp, 3.dp),
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .offset((-27).dp, (-22).dp)
             )
         }
         if (introDialogState) {
@@ -446,5 +442,39 @@ fun VacancyIntroDialog(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun SugangSnuFloatingActionButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Surface(
+        modifier = modifier
+            .size(110.dp, 32.dp)
+            .clicks { onClick() },
+        shape = RoundedCornerShape(50),
+        color = SNUTTColors.SNUTTVacancy,
+        elevation = FloatingActionButtonDefaults.elevation(3.dp, 3.dp).elevation(interactionSource).value,
+    ) {
+        Box(
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.vacancy_floating_button),
+                style = SNUTTTypography.h5.copy(color = SNUTTColors.AllWhite),
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SugangSnuFloatingActionButtonPreview() {
+    SNUTTTheme {
+        SugangSnuFloatingActionButton({})
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyPage.kt
@@ -256,7 +256,8 @@ fun VacancyPage(
         AnimatedVisibility(
             visible = !vacancyViewModel.isEditMode,
             modifier = Modifier
-                .align(Alignment.BottomEnd),
+                .align(Alignment.BottomEnd)
+                .offset((-27).dp, (-22).dp),
             enter = slideInVertically {
                 with(density) { 10.dp.roundToPx() }
             } + fadeIn(),
@@ -270,9 +271,6 @@ fun VacancyPage(
                         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(it)))
                     }
                 },
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .offset((-27).dp, (-22).dp)
             )
         }
         if (introDialogState) {


### PR DESCRIPTION
## 변경사항
- SugangSnuFloatingActionButton으로 분리 & 미리보기 추가
- 머터리얼 ExtendedFloatingActionButton은 글자가 다 안들어가서 Surface로 바꿈
- 피그마를 제대로 따름

디자이너 말을 잘 듣자!
| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/a15ebbe9-c3d7-4ba3-a588-c8c572eefb53" width=300 /> | <img src="https://github.com/user-attachments/assets/b4e67fc9-1b32-4011-9dde-4487db0b9b51" width=300 /> |