### PR TITLE
Github Actions 버전 업그레이드 (v2 to v3)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'
@@ -60,7 +60,7 @@ jobs:
           echo "TITLE=$TITLE" >> $GITHUB_ENV
           echo "MESSAGE=$MESSAGE" >> $GITHUB_ENV
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@v3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: ${{ env.TITLE }}
@@ -71,9 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Upload artifact to Firebase App Distribution
         run: ./gradlew appDistributionUploadStagingRelease
       - name: Slack Upload APK
-        uses: MeilCli/slack-upload-file@v3
+        uses: MeilCli/slack-upload-file@v2
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}
           channel_id: ${{ secrets.SLACK_DEPLOY_CHANNEL_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,7 +60,7 @@ jobs:
           echo "TITLE=$TITLE" >> $GITHUB_ENV
           echo "MESSAGE=$MESSAGE" >> $GITHUB_ENV
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: ${{ env.TITLE }}
@@ -111,7 +111,7 @@ jobs:
       - name: Upload artifact to Firebase App Distribution
         run: ./gradlew appDistributionUploadStagingRelease
       - name: Slack Upload APK
-        uses: MeilCli/slack-upload-file@v2
+        uses: MeilCli/slack-upload-file@v3
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}
           channel_id: ${{ secrets.SLACK_DEPLOY_CHANNEL_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     needs: cancel-workflow
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'
@@ -33,7 +33,7 @@ jobs:
       - name: Run ktlintDebug
         run: ./gradlew ktlintMainSourceSetCheck
       - name: Upload ktlint report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ktlint-result
@@ -44,9 +44,9 @@ jobs:
     needs: static-check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -26,9 +26,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyListItem.kt
@@ -152,7 +152,7 @@ fun LazyItemScope.VacancyListItem(
                         text = classTimeText,
                         style = SNUTTTypography.body2.copy(fontSize = 13.sp, fontWeight = FontWeight.Normal),
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/vacancy_noti/VacancyListItem.kt
@@ -152,7 +152,7 @@ fun LazyItemScope.VacancyListItem(
                         text = classTimeText,
                         style = SNUTTTypography.body2.copy(fontSize = 13.sp, fontWeight = FontWeight.Normal),
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
기존에 .yml 파일들에서 github actions 버전으로 v2를 쓰고 있었는데,
이게 deprecated 되면서 CI가 무조건 터지는 상황이 발생해서
v2 -> v3로 업그레이드