### PR TITLE
같은 이름의 태그 선택 가능하도록 코드 개선

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/TagDto.kt
@@ -7,11 +7,12 @@ data class TagDto(
     val type: TagType,
     val name: String,
 ) {
-
     companion object {
         val TIME_EMPTY: TagDto = TagDto(TagType.TIME, "빈 시간대로 검색")
         val TIME_SELECT: TagDto = TagDto(TagType.TIME, "시간대 직접 선택")
         val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
         val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
     }
+
+    fun toItemKey(): String = type.toString() + name
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
@@ -49,7 +49,7 @@ fun SearchResultList(
     val keyBoardController = LocalSoftwareKeyboardController.current
 
     Column {
-        AnimatedLazyRow(itemList = selectedTags, itemKey = { it.name }) {
+        AnimatedLazyRow(itemList = selectedTags, itemKey = { it.type.toString() + it.name }) {
             TagCell(
                 tagDto = it,
                 onClick = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
@@ -49,7 +49,7 @@ fun SearchResultList(
     val keyBoardController = LocalSoftwareKeyboardController.current
 
     Column {
-        AnimatedLazyRow(itemList = selectedTags, itemKey = { it.type.toString() + it.name }) {
+        AnimatedLazyRow(itemList = selectedTags, itemKey = { it.toItemKey() }) {
             TagCell(
                 tagDto = it,
                 onClick = {


### PR DESCRIPTION
- TagType는 다르지만 Tag 이름은 같은 경우가 생겨서, Tag.name과 TagType를 함께 LazyRow의 key로 넣어줌