### PR TITLE
시간표 블록 그리기 로직 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/AdjustedTextLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/AdjustedTextLayout.kt
@@ -76,9 +76,11 @@ fun calculateAdjustedTextLayout(
     if (textMeasurer.measure(allOneLineParagraph).multiParagraph.height > maxHeight) {
         return cellInfoList.fold(emptyList<LectureCellInfo>()) { acc, current ->
             val paragraph = buildAnnotatedString {
-                (acc + current).forEach {
+                (acc + current).forEachIndexed { idx, it ->
                     pushStyle(it.minifiedStyle.toSpanStyle())
-                    appendLine()
+                    if ((acc + current).lastIndex != idx) {
+                        appendLine()
+                    }
                 }
             }
             if (textMeasurer.measure(paragraph).multiParagraph.height < maxHeight) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/AdjustedTextLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/AdjustedTextLayout.kt
@@ -33,7 +33,7 @@ fun calculateAdjustedTextLayout(
             repeat(idealMaxLines) { appendLine() }
         }
     }
-    if (textMeasurer.measure(fullRenderParagraph).multiParagraph.height <= maxHeight) {
+    if (textMeasurer.measure(fullRenderParagraph).multiParagraph.height < maxHeight) {
         return cellInfoList.map {
             AdjustedTextLayout(
                 it.text,
@@ -56,7 +56,7 @@ fun calculateAdjustedTextLayout(
             repeat(idealMaxLines) { appendLine() }
         }
     }
-    if (textMeasurer.measure(minifiedRenderParagraph).multiParagraph.height <= maxHeight) {
+    if (textMeasurer.measure(minifiedRenderParagraph).multiParagraph.height < maxHeight) {
         return cellInfoList.map {
             AdjustedTextLayout(
                 it.text,
@@ -127,7 +127,7 @@ fun calculateAdjustedTextLayout(
                         appendLine()
                     }
                 },
-            ).multiParagraph.height <= maxHeight
+            ).multiParagraph.height < maxHeight
         ) {
             currentMaxLines++
             // 높이 제약이 없을 때의 라인 수에 도달하면, 더 라인 수를 늘려서 계산해 볼 필요가 없으니 break


### PR DESCRIPTION
- 크기를 측정할 paragraph를 만들 때 appendLine 을 무조건 의도보다 한 번 더 하고 있어서, 공간이 충분해도 그리지 않고 있는 문제를 수정
- 안전을 위해 <= 대신 < 사용하도록 수정