### PR TITLE
강의 검색 정렬기준 추가

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
@@ -24,11 +24,11 @@ class LectureSearchPagingSource(
         year = year,
         semester = semester,
         title = title,
-        classification = tags.extractTagString(TagType.Classification),
-        credit = tags.extractTagString(TagType.Credit).map { it.toCreditNumber() },
-        academic_year = tags.extractTagString(TagType.AcademicYear),
-        department = tags.extractTagString(TagType.Department),
-        category = tags.extractTagString(TagType.Category),
+        classification = tags.extractTagString(TagType.CLASSIFICATION),
+        credit = tags.extractTagString(TagType.CREDIT).map { it.toCreditNumber() },
+        academic_year = tags.extractTagString(TagType.ACADEMIC_YEAR),
+        department = tags.extractTagString(TagType.DEPARTMENT),
+        category = tags.extractTagString(TagType.CATEGORY),
         times = times,
         timesToExclude = timesToExclude,
         etc = tags.mapNotNull {
@@ -40,7 +40,7 @@ class LectureSearchPagingSource(
         }.ifEmpty { null },
         offset = null,
         limit = null,
-        sortCriteria = tags.extractTagString(TagType.SortCriteria).lastOrNull(), // 중복 선택 불가능
+        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).lastOrNull(), // 중복 선택 불가능
     )
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, LectureDto> {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
@@ -24,11 +24,11 @@ class LectureSearchPagingSource(
         year = year,
         semester = semester,
         title = title,
-        classification = tags.extractTagString(TagType.CLASSIFICATION),
-        credit = tags.extractTagString(TagType.CREDIT).map { it.toCreditNumber() },
-        academic_year = tags.extractTagString(TagType.ACADEMIC_YEAR),
-        department = tags.extractTagString(TagType.DEPARTMENT),
-        category = tags.extractTagString(TagType.CATEGORY),
+        classification = tags.extractTagString(TagType.Classification),
+        credit = tags.extractTagString(TagType.Credit).map { it.toCreditNumber() },
+        academic_year = tags.extractTagString(TagType.AcademicYear),
+        department = tags.extractTagString(TagType.Department),
+        category = tags.extractTagString(TagType.Category),
         times = times,
         timesToExclude = timesToExclude,
         etc = tags.mapNotNull {
@@ -40,7 +40,7 @@ class LectureSearchPagingSource(
         }.ifEmpty { null },
         offset = null,
         limit = null,
-        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).lastOrNull(), // 중복 선택 불가능
+        sortCriteria = tags.extractTagString(TagType.SortCriteria).lastOrNull(), // 중복 선택 불가능
     )
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, LectureDto> {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
@@ -40,7 +40,7 @@ class LectureSearchPagingSource(
         }.ifEmpty { null },
         offset = null,
         limit = null,
-        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).lastOrNull()    // 중복 선택 불가능
+        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).lastOrNull(), // 중복 선택 불가능
     )
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, LectureDto> {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
@@ -40,6 +40,7 @@ class LectureSearchPagingSource(
         }.ifEmpty { null },
         offset = null,
         limit = null,
+        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).last()  // 중복 선택 불가능
     )
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, LectureDto> {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchPagingSource.kt
@@ -40,7 +40,7 @@ class LectureSearchPagingSource(
         }.ifEmpty { null },
         offset = null,
         limit = null,
-        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).last()  // 중복 선택 불가능
+        sortCriteria = tags.extractTagString(TagType.SORT_CRITERIA).lastOrNull()    // 중복 선택 불가능
     )
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, LectureDto> {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
@@ -51,12 +51,12 @@ class LectureSearchRepositoryImpl @Inject constructor(
         val response = api._getTagList(year.toInt(), semester.toInt())
         val list = mutableListOf<TagDto>()
         list.apply {
-            addAll(response.department.map { TagDto(TagType.Department, it) })
-            addAll(response.classification.map { TagDto(TagType.Classification, it) })
-            addAll(response.academicYear.map { TagDto(TagType.AcademicYear, it) })
-            addAll(response.credit.map { TagDto(TagType.Credit, it) })
-            addAll(response.category.map { TagDto(TagType.Category, it) })
-            addAll(response.sortCriteria.map { TagDto(TagType.SortCriteria, it) })
+            addAll(response.department.map { TagDto(TagType.DEPARTMENT, it) })
+            addAll(response.classification.map { TagDto(TagType.CLASSIFICATION, it) })
+            addAll(response.academicYear.map { TagDto(TagType.ACADEMIC_YEAR, it) })
+            addAll(response.credit.map { TagDto(TagType.CREDIT, it) })
+            addAll(response.category.map { TagDto(TagType.CATEGORY, it) })
+            addAll(response.sortCriteria.map { TagDto(TagType.SORT_CRITERIA, it) })
         }
         return list
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
@@ -51,12 +51,12 @@ class LectureSearchRepositoryImpl @Inject constructor(
         val response = api._getTagList(year.toInt(), semester.toInt())
         val list = mutableListOf<TagDto>()
         list.apply {
-            addAll(response.department.map { TagDto(TagType.DEPARTMENT, it) })
-            addAll(response.classification.map { TagDto(TagType.CLASSIFICATION, it) })
-            addAll(response.academicYear.map { TagDto(TagType.ACADEMIC_YEAR, it) })
-            addAll(response.credit.map { TagDto(TagType.CREDIT, it) })
-            addAll(response.category.map { TagDto(TagType.CATEGORY, it) })
-            addAll(response.sortCriteria.map { TagDto(TagType.SORT_CRITERIA, it) })
+            addAll(response.department.map { TagDto(TagType.Department, it) })
+            addAll(response.classification.map { TagDto(TagType.Classification, it) })
+            addAll(response.academicYear.map { TagDto(TagType.AcademicYear, it) })
+            addAll(response.credit.map { TagDto(TagType.Credit, it) })
+            addAll(response.category.map { TagDto(TagType.Category, it) })
+            addAll(response.sortCriteria.map { TagDto(TagType.SortCriteria, it) })
         }
         return list
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecture_search/LectureSearchRepositoryImpl.kt
@@ -56,6 +56,7 @@ class LectureSearchRepositoryImpl @Inject constructor(
             addAll(response.academicYear.map { TagDto(TagType.ACADEMIC_YEAR, it) })
             addAll(response.credit.map { TagDto(TagType.CREDIT, it) })
             addAll(response.category.map { TagDto(TagType.CATEGORY, it) })
+            addAll(response.sortCriteria.map { TagDto(TagType.SORT_CRITERIA, it) })
         }
         return list
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
@@ -40,6 +40,7 @@ fun CourseBookDto.toFormattedString(context: Context): String {
 
 fun TagType.color(): androidx.compose.ui.graphics.Color {
     return when (this) {
+        TagType.SORT_CRITERIA -> SNUTTColors.Gray30
         TagType.CLASSIFICATION -> SNUTTColors.Red
         TagType.DEPARTMENT -> SNUTTColors.Orange
         TagType.ACADEMIC_YEAR -> SNUTTColors.Grass

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.lib
 
 import android.content.Context
-import android.graphics.Color
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.network.dto.core.ClassTimeDto
 import com.wafflestudio.snutt2.lib.network.dto.core.CourseBookDto
@@ -40,14 +39,14 @@ fun CourseBookDto.toFormattedString(context: Context): String {
 
 fun TagType.color(): androidx.compose.ui.graphics.Color {
     return when (this) {
-        TagType.SORT_CRITERIA -> SNUTTColors.Gray30
-        TagType.CLASSIFICATION -> SNUTTColors.Red
-        TagType.DEPARTMENT -> SNUTTColors.Orange
-        TagType.ACADEMIC_YEAR -> SNUTTColors.Grass
-        TagType.CREDIT -> SNUTTColors.Sky
-        TagType.TIME -> SNUTTColors.Blue
-        TagType.CATEGORY -> SNUTTColors.NavyBlue
-        TagType.ETC -> SNUTTColors.Violet
+        TagType.SortCriteria -> SNUTTColors.Gray30
+        TagType.Classification -> SNUTTColors.Red
+        TagType.Department -> SNUTTColors.Orange
+        TagType.AcademicYear -> SNUTTColors.Grass
+        TagType.Credit -> SNUTTColors.Sky
+        TagType.Time -> SNUTTColors.Blue
+        TagType.Category -> SNUTTColors.NavyBlue
+        TagType.Etc -> SNUTTColors.Violet
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/ModelExt.kt
@@ -39,14 +39,14 @@ fun CourseBookDto.toFormattedString(context: Context): String {
 
 fun TagType.color(): androidx.compose.ui.graphics.Color {
     return when (this) {
-        TagType.SortCriteria -> SNUTTColors.Gray30
-        TagType.Classification -> SNUTTColors.Red
-        TagType.Department -> SNUTTColors.Orange
-        TagType.AcademicYear -> SNUTTColors.Grass
-        TagType.Credit -> SNUTTColors.Sky
-        TagType.Time -> SNUTTColors.Blue
-        TagType.Category -> SNUTTColors.NavyBlue
-        TagType.Etc -> SNUTTColors.Violet
+        TagType.SORT_CRITERIA -> SNUTTColors.Gray30
+        TagType.CLASSIFICATION -> SNUTTColors.Red
+        TagType.DEPARTMENT -> SNUTTColors.Orange
+        TagType.ACADEMIC_YEAR -> SNUTTColors.Grass
+        TagType.CREDIT -> SNUTTColors.Sky
+        TagType.TIME -> SNUTTColors.Blue
+        TagType.CATEGORY -> SNUTTColors.NavyBlue
+        TagType.ETC -> SNUTTColors.Violet
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/GetTagListResults.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/GetTagListResults.kt
@@ -11,4 +11,5 @@ data class GetTagListResults(
     @Json(name = "credit") val credit: List<String>,
     @Json(name = "instructor") val instructor: List<String>,
     @Json(name = "category") val category: List<String>,
+    @Json(name = "sortCriteria") val sortCriteria: List<String>,
 )

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/PostSearchQueryParams.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/PostSearchQueryParams.kt
@@ -20,4 +20,5 @@ data class PostSearchQueryParams(
     @Json(name = "timesToExclude") val timesToExclude: List<SearchTimeDto>?,
     @Json(name = "offset") val offset: Long? = null,
     @Json(name = "limit") val limit: Long? = null,
+    @Json(name = "sortCriteria") val sortCriteria: String? = null,
 )

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
@@ -9,9 +9,9 @@ data class TagDto(
 ) {
 
     companion object {
-        val TIME_EMPTY: TagDto = TagDto(TagType.TIME, "빈 시간대로 검색")
-        val TIME_SELECT: TagDto = TagDto(TagType.TIME, "시간대 직접 선택")
-        val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
-        val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
+        val TIME_EMPTY: TagDto = TagDto(TagType.Time, "빈 시간대로 검색")
+        val TIME_SELECT: TagDto = TagDto(TagType.Time, "시간대 직접 선택")
+        val ETC_ENG: TagDto = TagDto(TagType.Etc, "영어진행 강의")
+        val ETC_MILITARY: TagDto = TagDto(TagType.Etc, "군휴학 원격수업")
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
@@ -11,8 +11,6 @@ data class TagDto(
     companion object {
         val TIME_EMPTY: TagDto = TagDto(TagType.TIME, "빈 시간대로 검색")
         val TIME_SELECT: TagDto = TagDto(TagType.TIME, "시간대 직접 선택")
-        val REVIEW_COUNT_DESC: TagDto = TagDto(TagType.SORT_CRITERIA, "강의평 많은 순")
-        val REVIEW_RATING_DESC: TagDto = TagDto(TagType.SORT_CRITERIA, "평점 높은 순")
         val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
         val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
@@ -9,9 +9,9 @@ data class TagDto(
 ) {
 
     companion object {
-        val TIME_EMPTY: TagDto = TagDto(TagType.Time, "빈 시간대로 검색")
-        val TIME_SELECT: TagDto = TagDto(TagType.Time, "시간대 직접 선택")
-        val ETC_ENG: TagDto = TagDto(TagType.Etc, "영어진행 강의")
-        val ETC_MILITARY: TagDto = TagDto(TagType.Etc, "군휴학 원격수업")
+        val TIME_EMPTY: TagDto = TagDto(TagType.TIME, "빈 시간대로 검색")
+        val TIME_SELECT: TagDto = TagDto(TagType.TIME, "시간대 직접 선택")
+        val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
+        val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
@@ -11,6 +11,8 @@ data class TagDto(
     companion object {
         val TIME_EMPTY: TagDto = TagDto(TagType.TIME, "빈 시간대로 검색")
         val TIME_SELECT: TagDto = TagDto(TagType.TIME, "시간대 직접 선택")
+        val REVIEW_COUNT_DESC: TagDto = TagDto(TagType.SORT_CRITERIA, "강의평 많은 순")
+        val REVIEW_RATING_DESC: TagDto = TagDto(TagType.SORT_CRITERIA, "평점 높은 순")
         val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
         val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
@@ -4,12 +4,12 @@ package com.wafflestudio.snutt2.model
  * Created by makesource on 2017. 8. 26..
  */
 sealed class TagType(val isExclusive: Boolean) {
-    data object CLASSIFICATION : TagType(false)
-    data object DEPARTMENT : TagType(false)
-    data object ACADEMIC_YEAR : TagType(false)
-    data object CREDIT : TagType(false)
-    data object TIME : TagType(false)
-    data object CATEGORY : TagType(false)
-    data object SORT_CRITERIA : TagType(true)
-    data object ETC : TagType(false)
+    data object Classification : TagType(false)
+    data object Department : TagType(false)
+    data object AcademicYear : TagType(false)
+    data object Credit : TagType(false)
+    data object Time : TagType(false)
+    data object Category : TagType(false)
+    data object SortCriteria : TagType(true)
+    data object Etc : TagType(false)
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
@@ -4,5 +4,5 @@ package com.wafflestudio.snutt2.model
  * Created by makesource on 2017. 8. 26..
  */
 enum class TagType {
-    CLASSIFICATION, DEPARTMENT, ACADEMIC_YEAR, CREDIT, TIME, CATEGORY, ETC
+    CLASSIFICATION, DEPARTMENT, ACADEMIC_YEAR, CREDIT, TIME, CATEGORY, SORT_CRITERIA, ETC
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
@@ -4,12 +4,12 @@ package com.wafflestudio.snutt2.model
  * Created by makesource on 2017. 8. 26..
  */
 sealed class TagType(val isExclusive: Boolean) {
+    data object SortCriteria : TagType(true)
     data object Classification : TagType(false)
     data object Department : TagType(false)
     data object AcademicYear : TagType(false)
     data object Credit : TagType(false)
     data object Time : TagType(false)
     data object Category : TagType(false)
-    data object SortCriteria : TagType(true)
     data object Etc : TagType(false)
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
@@ -3,13 +3,13 @@ package com.wafflestudio.snutt2.model
 /**
  * Created by makesource on 2017. 8. 26..
  */
-sealed class TagType(val isExclusive: Boolean) {
-    data object SortCriteria : TagType(true)
-    data object Classification : TagType(false)
-    data object Department : TagType(false)
-    data object AcademicYear : TagType(false)
-    data object Credit : TagType(false)
-    data object Time : TagType(false)
-    data object Category : TagType(false)
-    data object Etc : TagType(false)
+enum class TagType(val isExclusive: Boolean) {
+    SORT_CRITERIA(true),
+    CLASSIFICATION(false),
+    DEPARTMENT(false),
+    ACADEMIC_YEAR(false),
+    CREDIT(false),
+    TIME(false),
+    CATEGORY(false),
+    ETC(false),
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagType.kt
@@ -3,6 +3,13 @@ package com.wafflestudio.snutt2.model
 /**
  * Created by makesource on 2017. 8. 26..
  */
-enum class TagType {
-    CLASSIFICATION, DEPARTMENT, ACADEMIC_YEAR, CREDIT, TIME, CATEGORY, SORT_CRITERIA, ETC
+sealed class TagType(val isExclusive: Boolean) {
+    data object CLASSIFICATION : TagType(false)
+    data object DEPARTMENT : TagType(false)
+    data object ACADEMIC_YEAR : TagType(false)
+    data object CREDIT : TagType(false)
+    data object TIME : TagType(false)
+    data object CATEGORY : TagType(false)
+    data object SORT_CRITERIA : TagType(true)
+    data object ETC : TagType(false)
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -104,12 +104,13 @@ class SearchViewModel @Inject constructor(
     }
 
     private val timeTags = listOf(TagDto.TIME_EMPTY, TagDto.TIME_SELECT)
+    private val sortCriteriaTags = listOf(TagDto.REVIEW_COUNT_DESC, TagDto.REVIEW_RATING_DESC)
     private val etcTags = listOf(TagDto.ETC_ENG, TagDto.ETC_MILITARY)
 
     val tagsByTagType: StateFlow<List<Selectable<TagDto>>> = combine(
         _searchTagList, _selectedTagType, _selectedTags,
     ) { tags, selectedTagType, selectedTags ->
-        (tags + etcTags + timeTags).filter { it.type == selectedTagType }
+        (tags + etcTags + sortCriteriaTags + timeTags).filter { it.type == selectedTagType }
             .map { it.toDataWithState(selectedTags.contains(it)) }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -56,7 +56,7 @@ class SearchViewModel @Inject constructor(
     private val _selectedLecture = MutableStateFlow<LectureDto?>(null)
     val selectedLecture = _selectedLecture.asStateFlow()
 
-    private val _selectedTagType = MutableStateFlow<TagType>(TagType.SortCriteria)
+    private val _selectedTagType = MutableStateFlow<TagType>(TagType.SORT_CRITERIA)
     val selectedTagType = _selectedTagType.asStateFlow()
 
     private val _selectedTags = MutableStateFlow(listOf<TagDto>())

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -56,7 +56,7 @@ class SearchViewModel @Inject constructor(
     private val _selectedLecture = MutableStateFlow<LectureDto?>(null)
     val selectedLecture = _selectedLecture.asStateFlow()
 
-    private val _selectedTagType = MutableStateFlow<TagType>(TagType.AcademicYear)
+    private val _selectedTagType = MutableStateFlow<TagType>(TagType.SortCriteria)
     val selectedTagType = _selectedTagType.asStateFlow()
 
     private val _selectedTags = MutableStateFlow(listOf<TagDto>())

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -104,13 +104,12 @@ class SearchViewModel @Inject constructor(
     }
 
     private val timeTags = listOf(TagDto.TIME_EMPTY, TagDto.TIME_SELECT)
-    private val sortCriteriaTags = listOf(TagDto.REVIEW_COUNT_DESC, TagDto.REVIEW_RATING_DESC)
     private val etcTags = listOf(TagDto.ETC_ENG, TagDto.ETC_MILITARY)
 
     val tagsByTagType: StateFlow<List<Selectable<TagDto>>> = combine(
         _searchTagList, _selectedTagType, _selectedTags,
     ) { tags, selectedTagType, selectedTags ->
-        (tags + etcTags + sortCriteriaTags + timeTags).filter { it.type == selectedTagType }
+        (tags + etcTags + timeTags).filter { it.type == selectedTagType }
             .map { it.toDataWithState(selectedTags.contains(it)) }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -56,7 +56,7 @@ class SearchViewModel @Inject constructor(
     private val _selectedLecture = MutableStateFlow<LectureDto?>(null)
     val selectedLecture = _selectedLecture.asStateFlow()
 
-    private val _selectedTagType = MutableStateFlow(TagType.ACADEMIC_YEAR)
+    private val _selectedTagType = MutableStateFlow<TagType>(TagType.ACADEMIC_YEAR)
     val selectedTagType = _selectedTagType.asStateFlow()
 
     private val _selectedTags = MutableStateFlow(listOf<TagDto>())
@@ -194,7 +194,12 @@ class SearchViewModel @Inject constructor(
                 _searchTimeList.emit(null)
             }
         } else {
-            _selectedTags.emit(concatenate(_selectedTags.value, listOf(tag)))
+            val selectedTags = if (tag.type.isExclusive) {
+                concatenate(_selectedTags.value.filter { it.type != tag.type }, listOf(tag))
+            } else {
+                concatenate(_selectedTags.value, listOf(tag))
+            }
+            _selectedTags.emit(selectedTags)
 
             if (tag == TagDto.TIME_SELECT) {
                 _draggedTimeBlock.value.clusterToTimeBlocks().let {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -56,7 +56,7 @@ class SearchViewModel @Inject constructor(
     private val _selectedLecture = MutableStateFlow<LectureDto?>(null)
     val selectedLecture = _selectedLecture.asStateFlow()
 
-    private val _selectedTagType = MutableStateFlow<TagType>(TagType.ACADEMIC_YEAR)
+    private val _selectedTagType = MutableStateFlow<TagType>(TagType.AcademicYear)
     val selectedTagType = _selectedTagType.asStateFlow()
 
     private val _selectedTags = MutableStateFlow(listOf<TagDto>())

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
@@ -31,14 +31,14 @@ fun TagTypeColumn(
     val context = LocalContext.current
     val tagTypeList = remember {
         listOf(
-            context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SortCriteria,
-            context.getString(R.string.search_option_tag_type_classification) to TagType.Classification,
-            context.getString(R.string.search_option_tag_type_department) to TagType.Department,
-            context.getString(R.string.search_option_tag_type_academic_year) to TagType.AcademicYear,
-            context.getString(R.string.search_option_tag_type_credit) to TagType.Credit,
-            context.getString(R.string.search_option_tag_type_time) to TagType.Time,
-            context.getString(R.string.search_option_tag_type_general_category) to TagType.Category,
-            context.getString(R.string.search_option_tag_type_etc) to TagType.Etc,
+            context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SORT_CRITERIA,
+            context.getString(R.string.search_option_tag_type_classification) to TagType.CLASSIFICATION,
+            context.getString(R.string.search_option_tag_type_department) to TagType.DEPARTMENT,
+            context.getString(R.string.search_option_tag_type_academic_year) to TagType.ACADEMIC_YEAR,
+            context.getString(R.string.search_option_tag_type_credit) to TagType.CREDIT,
+            context.getString(R.string.search_option_tag_type_time) to TagType.TIME,
+            context.getString(R.string.search_option_tag_type_general_category) to TagType.CATEGORY,
+            context.getString(R.string.search_option_tag_type_etc) to TagType.ETC,
         )
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
@@ -31,14 +31,14 @@ fun TagTypeColumn(
     val context = LocalContext.current
     val tagTypeList = remember {
         listOf(
-            context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SORT_CRITERIA,
-            context.getString(R.string.search_option_tag_type_academic_year) to TagType.ACADEMIC_YEAR,
-            context.getString(R.string.search_option_tag_type_classification) to TagType.CLASSIFICATION,
-            context.getString(R.string.search_option_tag_type_credit) to TagType.CREDIT,
-            context.getString(R.string.search_option_tag_type_time) to TagType.TIME,
-            context.getString(R.string.search_option_tag_type_department) to TagType.DEPARTMENT,
-            context.getString(R.string.search_option_tag_type_general_category) to TagType.CATEGORY,
-            context.getString(R.string.search_option_tag_type_etc) to TagType.ETC,
+            context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SortCriteria,
+            context.getString(R.string.search_option_tag_type_academic_year) to TagType.AcademicYear,
+            context.getString(R.string.search_option_tag_type_classification) to TagType.Classification,
+            context.getString(R.string.search_option_tag_type_credit) to TagType.Credit,
+            context.getString(R.string.search_option_tag_type_time) to TagType.Time,
+            context.getString(R.string.search_option_tag_type_department) to TagType.Department,
+            context.getString(R.string.search_option_tag_type_general_category) to TagType.Category,
+            context.getString(R.string.search_option_tag_type_etc) to TagType.Etc,
         )
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
@@ -31,6 +31,7 @@ fun TagTypeColumn(
     val context = LocalContext.current
     val tagTypeList = remember {
         listOf(
+            context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SORT_CRITERIA,
             context.getString(R.string.search_option_tag_type_academic_year) to TagType.ACADEMIC_YEAR,
             context.getString(R.string.search_option_tag_type_classification) to TagType.CLASSIFICATION,
             context.getString(R.string.search_option_tag_type_credit) to TagType.CREDIT,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TagTypeColumn.kt
@@ -32,11 +32,11 @@ fun TagTypeColumn(
     val tagTypeList = remember {
         listOf(
             context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SortCriteria,
-            context.getString(R.string.search_option_tag_type_academic_year) to TagType.AcademicYear,
             context.getString(R.string.search_option_tag_type_classification) to TagType.Classification,
+            context.getString(R.string.search_option_tag_type_department) to TagType.Department,
+            context.getString(R.string.search_option_tag_type_academic_year) to TagType.AcademicYear,
             context.getString(R.string.search_option_tag_type_credit) to TagType.Credit,
             context.getString(R.string.search_option_tag_type_time) to TagType.Time,
-            context.getString(R.string.search_option_tag_type_department) to TagType.Department,
             context.getString(R.string.search_option_tag_type_general_category) to TagType.Category,
             context.getString(R.string.search_option_tag_type_etc) to TagType.Etc,
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,6 +368,7 @@
     <string name="search_option_tag_type_time">시간</string>
     <string name="search_option_tag_type_department">학과</string>
     <string name="search_option_tag_type_general_category">교양분류</string>
+    <string name="search_option_tag_type_sort_criteria">정렬 기준</string>
     <string name="search_option_tag_type_etc">기타</string>
     <string name="search_option_apply_button">필터 적용</string>
     <string name="search_option_select_empty_time_slots">빈시간대 선택하기</string>


### PR DESCRIPTION
## 변경사항
- POST /search_query의 request body에 sortCriteria 추가
- TagType.SortCriteria 추가
- TagType.SortCriteria는 다중선택이 불가능하므로, TagType을 enum에서 sealed class로 바꾸고 isExclusive 프로퍼티 추가
  - TagType을 camelcase로 수정