### PR TITLE
비밀번호 재설정 regex 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/data/SNUTTStringUtils.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/data/SNUTTStringUtils.kt
@@ -174,5 +174,5 @@ object SNUTTStringUtils {
         }
     }.toString()
 
-    fun String.isValidPassword(): Boolean = Regex("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,20}$").matches(this)
+    fun String.isValidPassword(): Boolean = Regex("^(?=.*\\d)(?=.*[a-zA-Z])\\S{6,20}\$").matches(this)
 }


### PR DESCRIPTION
- 기존 regex가 특수문자를 포함하지 못함
- 서버에서 사용하는 regex 그대로 사용