### PR TITLE
build variant에 따라 다른 테마마켓 웹뷰 url 사용하기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/ThemeMarketWebViewContainer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/webview/ThemeMarketWebViewContainer.kt
@@ -63,7 +63,7 @@ class ThemeMarketWebViewContainer(
 
     override suspend fun openPage(url: String?) {
         val accessToken = accessToken.filterNotNull().first()
-        val themeMarketUrl = url ?: THEME_MARKET_URL
+        val themeMarketUrl = url ?: context.getString(R.string.theme_market_base_url)
         val urlHost = URL(themeMarketUrl).host
 
         setCookies(urlHost, accessToken)
@@ -107,9 +107,5 @@ class ThemeMarketWebViewContainer(
                 }",
             )
         }.flush()
-    }
-
-    companion object {
-        private val THEME_MARKET_URL = "https://snutt-theme-market-dev.wafflestudio.com/download"
     }
 }


### PR DESCRIPTION
- 코드에 하드코딩해두었던 걸 strings.xml으로 빼냄
- 웹뷰 url을 staging, live 구분하기 위함
- build variant 구분이 목적인데 시크릿을 건드리는 건 좀 이상한듯... api key같은 시크릿 가져올 때 context 필요한 것도 이상한듯... 바꿔야할듯....
- 레포 시크릿 반영완료