### PR TITLE
WebViewContainer 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/SnuttWebView.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/SnuttWebView.kt
@@ -135,18 +135,17 @@ private fun WebViewSuccess(
     webView: WebView,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxSize()) {
-        AndroidView(
-            factory = {
-                webView.apply {
-                    layoutParams = ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                }
-            },
-        )
-    }
+    AndroidView(
+        modifier = modifier.fillMaxSize(),
+        factory = {
+            webView.apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/SnuttWebView.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/SnuttWebView.kt
@@ -1,0 +1,169 @@
+package com.wafflestudio.snutt2.components.compose
+
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
+import com.wafflestudio.snutt2.lib.android.webview.WebViewLoadState
+import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.ui.SNUTTTypography
+import kotlinx.coroutines.launch
+
+@Composable
+fun SnuttWebView(
+    webViewContainer: WebViewContainer,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = modifier
+            .background(SNUTTColors.White900),
+    ) {
+        when (val loadState = webViewContainer.loadState.value) {
+            WebViewLoadState.Error -> WebViewError(
+                modifier = Modifier.fillMaxSize(),
+                onRetry = { scope.launch { webViewContainer.reload() } },
+            )
+
+            is WebViewLoadState.InitialLoading -> WebViewLoading(
+                modifier = Modifier.fillMaxSize(),
+                progress = loadState.progress / 100.0f,
+            )
+
+            is WebViewLoadState.Loading -> WebViewLoading(
+                modifier = Modifier.fillMaxSize(),
+                progress = loadState.progress / 100.0f,
+            )
+
+            WebViewLoadState.Success -> WebViewSuccess(
+                modifier = Modifier.fillMaxSize(),
+                webView = webViewContainer.webView,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WebViewError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        TopBar(
+            title = {
+                Text(
+                    text = stringResource(id = R.string.reviews_app_bar_title),
+                    style = SNUTTTypography.h2,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            navigationIcon = {
+                TimetableIcon(
+                    modifier = Modifier.size(30.dp),
+                    isSelected = true,
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                )
+            },
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                modifier = Modifier.size(width = 50.dp, height = 58.dp),
+                painter = painterResource(id = R.drawable.ic_cat_retry),
+                contentDescription = "네트워크 연결을 확인해주세요.",
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(id = R.string.reviews_error_message),
+                style = SNUTTTypography.subtitle1,
+                color = SNUTTColors.Black900,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Button(
+                onClick = onRetry,
+                colors = ButtonDefaults.buttonColors(backgroundColor = SNUTTColors.Sky),
+            ) {
+                Text(
+                    text = stringResource(id = R.string.reviews_error_retry),
+                    style = SNUTTTypography.h3,
+                    color = SNUTTColors.White900,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WebViewSuccess(
+    webView: WebView,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        AndroidView(
+            factory = {
+                webView.apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun WebViewLoading(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        LinearProgressIndicator(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp),
+            progress = progress,
+            color = SNUTTColors.Gray200,
+        )
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/LoadState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/LoadState.kt
@@ -1,8 +1,0 @@
-package com.wafflestudio.snutt2.lib.android.webview
-
-sealed class LoadState {
-    object Success : LoadState()
-    object Error : LoadState()
-    data class Loading(val progress: Int) : LoadState()
-    data class InitialLoading(val progress: Int) : LoadState()
-}

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewContainer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewContainer.kt
@@ -60,67 +60,48 @@ class WebViewContainer(
         this.settings.javaScriptEnabled = true
     }
 
-    suspend fun openPage(url: String?) {
+    suspend fun openPage(url: String) {
+        val host = URL(url).host
         val accessToken = accessToken.filterNotNull().first()
-        val reviewUrlHost = URL(context.getString(R.string.review_base_url)).host
-
-        CookieManager.getInstance().apply {
-            setCookie(
-                reviewUrlHost,
-                "x-access-apikey=${context.getString(R.string.api_key)}",
-            )
-            setCookie(
-                reviewUrlHost,
-                "x-access-token=$accessToken",
-            )
-            setCookie(
-                reviewUrlHost,
-                "x-os-type=android",
-            )
-            setCookie(
-                reviewUrlHost,
-                "x-os-version=${Build.VERSION.SDK_INT}",
-            )
-            setCookie(
-                reviewUrlHost,
-                "x-app-version=${BuildConfig.VERSION_NAME}",
-            )
-            setCookie(
-                reviewUrlHost,
-                "x-app-type=${if (BuildConfig.DEBUG) "debug" else "release"}",
-            )
-            setCookie(
-                reviewUrlHost,
-                "theme=${
-                    if (isDarkMode) {
-                        "dark"
-                    } else {
-                        "light"
-                    }
-                }",
-            )
-        }.flush()
-        webView.loadUrl(url ?: context.getString(R.string.review_base_url))
+        setCookies(host, accessToken)
+        webView.loadUrl(url)
     }
 
     suspend fun reload() {
         val accessToken = accessToken.filterNotNull().first()
-        val reviewUrlHost = URL(context.getString(R.string.review_base_url)).host
+        val host = URL(webView.url).host
+        setCookies(host, accessToken)
+        webView.reload()
+    }
+
+    private fun setCookies(host: String, accessToken: String) {
         CookieManager.getInstance().apply {
             setCookie(
-                reviewUrlHost,
+                host,
                 "x-access-apikey=${context.getString(R.string.api_key)}",
             )
             setCookie(
-                reviewUrlHost,
+                host,
                 "x-access-token=$accessToken",
             )
             setCookie(
-                reviewUrlHost,
+                host,
                 "x-os-type=android",
             )
             setCookie(
-                reviewUrlHost,
+                host,
+                "x-os-version=${Build.VERSION.SDK_INT}",
+            )
+            setCookie(
+                host,
+                "x-app-version=${BuildConfig.VERSION_NAME}",
+            )
+            setCookie(
+                host,
+                "x-app-type=${if (BuildConfig.DEBUG) "debug" else "release"}",
+            )
+            setCookie(
+                host,
                 "theme=${
                     if (isDarkMode) {
                         "dark"
@@ -130,7 +111,6 @@ class WebViewContainer(
                 }",
             )
         }.flush()
-        webView.reload()
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewContainer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewContainer.kt
@@ -18,7 +18,7 @@ class WebViewContainer(
     private val accessToken: StateFlow<String?>,
     private val isDarkMode: Boolean,
 ) {
-    val loadState: MutableState<LoadState> = mutableStateOf(LoadState.InitialLoading(0))
+    val loadState: MutableState<WebViewLoadState> = mutableStateOf(WebViewLoadState.InitialLoading(0))
 
     val webView: WebView = WebView(context).apply {
         if (BuildConfig.DEBUG) {
@@ -26,15 +26,15 @@ class WebViewContainer(
         }
         this.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
-                if (loadState.value != LoadState.Error) {
-                    loadState.value = LoadState.Success
+                if (loadState.value != WebViewLoadState.Error) {
+                    loadState.value = WebViewLoadState.Success
                 }
             }
 
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                 loadState.value = when (loadState.value) {
-                    is LoadState.InitialLoading -> LoadState.InitialLoading(0)
-                    else -> LoadState.Loading(0)
+                    is WebViewLoadState.InitialLoading -> WebViewLoadState.InitialLoading(0)
+                    else -> WebViewLoadState.Loading(0)
                 }
             }
 
@@ -43,14 +43,14 @@ class WebViewContainer(
                 request: WebResourceRequest?,
                 error: WebResourceError?,
             ) {
-                loadState.value = LoadState.Error
+                loadState.value = WebViewLoadState.Error
             }
         }
         this.webChromeClient = object : WebChromeClient() {
             override fun onProgressChanged(view: WebView?, newProgress: Int) {
                 when (loadState.value) {
-                    is LoadState.InitialLoading -> LoadState.InitialLoading(newProgress)
-                    is LoadState.Loading -> LoadState.Loading(newProgress)
+                    is WebViewLoadState.InitialLoading -> WebViewLoadState.InitialLoading(newProgress)
+                    is WebViewLoadState.Loading -> WebViewLoadState.Loading(newProgress)
                     else -> null
                 }?.let {
                     loadState.value = it

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewLoadState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/WebViewLoadState.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.snutt2.lib.android.webview
+
+sealed class WebViewLoadState {
+    object Success : WebViewLoadState()
+    object Error : WebViewLoadState()
+    data class Loading(val progress: Int) : WebViewLoadState()
+    data class InitialLoading(val progress: Int) : WebViewLoadState()
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/LectureReviewDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/dto/core/LectureReviewDto.kt
@@ -8,7 +8,7 @@ import com.wafflestudio.snutt2.core.network.model.LectureReviewDto as LectureRev
 
 @JsonClass(generateAdapter = true)
 data class LectureReviewDto(
-    @Json(name = "evLectureId") val id: String,
+    @Json(name = "evLectureId") val id: String? = null,
     @Json(name = "avgRating") val rating: Double? = null,
     @Json(name = "evaluationCount") val reviewCount: Int? = null,
 ) {
@@ -16,7 +16,7 @@ data class LectureReviewDto(
     val displayText get() = "$ratingDisplayText (${reviewCount ?: 0})"
 
     fun getReviewUrl(context: Context): String? { // DTO와 ui model 분리 후 ui model으로 옮기기
-        return id.let {
+        return id?.let {
             context.getString(R.string.review_base_url) + "/detail?id=$it"
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/BottomNavigation.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/BottomNavigation.kt
@@ -58,7 +58,7 @@ internal fun BottomNavigation(
                 .weight(1f)
                 .fillMaxHeight(),
             onClick = {
-                onUpdatePageState(HomeItem.Review())
+                onUpdatePageState(HomeItem.Review)
             },
         ) {
             ReviewIcon(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -127,11 +127,7 @@ fun HomePage() {
                 when (pageController.homePageState.value) {
                     HomeItem.Timetable -> TimetablePage(uncheckedNotification)
                     HomeItem.Search -> SearchPage(searchResultPagingItems)
-                    is HomeItem.Review -> {
-                        CompositionLocalProvider(LocalReviewWebView provides reviewPageWebViewContainer) {
-                            ReviewPage()
-                        }
-                    }
+                    HomeItem.Review -> ReviewPage(reviewPageWebViewContainer)
                     HomeItem.Friends -> FriendsPage()
                     HomeItem.Settings -> SettingsPage()
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.layouts.ModalDrawerWithBottomSheetLayout
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
@@ -89,8 +90,8 @@ fun HomePage() {
         }
     }
 
-    LaunchedEffect((pageController.homePageState.value as? HomeItem.Review)?.landingPage) {
-        reviewPageWebViewContainer.openPage((pageController.homePageState.value as? HomeItem.Review)?.landingPage)
+    LaunchedEffect(Unit) {
+        reviewPageWebViewContainer.openPage(context.getString(R.string.review_base_url))
     }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePageController.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePageController.kt
@@ -25,7 +25,7 @@ sealed class HomeItem {
 
     object Timetable : HomeItem()
     object Search : HomeItem()
-    data class Review(val landingPage: String? = null) : HomeItem()
+    object Review : HomeItem()
     object Friends : HomeItem()
     object Settings : HomeItem()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
@@ -1,42 +1,11 @@
 package com.wafflestudio.snutt2.views.logged_in.home.reviews
 
-import android.view.ViewGroup
-import android.webkit.WebView
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
-import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.components.compose.TimetableIcon
-import com.wafflestudio.snutt2.components.compose.TopBar
-import com.wafflestudio.snutt2.lib.android.webview.LoadState
+import com.wafflestudio.snutt2.components.compose.SnuttWebView
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
-import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.views.LocalHomePageController
 import com.wafflestudio.snutt2.views.logged_in.home.HomeItem
-import kotlinx.coroutines.launch
 
 @Composable
 fun ReviewPage(
@@ -56,132 +25,5 @@ fun ReviewPage(
         onBackPressed()
     }
 
-    ReviewWebView(webViewContainer)
-}
-
-@Composable
-fun ReviewWebView(
-    webViewContainer: WebViewContainer,
-    height: Float = 1.0f,
-) {
-    val scope = rememberCoroutineScope()
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight(height)
-            .background(SNUTTColors.White900),
-    ) {
-        when (val loadState = webViewContainer.loadState.value) {
-            LoadState.Error -> WebViewErrorPage(
-                modifier = Modifier.fillMaxSize(),
-                onRetry = { scope.launch { webViewContainer.reload() } },
-            )
-
-            is LoadState.InitialLoading -> WebViewLoading(
-                modifier = Modifier.fillMaxSize(),
-                progress = loadState.progress / 100.0f,
-            )
-
-            is LoadState.Loading -> WebViewLoading(
-                modifier = Modifier.fillMaxSize(),
-                progress = loadState.progress / 100.0f,
-            )
-
-            LoadState.Success -> WebViewSuccess(
-                modifier = Modifier.fillMaxSize(),
-                webView = webViewContainer.webView,
-            )
-        }
-    }
-}
-
-@Composable
-private fun WebViewErrorPage(modifier: Modifier, onRetry: () -> Unit) {
-    Column(modifier = modifier) {
-        TopBar(
-            title = {
-                Text(
-                    text = stringResource(id = R.string.reviews_app_bar_title),
-                    style = SNUTTTypography.h2,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            },
-            navigationIcon = {
-                TimetableIcon(
-                    modifier = Modifier.size(30.dp),
-                    isSelected = true,
-                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                )
-            },
-        )
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Image(
-                modifier = Modifier.size(width = 50.dp, height = 58.dp),
-                painter = painterResource(id = R.drawable.ic_cat_retry),
-                contentDescription = "네트워크 연결을 확인해주세요.",
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Text(
-                text = stringResource(id = R.string.reviews_error_message),
-                style = SNUTTTypography.subtitle1,
-                color = SNUTTColors.Black900,
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Button(
-                onClick = onRetry,
-                colors = ButtonDefaults.buttonColors(backgroundColor = SNUTTColors.Sky),
-            ) {
-                Text(
-                    text = stringResource(id = R.string.reviews_error_retry),
-                    style = SNUTTTypography.h3,
-                    color = SNUTTColors.White900,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun WebViewSuccess(modifier: Modifier, webView: WebView) {
-    Column(modifier = modifier.fillMaxSize()) {
-        AndroidView(
-            factory = {
-                webView.apply {
-                    layoutParams = ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                }
-            },
-        )
-    }
-}
-
-@Composable
-private fun WebViewLoading(modifier: Modifier, progress: Float) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.Top,
-    ) {
-        LinearProgressIndicator(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(2.dp),
-            progress = progress,
-            color = SNUTTColors.Gray200,
-        )
-    }
+    SnuttWebView(webViewContainer)
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewPage.kt
@@ -25,23 +25,23 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.TimetableIcon
 import com.wafflestudio.snutt2.components.compose.TopBar
 import com.wafflestudio.snutt2.lib.android.webview.LoadState
+import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.views.LocalHomePageController
-import com.wafflestudio.snutt2.views.LocalReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.home.HomeItem
 import kotlinx.coroutines.launch
 
 @Composable
-fun ReviewPage() {
-    val webViewContainer = LocalReviewWebView.current
+fun ReviewPage(
+    webViewContainer: WebViewContainer,
+) {
     val homePageController = LocalHomePageController.current
 
     val onBackPressed: () -> Unit = {
@@ -56,12 +56,14 @@ fun ReviewPage() {
         onBackPressed()
     }
 
-    ReviewWebView()
+    ReviewWebView(webViewContainer)
 }
 
 @Composable
-fun ReviewWebView(height: Float = 1.0f) {
-    val webViewContainer = LocalReviewWebView.current
+fun ReviewWebView(
+    webViewContainer: WebViewContainer,
+    height: Float = 1.0f,
+) {
     val scope = rememberCoroutineScope()
 
     Column(
@@ -182,10 +184,4 @@ private fun WebViewLoading(modifier: Modifier, progress: Float) {
             color = SNUTTColors.Gray200,
         )
     }
-}
-
-@Preview
-@Composable
-fun ReviewPagePreview() {
-    ReviewPage()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/LectureListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/LectureListItem.kt
@@ -247,6 +247,7 @@ fun LazyItemScope.LectureListItem(
                     onClick = {
                         scope.launch {
                             val url = lectureDataWithState.item.review?.getReviewUrl(context)
+                                ?: return@launch
                             openReviewBottomSheet(url, reviewWebViewContainer, bottomSheet)
                         }
                     },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.home.search
 
 import androidx.compose.material.Text
-import androidx.compose.runtime.CompositionLocalProvider
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.BottomSheet
 import com.wafflestudio.snutt2.components.compose.ComposableStates
@@ -9,7 +8,6 @@ import com.wafflestudio.snutt2.core.network.util.ErrorCode
 import com.wafflestudio.snutt2.core.network.util.ErrorParsedHttpException
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.ui.SNUTTTypography
-import com.wafflestudio.snutt2.views.LocalReviewWebView
 import com.wafflestudio.snutt2.views.launchSuspendApi
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import kotlinx.coroutines.launch
@@ -21,9 +19,10 @@ suspend fun openReviewBottomSheet(
 ) {
     reviewWebViewContainer.openPage("$url&on_back=close")
     bottomSheet.setSheetContent {
-        CompositionLocalProvider(LocalReviewWebView provides reviewWebViewContainer) {
-            ReviewWebView(0.95f)
-        }
+        ReviewWebView(
+            webViewContainer = reviewWebViewContainer,
+            height = 0.95f,
+        )
     }
     bottomSheet.show()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
@@ -15,7 +15,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import kotlinx.coroutines.launch
 
 suspend fun openReviewBottomSheet(
-    url: String?,
+    url: String,
     reviewWebViewContainer: WebViewContainer,
     bottomSheet: BottomSheet,
 ) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
@@ -1,15 +1,18 @@
 package com.wafflestudio.snutt2.views.logged_in.home.search
 
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.BottomSheet
 import com.wafflestudio.snutt2.components.compose.ComposableStates
+import com.wafflestudio.snutt2.components.compose.SnuttWebView
 import com.wafflestudio.snutt2.core.network.util.ErrorCode
 import com.wafflestudio.snutt2.core.network.util.ErrorParsedHttpException
 import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.views.launchSuspendApi
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import kotlinx.coroutines.launch
 
 suspend fun openReviewBottomSheet(
@@ -19,9 +22,11 @@ suspend fun openReviewBottomSheet(
 ) {
     reviewWebViewContainer.openPage("$url&on_back=close")
     bottomSheet.setSheetContent {
-        ReviewWebView(
+        SnuttWebView(
             webViewContainer = reviewWebViewContainer,
-            height = 0.95f,
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.95f),
         )
     }
     bottomSheet.show()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -614,6 +614,7 @@ fun LectureDetailPage(
                                 LectureDetailButton(title = stringResource(R.string.lecture_detail_review_button)) {
                                     scope.launch {
                                         val url = editingLectureReview?.getReviewUrl(context)
+                                            ?: return@launch
                                         openReviewBottomSheet(
                                             url,
                                             reviewBottomSheetWebViewContainer,


### PR DESCRIPTION
## 요약
- WebViewContainer가 강의평에 사용됨이 암시되어있어서 테마마켓으로 쓰기 어려웠음
- 테마마켓 작업에 앞서 약간의 개선
  
## 변경사항
- WebViewContainer에서 강의평 관련 맥락을 제거하여, 테마마켓용으로도 쓸 수 있도록 개선
- openPage()의 url을 non-nullable으로 바꾸고, HomItem.Review.landingPage도 제거
- 깊이가 깊지 않음에도 LocalReviewWebView라는 CompositionLocal을 사용하던 곳 수정
  - SearchPage -> SearchResultList -> LectureListItem -> openReviewBottomSheet로 길게 이어질 때에는 오히려 CompositionLocal을 안쓰는데, 여기서 쓰도록 바꿀까?
  - 아니면 LocalReviewWebView 아예 없애고
- ReviewWebView -> SnuttWebView 네이밍 변경