### PR TITLE
강의 겹칠 시 alert에서 displayMessage를 보여주도록 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPageDialogs.kt
@@ -59,7 +59,7 @@ fun checkLectureOverlap(
             when (e) {
                 is ErrorParsedHttpException -> {
                     if (e.errorDTO?.code == ErrorCode.LECTURE_TIME_OVERLAP) {
-                        onLectureOverlap(e.errorDTO.ext?.get("confirm_message") ?: "")
+                        onLectureOverlap(e.errorDTO.displayMessage ?: "")
                     } else {
                         apiOnError(e)
                     }


### PR DESCRIPTION
강의 겹쳤을 때 alert의 메시지로 displayMessage 쓰도록 바꿔야했는데 아직도 body.ext.confirm_message 쓰고있었다 [[Slack]](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1704570668587859)
dev에서 강의 겹쳤을 때 alert의 메시지가 비어있는 것 확인하고 수정
일단 prod에서는 문제 발생 안함

<img src="https://github.com/user-attachments/assets/6873e936-9ea4-460c-8cbb-589acdfbeaa3" width=300 />
