### PR TITLE
알림 페이지 리팩토링

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ android {
         create("staging") {
             isDefault = true
             applicationIdSuffix = ".staging"
+            dimension = "mode"
 
             val propertyVersionName = versionProps.getProperty("snuttVersionName")
             versionCode = SemVer.sementicVersionToSerializedCode(propertyVersionName).toInt()
@@ -92,6 +93,7 @@ android {
 
         create("live") {
             applicationIdSuffix = ".live"
+            dimension = "mode"
 
             val propertyVersionName = versionProps.getProperty("snuttVersionName")
             versionCode = SemVer.sementicVersionToSerializedCode(propertyVersionName).toInt()
@@ -103,6 +105,18 @@ android {
         }
     }
 
+    flavorDimensions.add("implementation")
+    productFlavors {
+        create("refactor") {
+            dimension = "implementation"
+            buildConfigField("boolean", "REFACTOR", "true")
+        }
+        create("normal") {
+            isDefault = true
+            dimension = "implementation"
+            buildConfigField("boolean", "REFACTOR", "false")
+        }
+    }
     kotlinOptions {
         jvmTarget = "17"
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"

--- a/app/src/main/java/com/wafflestudio/snutt2/data/notifications/NotificationRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/notifications/NotificationRepository.kt
@@ -1,12 +1,15 @@
 package com.wafflestudio.snutt2.data.notifications
 
 import androidx.paging.PagingData
+import com.wafflestudio.snutt2.domain_model.Notification
 import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
 import kotlinx.coroutines.flow.Flow
 
 interface NotificationRepository {
 
     suspend fun getNotificationResultStream(): Flow<PagingData<NotificationDto>>
+
+    suspend fun getNotificationListStream(): Flow<PagingData<Notification>>
 
     suspend fun getNotificationCount(): Long
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/notifications/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/notifications/NotificationRepositoryImpl.kt
@@ -3,9 +3,13 @@ package com.wafflestudio.snutt2.data.notifications
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.map
+import com.wafflestudio.snutt2.domain_model.Notification
+import com.wafflestudio.snutt2.domain_model.domainModel
 import com.wafflestudio.snutt2.lib.network.SNUTTRestApi
 import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,6 +24,20 @@ class NotificationRepositoryImpl @Inject constructor(private val api: SNUTTRestA
             ),
             pagingSourceFactory = { NotificationPagingSource(api) },
         ).flow
+    }
+
+    override suspend fun getNotificationListStream(): Flow<PagingData<Notification>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = NOTIFICATIONS_LOAD_PAGE_SIZE,
+                enablePlaceholders = false,
+            ),
+            pagingSourceFactory = { NotificationPagingSource(api) },
+        ).flow.map { pagingData ->
+            pagingData.map { notification ->
+                notification.domainModel()
+            }
+        }
     }
 
     override suspend fun getNotificationCount(): Long {

--- a/app/src/main/java/com/wafflestudio/snutt2/di/ApplicationModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/ApplicationModule.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.di
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.ui.SNUTTAppState
 import com.wafflestudio.snutt2.views.logged_in.home.popups.PopupState
 import dagger.Module
 import dagger.Provides
@@ -34,5 +35,11 @@ object ApplicationModule {
     @Singleton
     fun provideCoroutineScope(): CoroutineScope {
         return CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSNUTTAppState(): SNUTTAppState {
+        return SNUTTAppState.REFACTOR
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/domain_model/Notification.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain_model/Notification.kt
@@ -1,0 +1,37 @@
+package com.wafflestudio.snutt2.domain_model
+
+import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
+
+data class Notification(
+    val title: String,
+    val message: String,
+    val createdAt: String,
+    val type: NotificationType,
+    val deeplink: String?,
+)
+
+enum class NotificationType {
+    Warning,
+    Calendar,
+    RefreshTime,
+    Trash,
+    Vacancy,
+    Friend,
+    Megaphone,
+}
+
+fun NotificationDto.domainModel() = Notification(
+    title = title,
+    message = message,
+    createdAt = createdAt,
+    type = when(type) {
+        0 -> NotificationType.Warning
+        1 -> NotificationType.Calendar
+        2 -> NotificationType.RefreshTime
+        3 -> NotificationType.Trash
+        4 -> NotificationType.Vacancy
+        5 -> NotificationType.Friend
+        else -> NotificationType.Megaphone
+    },
+    deeplink = deeplink,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/domain_model/Notification.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain_model/Notification.kt
@@ -24,7 +24,7 @@ fun NotificationDto.domainModel() = Notification(
     title = title,
     message = message,
     createdAt = createdAt,
-    type = when(type) {
+    type = when (type) {
         0 -> NotificationType.Warning
         1 -> NotificationType.Calendar
         2 -> NotificationType.RefreshTime

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/data/SNUTTStringUtils.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/data/SNUTTStringUtils.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.lib.data
 import android.content.Context
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.SNUTTUtils
+import com.wafflestudio.snutt2.domain_model.Notification
 import com.wafflestudio.snutt2.lib.network.dto.core.ClassTimeDto
 import com.wafflestudio.snutt2.lib.network.dto.core.LectureDto
 import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
@@ -78,6 +79,37 @@ object SNUTTStringUtils {
     }
 
     fun getNotificationTime(context: Context, info: NotificationDto): String {
+        try {
+            val format: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            format.timeZone = TimeZone.getTimeZone("UTC")
+            val date1 = format.parse(info.createdAt) ?: Date()
+            val date2 = Date()
+
+            val diff = date2.time - date1.time
+            val hours = diff / (1000 * 60 * 60)
+            val minutes = diff / (1000 * 60)
+            val days = hours / 24
+            return when {
+                days > 0 -> {
+                    SimpleDateFormat("yyyy/MM/dd").format(date1)
+                }
+                hours > 0 -> {
+                    context.getString(R.string.time_hours_ago, hours)
+                }
+                minutes > 0 -> {
+                    context.getString(R.string.time_minutes_ago, minutes)
+                }
+                else -> {
+                    context.getString(R.string.time_now)
+                }
+            }
+        } catch (e: ParseException) {
+            Timber.e("notification created time parse error!")
+            return ""
+        }
+    }
+
+    fun getNotificationTime(context: Context, info: Notification): String {
         try {
             val format: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             format.timeZone = TimeZone.getTimeZone("UTC")

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/SNUTTAppState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/SNUTTAppState.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.snutt2.ui
+
+enum class SNUTTAppState {
+    NORMAL,
+    REFACTOR,
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -72,7 +72,7 @@ import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureColorSelect
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailPage
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetailViewModel
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.deeplink.TimetableLectureDetailPage
-import com.wafflestudio.snutt2.views.logged_in.notifications.NotificationPage
+import com.wafflestudio.snutt2.views.logged_in.notifications.NotificationRoute
 import com.wafflestudio.snutt2.views.logged_in.table_lectures.LecturesOfTablePage
 import com.wafflestudio.snutt2.views.logged_in.vacancy_noti.VacancyPage
 import com.wafflestudio.snutt2.views.logged_in.vacancy_noti.VacancyViewModel
@@ -258,7 +258,7 @@ class RootActivity : AppCompatActivity() {
 
                     composable2(NavigationDestination.ImportantNotice) { ImportantNoticePage() }
 
-                    composable2(NavigationDestination.Notification) { NotificationPage() }
+                    composable2(NavigationDestination.Notification) { NotificationRoute() }
 
                     composable2(NavigationDestination.LecturesOfTable) { LecturesOfTablePage() }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
@@ -56,7 +56,7 @@ import com.wafflestudio.snutt2.views.NavigationDestination
 @Composable
 fun NotificationRoute(
     modifier: Modifier = Modifier,
-    viewModel: NotificationsViewModel = hiltViewModel()
+    viewModel: NotificationsViewModel = hiltViewModel(),
 ) {
     val navController = LocalNavController.current
     val notificationList = viewModel.notificationList.collectAsLazyPagingItems()
@@ -363,9 +363,9 @@ fun NotificationIcon(type: NotificationType) {
 
 sealed interface NotificationUiState {
     data class Success(val notificationList: LazyPagingItems<Notification>) : NotificationUiState
-    data object Error: NotificationUiState
-    data object Loading: NotificationUiState
-    data object Empty: NotificationUiState
+    data object Error : NotificationUiState
+    data object Loading : NotificationUiState
+    data object Empty : NotificationUiState
 }
 
 private fun LazyPagingItems<Notification>.notificationUiState(): NotificationUiState {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
@@ -51,7 +51,27 @@ import com.wafflestudio.snutt2.views.LocalNavController
 import com.wafflestudio.snutt2.views.NavigationDestination
 
 @Composable
-fun NotificationPage() {
+fun NotificationRoute(
+    modifier: Modifier = Modifier,
+    viewModel: NotificationsViewModel = hiltViewModel()
+) {
+    val navController = LocalNavController.current
+    if (viewModel.isRefactoring()) {
+        NotificationPage(
+            onBackClick = {
+                if (navController.currentDestination?.route == NavigationDestination.Notification) {
+                    navController.popBackStack()
+                }
+            },
+            modifier = modifier,
+        )
+    } else {
+        NotificationPage()
+    }
+}
+
+@Composable
+private fun NotificationPage() {
     val navController = LocalNavController.current
     val vm = hiltViewModel<NotificationsViewModel>()
 
@@ -220,3 +240,12 @@ fun NotificationItemPreview() {
 fun NotificationPagePreview() {
     NotificationPage()
 }
+
+@Composable
+fun NotificationPage(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit,
+) {
+
+}
+

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
@@ -43,6 +43,8 @@ import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.components.compose.WarningIcon
 import com.wafflestudio.snutt2.components.compose.clicks
 import com.wafflestudio.snutt2.deeplink.DeeplinkExecutor
+import com.wafflestudio.snutt2.domain_model.Notification
+import com.wafflestudio.snutt2.domain_model.NotificationType
 import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getNotificationTime
 import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
 import com.wafflestudio.snutt2.ui.SNUTTColors
@@ -80,7 +82,7 @@ private fun NotificationPage() {
     val navController = LocalNavController.current
     val vm = hiltViewModel<NotificationsViewModel>()
 
-    val notificationList = vm.notificationList.collectAsLazyPagingItems()
+    val notificationList = vm.notificationResult.collectAsLazyPagingItems()
     val refreshState = notificationList.loadState.refresh
     val appendState = notificationList.loadState.append
 
@@ -279,14 +281,94 @@ fun NotificationPage(
     }
 }
 
+@Composable
+fun NotificationItem(notification: Notification, onClick: () -> Unit) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier
+            .clicks {
+                onClick()
+            }
+            .padding(horizontal = 16.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(top = 8.dp, bottom = 8.dp, end = 2.dp),
+        ) {
+            NotificationIcon(notification.type)
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(
+                modifier = Modifier.padding(top = 4.dp, bottom = 7.dp),
+            ) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Text(text = notification.title, style = SNUTTTypography.h4.copy(fontSize = 13.sp, fontWeight = FontWeight.SemiBold))
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = getNotificationTime(context, notification),
+                        style = SNUTTTypography.body1.copy(fontSize = 13.sp, color = SNUTTColors.Gray2),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = notification.message,
+                    style = SNUTTTypography.body1.copy(fontSize = 13.sp, lineHeight = 18.2.sp),
+                )
+            }
+        }
+        Divider(color = SNUTTColors.Black250, thickness = 0.5.dp)
+    }
+}
+
+@Composable
+fun NotificationIcon(type: NotificationType) {
+    when (type) {
+        NotificationType.Warning -> WarningIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Calendar -> CalendarIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.RefreshTime -> RefreshTimeIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Trash -> NotificationTrashIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Vacancy -> NotificationVacancyIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Friend -> NotificationFriendIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Megaphone -> MegaphoneIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+    }
+}
+
 sealed interface NotificationUiState {
-    data class Success(val notificationList: LazyPagingItems<NotificationDto>) : NotificationUiState
+    data class Success(val notificationList: LazyPagingItems<Notification>) : NotificationUiState
     data object Error: NotificationUiState
     data object Loading: NotificationUiState
     data object Empty: NotificationUiState
 }
 
-private fun LazyPagingItems<NotificationDto>.notificationUiState(): NotificationUiState {
+private fun LazyPagingItems<Notification>.notificationUiState(): NotificationUiState {
     val refreshState = loadState.refresh
     val appendState = loadState.append
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationPage.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.items
 import com.wafflestudio.snutt2.R
@@ -56,6 +57,9 @@ fun NotificationRoute(
     viewModel: NotificationsViewModel = hiltViewModel()
 ) {
     val navController = LocalNavController.current
+    val notificationList = viewModel.notificationList.collectAsLazyPagingItems()
+    val notificationUiState = notificationList.notificationUiState()
+
     if (viewModel.isRefactoring()) {
         NotificationPage(
             onBackClick = {
@@ -63,6 +67,7 @@ fun NotificationRoute(
                     navController.popBackStack()
                 }
             },
+            uiState = notificationUiState,
             modifier = modifier,
         )
     } else {
@@ -244,8 +249,51 @@ fun NotificationPagePreview() {
 @Composable
 fun NotificationPage(
     modifier: Modifier = Modifier,
+    uiState: NotificationUiState,
     onBackClick: () -> Unit,
 ) {
+    Column(
+        modifier = Modifier
+            .background(SNUTTColors.White900)
+            .fillMaxSize(),
+    ) {
+        SimpleTopBar(
+            title = stringResource(R.string.notifications_app_bar_title),
+            onClickNavigateBack = onBackClick,
+        )
 
+        when (uiState) {
+            NotificationUiState.Empty -> NotificationPlaceholder()
+            NotificationUiState.Error -> NotificationError()
+            NotificationUiState.Loading -> {}
+            is NotificationUiState.Success -> LazyColumn {
+                items(uiState.notificationList) { notification ->
+                    notification?.let {
+                        NotificationItem(notification) {
+                            DeeplinkExecutor.execute(it.deeplink)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
+sealed interface NotificationUiState {
+    data class Success(val notificationList: LazyPagingItems<NotificationDto>) : NotificationUiState
+    data object Error: NotificationUiState
+    data object Loading: NotificationUiState
+    data object Empty: NotificationUiState
+}
+
+private fun LazyPagingItems<NotificationDto>.notificationUiState(): NotificationUiState {
+    val refreshState = loadState.refresh
+    val appendState = loadState.append
+
+    return when {
+        refreshState is LoadState.Loading -> NotificationUiState.Loading
+        refreshState is LoadState.Error -> NotificationUiState.Error
+        appendState.endOfPaginationReached && itemCount < 1 -> NotificationUiState.Empty
+        else -> NotificationUiState.Success(this)
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.wafflestudio.snutt2.data.notifications.NotificationRepository
+import com.wafflestudio.snutt2.domain_model.Notification
 import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
 import com.wafflestudio.snutt2.ui.SNUTTAppState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,17 +20,32 @@ class NotificationsViewModel @Inject constructor(
     private val snuttAppState: SNUTTAppState,
 ) : ViewModel() {
 
-    private val _notificationList =
+    private val _notificationResult =
         MutableStateFlow<PagingData<NotificationDto>>(PagingData.empty())
-    val notificationList: StateFlow<PagingData<NotificationDto>> = _notificationList
+    val notificationResult: StateFlow<PagingData<NotificationDto>> = _notificationResult
+
+    private val _notificationList =
+        MutableStateFlow<PagingData<Notification>>(PagingData.empty())
+    val notificationList: StateFlow<PagingData<Notification>> = _notificationList
 
     init {
         viewModelScope.launch {
-            notificationRepository.getNotificationResultStream()
-                .cachedIn(viewModelScope)
-                .collect {
-                    _notificationList.emit(it)
+            when (snuttAppState) {
+                SNUTTAppState.NORMAL -> {
+                    notificationRepository.getNotificationResultStream()
+                        .cachedIn(viewModelScope)
+                        .collect {
+                            _notificationResult.emit(it)
+                        }
                 }
+                SNUTTAppState.REFACTOR -> {
+                    notificationRepository.getNotificationListStream()
+                        .cachedIn(viewModelScope)
+                        .collect {
+                            _notificationList.emit(it)
+                        }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.wafflestudio.snutt2.data.notifications.NotificationRepository
 import com.wafflestudio.snutt2.lib.network.dto.core.NotificationDto
+import com.wafflestudio.snutt2.ui.SNUTTAppState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +16,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationsViewModel @Inject constructor(
     private val notificationRepository: NotificationRepository,
+    private val snuttAppState: SNUTTAppState,
 ) : ViewModel() {
 
     private val _notificationList =
@@ -30,4 +32,6 @@ class NotificationsViewModel @Inject constructor(
                 }
         }
     }
+
+    fun isRefactoring() = snuttAppState == SNUTTAppState.REFACTOR
 }

--- a/app/src/refactor/java/com/wafflestudio/snutt2/notification/NotificationPage.kt
+++ b/app/src/refactor/java/com/wafflestudio/snutt2/notification/NotificationPage.kt
@@ -1,0 +1,251 @@
+package com.wafflestudio.snutt2.notification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.items
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.components.compose.AlarmOnIcon
+import com.wafflestudio.snutt2.components.compose.CalendarIcon
+import com.wafflestudio.snutt2.components.compose.MegaphoneIcon
+import com.wafflestudio.snutt2.components.compose.NotificationFriendIcon
+import com.wafflestudio.snutt2.components.compose.NotificationTrashIcon
+import com.wafflestudio.snutt2.components.compose.NotificationVacancyIcon
+import com.wafflestudio.snutt2.components.compose.RefreshTimeIcon
+import com.wafflestudio.snutt2.components.compose.SimpleTopBar
+import com.wafflestudio.snutt2.components.compose.WarningIcon
+import com.wafflestudio.snutt2.components.compose.clicks
+import com.wafflestudio.snutt2.deeplink.DeeplinkExecutor
+import com.wafflestudio.snutt2.domain_model.Notification
+import com.wafflestudio.snutt2.domain_model.NotificationType
+import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getNotificationTime
+import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.ui.SNUTTTypography
+import com.wafflestudio.snutt2.ui.isDarkMode
+import com.wafflestudio.snutt2.views.LocalNavController
+import com.wafflestudio.snutt2.views.NavigationDestination
+import com.wafflestudio.snutt2.views.logged_in.notifications.NotificationsViewModel
+import kotlinx.coroutines.flow.flowOf
+
+@Composable
+fun NotificationRoute(
+    modifier: Modifier = Modifier,
+    viewModel: NotificationsViewModel = hiltViewModel(),
+) {
+    val navController = LocalNavController.current
+    val notificationList = viewModel.notificationList.collectAsLazyPagingItems()
+    val notificationUiState = notificationList.notificationUiState()
+
+    NotificationPage(
+        onBackClick = {
+            if (navController.currentDestination?.route == NavigationDestination.Notification) {
+                navController.popBackStack()
+            }
+        },
+        uiState = notificationUiState,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun NotificationPage(
+    modifier: Modifier = Modifier,
+    uiState: NotificationUiState,
+    onBackClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .background(SNUTTColors.White900)
+            .fillMaxSize(),
+    ) {
+        SimpleTopBar(
+            title = stringResource(R.string.notifications_app_bar_title),
+            onClickNavigateBack = onBackClick,
+        )
+
+        when (uiState) {
+            NotificationUiState.Empty -> NotificationPlaceholder()
+            NotificationUiState.Error -> NotificationError()
+            NotificationUiState.Loading -> {}
+            is NotificationUiState.Success -> LazyColumn {
+                items(uiState.notificationList) { notification ->
+                    notification?.let {
+                        NotificationItem(notification) {
+                            DeeplinkExecutor.execute(it.deeplink)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NotificationItem(notification: Notification, onClick: () -> Unit) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier
+            .clicks {
+                onClick()
+            }
+            .padding(horizontal = 16.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(top = 8.dp, bottom = 8.dp, end = 2.dp),
+        ) {
+            NotificationIcon(notification.type)
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(
+                modifier = Modifier.padding(top = 4.dp, bottom = 7.dp),
+            ) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = notification.title,
+                        style = SNUTTTypography.h4.copy(
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = getNotificationTime(context, notification),
+                        style = SNUTTTypography.body1.copy(
+                            fontSize = 13.sp,
+                            color = SNUTTColors.Gray2,
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = notification.message,
+                    style = SNUTTTypography.body1.copy(fontSize = 13.sp, lineHeight = 18.2.sp),
+                )
+            }
+        }
+        Divider(color = SNUTTColors.Black250, thickness = 0.5.dp)
+    }
+}
+
+@Composable
+fun NotificationIcon(type: NotificationType) {
+    when (type) {
+        NotificationType.Warning -> WarningIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Calendar -> CalendarIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.RefreshTime -> RefreshTimeIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Trash -> NotificationTrashIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Vacancy -> NotificationVacancyIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Friend -> NotificationFriendIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+
+        NotificationType.Megaphone -> MegaphoneIcon(
+            modifier = Modifier.size(30.dp),
+            colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
+        )
+    }
+}
+
+@Composable
+fun NotificationError() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        WarningIcon(
+            modifier = Modifier.size(40.dp), colorFilter = ColorFilter.tint(SNUTTColors.Gray200),
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = stringResource(R.string.common_network_failure),
+            style = SNUTTTypography.body1.copy(color = SNUTTColors.Gray200),
+        )
+    }
+}
+
+@Composable
+fun NotificationPlaceholder() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 30.dp, end = 30.dp, bottom = 40.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AlarmOnIcon(
+            modifier = Modifier.size(40.dp),
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = stringResource(R.string.notifications_placeholder_title),
+            style = SNUTTTypography.h2.copy(color = SNUTTColors.Gray200),
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Text(
+            text = stringResource(R.string.notifications_placeholder_description),
+            style = SNUTTTypography.body1.copy(color = SNUTTColors.Gray200),
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NotificationPagePreview() {
+    val data =
+        PagingData.from(listOf(Notification("테스트 알림", "테스트 문구", "", NotificationType.Trash, "")))
+    val flow = flowOf(data)
+    val a = flow.collectAsLazyPagingItems()
+    NotificationPage(uiState = NotificationUiState.Success(a), onBackClick = {})
+}

--- a/app/src/refactor/java/com/wafflestudio/snutt2/notification/NotificationUiState.kt
+++ b/app/src/refactor/java/com/wafflestudio/snutt2/notification/NotificationUiState.kt
@@ -1,0 +1,24 @@
+package com.wafflestudio.snutt2.notification
+
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import com.wafflestudio.snutt2.domain_model.Notification
+
+sealed interface NotificationUiState {
+    data class Success(val notificationList: LazyPagingItems<Notification>) : NotificationUiState
+    data object Error : NotificationUiState
+    data object Loading : NotificationUiState
+    data object Empty : NotificationUiState
+}
+
+fun LazyPagingItems<Notification>.notificationUiState(): NotificationUiState {
+    val refreshState = loadState.refresh
+    val appendState = loadState.append
+
+    return when {
+        refreshState is LoadState.Loading -> NotificationUiState.Loading
+        refreshState is LoadState.Error -> NotificationUiState.Error
+        appendState.endOfPaginationReached && itemCount < 1 -> NotificationUiState.Empty
+        else -> NotificationUiState.Success(this)
+    }
+}


### PR DESCRIPTION
뭐가 정답인지 잘 모르지만, 오답지라도 만들면서 고쳐나가기 위한 PR

바뀐 점
- Normal / Refactor 상태를 구분하는 provideSNUTTAppState 생성
- 그 외에는 전에 리팩토링 얘기하면서 얘기한 점 반영 (Route/Page 분리, UiState 관리, 네트워크/도메인 모델 분리)

특이점
- 원래 UiState를 ViewModel에서 관리해야 하나 Paging의 경우 컴포저블 함수에서 collectAsLazyPagingItems()를 했을 때 state가 생성되므로 예외적으로 Route에서 UiState 관리
- 아직 Navigation까지는 그냥 기존 방식 채택
- develop과 섞이는 것을 방지하기 위해 refactor-base-branch 생성
- 그 외 사소한 점들은 코멘트로 작성