### PR TITLE
소셜 연동/해제 페이지 리팩토링

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/FacebookLogin.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/FacebookLogin.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 
 suspend fun facebookLogin(
     context: Context,
+    showToast: (String) -> Unit = context::toast,
 ): LoginResult {
     val callbackManager = CallbackManager.Factory.create()
     val loginManager = LoginManager.getInstance()
@@ -26,12 +27,12 @@ suspend fun facebookLogin(
             }
 
             override fun onCancel() {
-                context.toast(context.getString(R.string.sign_in_facebook_failed_cancelled))
+                showToast(context.getString(R.string.sign_in_facebook_failed_cancelled))
                 continuation.cancel()
             }
 
             override fun onError(error: FacebookException) {
-                context.toast(context.getString(R.string.sign_in_facebook_failed_unknown))
+                showToast(context.getString(R.string.sign_in_facebook_failed_unknown))
                 continuation.cancel(error)
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/model/SocialLoginType.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/model/SocialLoginType.kt
@@ -15,3 +15,5 @@ fun SocialLoginType.getString(): String {
         SocialLoginType.KAKAO -> "카카오"
     }
 }
+
+fun SocialLoginType.showDialog() = (this != SocialLoginType.NONE)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootActivity.kt
@@ -398,7 +398,7 @@ class RootActivity : AppCompatActivity() {
         composableAnimated<NavigationDestination.TimeTableConfig> { TimetableConfigPage() }
         composableAnimated<NavigationDestination.UserConfig> { UserConfigPage() }
         composableAnimated<NavigationDestination.ChangeNickname> { ChangeNicknamePage() }
-        composableAnimated<NavigationDestination.SocialLink> { SocialLinkPage() }
+        composableAnimated<NavigationDestination.SocialLink> { SocialLinkRoute() }
         composableAnimated<NavigationDestination.PersonalInformationPolicy> { PersonalInformationPolicyPage() }
         composableAnimated<NavigationDestination.ThemeModeSelect> { ColorModeSelectPage() }
         composableAnimated<NavigationDestination.VacancyNotification> {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
@@ -73,6 +72,14 @@ fun SocialLinkPage() {
         }
     }
 
+    LaunchedEffect(Unit) {
+        socialLinkViewModel.toastState.collect { message ->
+            if (message.isNotEmpty()) {
+                context.toast(message)
+            }
+        }
+    }
+
     val handleFacebookConnect = {
         coroutineScope.launch {
             launchSuspendApi(
@@ -80,7 +87,7 @@ fun SocialLinkPage() {
                 apiOnError = apiOnError,
                 loadingIndicatorTitle = context.getString(R.string.sign_in_sign_in_button),
             ) {
-                val loginResult = facebookLogin(context)
+                val loginResult = facebookLogin(context, socialLinkViewModel::showToast)
                 socialLinkViewModel.connectFacebook(
                     loginResult.accessToken.token,
                 )
@@ -104,7 +111,7 @@ fun SocialLinkPage() {
                     socialLinkViewModel.fetchUserInfo()
                     socialLinkViewModel.fetchSocialProviders()
                 } else {
-                    context.toast(context.getString(R.string.sign_in_kakao_failed_unknown))
+                    socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
                 }
             }
         }
@@ -113,16 +120,16 @@ fun SocialLinkPage() {
     val loginWithKakaoAccountCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         if (error != null) {
             if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                context.toast(context.getString(R.string.sign_in_kakao_failed_cancelled))
+                socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_cancelled))
             } else if (error is AuthError && error.reason == AuthErrorCause.AccessDenied) {
-                context.toast(context.getString(R.string.sign_in_kakao_failed_cancelled))
+                socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_cancelled))
             } else {
-                context.toast(context.getString(R.string.sign_in_kakao_failed_unknown))
+                socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
             }
         } else if (token != null) {
             connectWithKaKaoAccessToken(token.accessToken)
         } else {
-            context.toast(context.getString(R.string.sign_in_kakao_failed_unknown))
+            socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
         }
     }
 
@@ -131,9 +138,9 @@ fun SocialLinkPage() {
             UserApiClient.instance.loginWithKakaoTalk(context) { token, loginError ->
                 if (loginError != null) {
                     if (loginError is ClientError && loginError.reason == ClientErrorCause.Cancelled) {
-                        context.toast(context.getString(R.string.sign_in_kakao_failed_cancelled))
+                        socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_cancelled))
                     } else if (loginError is AuthError && loginError.reason == AuthErrorCause.AccessDenied) {
-                        context.toast(context.getString(R.string.sign_in_kakao_failed_cancelled))
+                        socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_cancelled))
                     } else {
                         // 카카오계정으로 로그인
                         UserApiClient.instance.loginWithKakaoAccount(context = context, callback = loginWithKakaoAccountCallback)
@@ -141,7 +148,7 @@ fun SocialLinkPage() {
                 } else if (token != null) {
                     connectWithKaKaoAccessToken(token.accessToken)
                 } else {
-                    context.toast(context.getString(R.string.sign_in_kakao_failed_unknown))
+                    socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
                 }
             }
         } else {
@@ -169,7 +176,7 @@ fun SocialLinkPage() {
                     socialLinkViewModel.fetchUserInfo()
                     socialLinkViewModel.fetchSocialProviders()
                 } else {
-                    context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                    socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
                 }
             }
         }
@@ -185,19 +192,19 @@ fun SocialLinkPage() {
                     val account = task.getResult(ApiException::class.java)
                     val authCode = account?.serverAuthCode
                     if (authCode == null) {
-                        context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                        socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
                         return@rememberLauncherForActivityResult
                     }
                     handleGoogleSignInCallback(authCode)
                 } catch (e: ApiException) {
-                    context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                    socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
                 }
             }
             Activity.RESULT_CANCELED -> {
-                context.toast(context.getString(R.string.sign_in_sign_in_google_cancelled))
+                socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_cancelled))
             }
             else -> {
-                context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
             }
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -84,26 +84,6 @@ fun SocialLinkPage() {
         }
     }
 
-    val connectWithKaKaoAccessToken: (String) -> Unit = { kakaoAccessToken ->
-        coroutineScope.launch {
-            launchSuspendApi(
-                apiOnProgress = apiOnProgress,
-                apiOnError = apiOnError,
-                loadingIndicatorTitle = context.getString(R.string.sign_in_sign_in_button),
-            ) {
-                if (kakaoAccessToken.isNotEmpty()) {
-                    socialLinkViewModel.connectKakao(
-                        kakaoAccessToken,
-                    )
-                    socialLinkViewModel.fetchUserInfo()
-                    socialLinkViewModel.fetchSocialProviders()
-                } else {
-                    socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
-                }
-            }
-        }
-    }
-
     val loginWithKakaoAccountCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         if (error != null) {
             if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
@@ -114,7 +94,9 @@ fun SocialLinkPage() {
                 socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
             }
         } else if (token != null) {
-            connectWithKaKaoAccessToken(token.accessToken)
+            coroutineScope.launch {
+                socialLinkViewModel.connectKakao(token.accessToken)
+            }
         } else {
             socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
         }
@@ -133,7 +115,9 @@ fun SocialLinkPage() {
                         UserApiClient.instance.loginWithKakaoAccount(context = context, callback = loginWithKakaoAccountCallback)
                     }
                 } else if (token != null) {
-                    connectWithKaKaoAccessToken(token.accessToken)
+                    coroutineScope.launch {
+                        socialLinkViewModel.connectKakao(token.accessToken)
+                    }
                 } else {
                     socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
                 }
@@ -225,7 +209,7 @@ fun SocialLinkPage() {
         ) {
             Margin(height = 10.dp)
 
-            if (socialProviders.kakao) {
+            if (socialLinkUiState.kakao == SocialLinkUiState.SocialProviders.LINKED) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_kakao),
                     titleColor = colorResource(R.color.theme_snutt_0),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -52,15 +52,12 @@ fun SocialLinkPage() {
     val context = LocalContext.current
     val navController = LocalNavController.current
     val coroutineScope = rememberCoroutineScope()
-    val apiOnProgress = LocalApiOnProgress.current
-    val apiOnError = LocalApiOnError.current
     val activityContext = LocalContext.current as Activity
 
     val clientId = context.getString(R.string.web_client_id)
     val clientSecret = context.getString(R.string.web_client_secret)
 
     val socialLinkViewModel = hiltViewModel<SocialLinkViewModel>()
-    val socialProviders by socialLinkViewModel.socialProviders.collectAsStateWithLifecycle()
     val disconnectSocialDialogState by socialLinkViewModel.disconnectSocialDialogState.collectAsStateWithLifecycle()
     val socialLinkUiState by socialLinkViewModel.socialLinkUiState.collectAsStateWithLifecycle()
 
@@ -70,10 +67,6 @@ fun SocialLinkPage() {
                 context.toast(message)
             }
         }
-    }
-
-    LaunchedEffect(socialLinkUiState) {
-        Log.d("plgafhdtest", socialLinkUiState.toString())
     }
 
     val handleFacebookConnect = {
@@ -93,9 +86,7 @@ fun SocialLinkPage() {
                 socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
             }
         } else if (token != null) {
-            coroutineScope.launch {
-                socialLinkViewModel.connectKakao(token.accessToken)
-            }
+            socialLinkViewModel.connectKakao(token.accessToken)
         } else {
             socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
         }
@@ -114,9 +105,7 @@ fun SocialLinkPage() {
                         UserApiClient.instance.loginWithKakaoAccount(context = context, callback = loginWithKakaoAccountCallback)
                     }
                 } else if (token != null) {
-                    coroutineScope.launch {
-                        socialLinkViewModel.connectKakao(token.accessToken)
-                    }
+                    socialLinkViewModel.connectKakao(token.accessToken)
                 } else {
                     socialLinkViewModel.showToast(context.getString(R.string.sign_in_kakao_failed_unknown))
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -130,25 +130,15 @@ fun SocialLinkPage() {
 
     val handleGoogleSignInCallback: (String) -> Unit = { authCode: String ->
         coroutineScope.launch {
-            launchSuspendApi(
-                apiOnProgress = apiOnProgress,
-                apiOnError = apiOnError,
-                loadingIndicatorTitle = context.getString(R.string.sign_in_sign_in_button),
-            ) {
-                val googleAccessToken = socialLinkViewModel.getAccessTokenByAuthCode(
-                    authCode = authCode,
-                    clientId = clientId,
-                    clientSecret = clientSecret,
-                )
-                if (googleAccessToken != null) {
-                    socialLinkViewModel.connectGoogle(
-                        googleAccessToken,
-                    )
-                    socialLinkViewModel.fetchUserInfo()
-                    socialLinkViewModel.fetchSocialProviders()
-                } else {
-                    socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
-                }
+            val googleAccessToken = socialLinkViewModel.getAccessTokenByAuthCode(
+                authCode = authCode,
+                clientId = clientId,
+                clientSecret = clientSecret,
+            )
+            if (googleAccessToken != null) {
+                socialLinkViewModel.connectGoogle(googleAccessToken)
+            } else {
+                socialLinkViewModel.showToast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
             }
         }
     }
@@ -226,7 +216,7 @@ fun SocialLinkPage() {
 
             Margin(height = 10.dp)
 
-            if (socialProviders.google) {
+            if (socialLinkUiState.google == SocialLinkUiState.SocialProviders.LINKED) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_google),
                     titleColor = colorResource(R.color.theme_snutt_0),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.views.logged_in.home.settings
 
 import android.app.Activity
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -62,15 +63,7 @@ fun SocialLinkPage() {
     val socialLinkViewModel = hiltViewModel<SocialLinkViewModel>()
     val socialProviders by socialLinkViewModel.socialProviders.collectAsStateWithLifecycle()
     val disconnectSocialDialogState by socialLinkViewModel.disconnectSocialDialogState.collectAsStateWithLifecycle()
-
-    LaunchedEffect(Unit) {
-        launchSuspendApi(
-            apiOnProgress = apiOnProgress,
-            apiOnError = apiOnError,
-        ) {
-            socialLinkViewModel.fetchSocialProviders()
-        }
-    }
+    val socialLinkUiState by socialLinkViewModel.socialLinkUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         socialLinkViewModel.toastState.collect { message ->
@@ -78,6 +71,10 @@ fun SocialLinkPage() {
                 context.toast(message)
             }
         }
+    }
+
+    LaunchedEffect(socialLinkUiState) {
+        Log.d("plgafhdtest", socialLinkUiState.toString())
     }
 
     val handleFacebookConnect = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -44,7 +44,6 @@ import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.views.LocalApiOnError
 import com.wafflestudio.snutt2.views.LocalApiOnProgress
 import com.wafflestudio.snutt2.views.LocalNavController
-import com.wafflestudio.snutt2.views.launchSuspendApi
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
 import kotlinx.coroutines.launch
 
@@ -259,13 +258,9 @@ fun SocialLinkPage() {
             onDismiss = { socialLinkViewModel.changeDialogState(SocialLoginType.NONE) },
             onConfirm = {
                 coroutineScope.launch {
-                    launchSuspendApi(apiOnProgress, apiOnError) {
-                        LoginManager.getInstance().logOut()
-                        socialLinkViewModel.disconnectSocialLogin(disconnectSocialDialogState)
-                        socialLinkViewModel.fetchUserInfo()
-                        socialLinkViewModel.fetchSocialProviders()
-                        socialLinkViewModel.changeDialogState(SocialLoginType.NONE)
-                    }
+                    LoginManager.getInstance().logOut()
+                    socialLinkViewModel.disconnectSocialLogin(disconnectSocialDialogState)
+                    socialLinkViewModel.changeDialogState(SocialLoginType.NONE)
                 }
             },
             title = context.getString(R.string.settings_user_config_social_disconnect_message, disconnectSocialDialogState.getString()),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -64,8 +62,7 @@ fun SocialLinkPage() {
 
     val socialLinkViewModel = hiltViewModel<SocialLinkViewModel>()
     val socialProviders by socialLinkViewModel.socialProviders.collectAsStateWithLifecycle()
-
-    var disconnectSocialDialogState by remember { mutableStateOf(SocialLoginType.NONE) }
+    val disconnectSocialDialogState by socialLinkViewModel.disconnectSocialDialogState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         launchSuspendApi(
@@ -239,7 +236,7 @@ fun SocialLinkPage() {
                     title = stringResource(R.string.social_unlink_kakao),
                     titleColor = colorResource(R.color.theme_snutt_0),
                     hasNextPage = false,
-                    onClick = { disconnectSocialDialogState = SocialLoginType.KAKAO },
+                    onClick = { socialLinkViewModel.changeDialogState(SocialLoginType.KAKAO) },
                 )
             } else {
                 SettingItem(
@@ -256,7 +253,7 @@ fun SocialLinkPage() {
                     title = stringResource(R.string.social_unlink_google),
                     titleColor = colorResource(R.color.theme_snutt_0),
                     hasNextPage = false,
-                    onClick = { disconnectSocialDialogState = SocialLoginType.GOOGLE },
+                    onClick = { socialLinkViewModel.changeDialogState(SocialLoginType.GOOGLE) },
                 )
             } else {
                 SettingItem(
@@ -277,7 +274,7 @@ fun SocialLinkPage() {
                     title = stringResource(R.string.social_unlink_facebook),
                     titleColor = colorResource(R.color.theme_snutt_0),
                     hasNextPage = false,
-                    onClick = { disconnectSocialDialogState = SocialLoginType.FACEBOOK },
+                    onClick = { socialLinkViewModel.changeDialogState(SocialLoginType.FACEBOOK) },
                 )
             } else {
                 SettingItem(
@@ -291,7 +288,7 @@ fun SocialLinkPage() {
 
     if (disconnectSocialDialogState != SocialLoginType.NONE) {
         CustomDialog(
-            onDismiss = { disconnectSocialDialogState = SocialLoginType.NONE },
+            onDismiss = { socialLinkViewModel.changeDialogState(SocialLoginType.NONE) },
             onConfirm = {
                 coroutineScope.launch {
                     launchSuspendApi(apiOnProgress, apiOnError) {
@@ -299,7 +296,7 @@ fun SocialLinkPage() {
                         socialLinkViewModel.disconnectSocialLogin(disconnectSocialDialogState)
                         socialLinkViewModel.fetchUserInfo()
                         socialLinkViewModel.fetchSocialProviders()
-                        disconnectSocialDialogState = SocialLoginType.NONE
+                        socialLinkViewModel.changeDialogState(SocialLoginType.NONE)
                     }
                 }
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -79,18 +79,8 @@ fun SocialLinkPage() {
 
     val handleFacebookConnect = {
         coroutineScope.launch {
-            launchSuspendApi(
-                apiOnProgress = apiOnProgress,
-                apiOnError = apiOnError,
-                loadingIndicatorTitle = context.getString(R.string.sign_in_sign_in_button),
-            ) {
-                val loginResult = facebookLogin(context, socialLinkViewModel::showToast)
-                socialLinkViewModel.connectFacebook(
-                    loginResult.accessToken.token,
-                )
-                socialLinkViewModel.fetchUserInfo()
-                socialLinkViewModel.fetchSocialProviders()
-            }
+            val loginResult = facebookLogin(context, socialLinkViewModel::showToast)
+            socialLinkViewModel.connectFacebook(loginResult.accessToken.token)
         }
     }
 
@@ -273,7 +263,7 @@ fun SocialLinkPage() {
 
             Margin(height = 10.dp)
 
-            if (socialProviders.facebook) {
+            if (socialLinkUiState.facebook == SocialLinkUiState.SocialProviders.LINKED) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_facebook),
                     titleColor = colorResource(R.color.theme_snutt_0),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -285,4 +286,31 @@ fun SocialButtonItem(
             onClick = onConnectClick,
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SocialLinkScreenPreview() {
+    SocialLinkScreen(
+        modifier = Modifier,
+        onBackClick = {},
+        uiState = SocialLinkUiState.Default,
+        dialogState = SocialLoginType.NONE,
+        changeDialogState = {},
+        handleFacebookConnect = {},
+        handleKakaoConnect = {},
+        handleGoogleConnect = {},
+        handleSocialDisconnect = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SocialButtonItemPreview() {
+    SocialButtonItem(
+        type = SocialLoginType.KAKAO,
+        linkState = SocialLinkUiState.SocialProviders.UNLINKED,
+        onConnectClick = {},
+        onDisconnectClick = {},
+    )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.home.settings
 
 import android.app.Activity
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -41,14 +40,15 @@ import com.wafflestudio.snutt2.lib.facebookLogin
 import com.wafflestudio.snutt2.model.SocialLoginType
 import com.wafflestudio.snutt2.model.getString
 import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.views.LocalApiOnError
-import com.wafflestudio.snutt2.views.LocalApiOnProgress
 import com.wafflestudio.snutt2.views.LocalNavController
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
 import kotlinx.coroutines.launch
 
 @Composable
-fun SocialLinkPage() {
+fun SocialLinkRoute(
+    modifier: Modifier = Modifier,
+    viewModel: SocialLinkViewModel = hiltViewModel(),
+) {
     val context = LocalContext.current
     val navController = LocalNavController.current
     val coroutineScope = rememberCoroutineScope()
@@ -61,19 +61,12 @@ fun SocialLinkPage() {
     val disconnectSocialDialogState by socialLinkViewModel.disconnectSocialDialogState.collectAsStateWithLifecycle()
     val socialLinkUiState by socialLinkViewModel.socialLinkUiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        socialLinkViewModel.toastState.collect { message ->
-            if (message.isNotEmpty()) {
-                context.toast(message)
-            }
-        }
-    }
-
     val handleFacebookConnect = {
         coroutineScope.launch {
             val loginResult = facebookLogin(context, socialLinkViewModel::showToast)
             socialLinkViewModel.connectFacebook(loginResult.accessToken.token)
         }
+        Unit
     }
 
     val loginWithKakaoAccountCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
@@ -167,18 +160,63 @@ fun SocialLinkPage() {
 
     // 구글 계정 선택 창 띄움
     val handleGoogleConnect = {
-        val signInIntent = googleSignInClient.signInIntent
-        googleLoginActivityResultLauncher.launch(signInIntent)
+        googleSignInClient.signOut().addOnCompleteListener {
+            val signInIntent = googleSignInClient.signInIntent
+            googleLoginActivityResultLauncher.launch(signInIntent)
+        }
+        Unit
     }
 
+    val handleSocialDisconnect = {
+        coroutineScope.launch {
+            LoginManager.getInstance().logOut()
+            socialLinkViewModel.disconnectSocialLogin(disconnectSocialDialogState)
+            socialLinkViewModel.changeDialogState(SocialLoginType.NONE)
+        }
+        Unit
+    }
+
+    LaunchedEffect(Unit) {
+        socialLinkViewModel.toastState.collect { message ->
+            if (message.isNotEmpty()) {
+                context.toast(message)
+            }
+        }
+    }
+
+    SocialLinkScreen(
+        modifier = modifier,
+        onBackClick = { navController.popBackStack() },
+        uiState = socialLinkUiState,
+        dialogState = disconnectSocialDialogState,
+        changeDialogState = viewModel::changeDialogState,
+        handleFacebookConnect = handleFacebookConnect,
+        handleKakaoConnect = handleKakaoConnect,
+        handleGoogleConnect = handleGoogleConnect,
+        handleSocialDisconnect = handleSocialDisconnect,
+    )
+}
+
+@Composable
+fun SocialLinkScreen(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit,
+    uiState: SocialLinkUiState,
+    dialogState: SocialLoginType,
+    changeDialogState: (SocialLoginType) -> Unit,
+    handleFacebookConnect: () -> Unit,
+    handleKakaoConnect: () -> Unit,
+    handleGoogleConnect: () -> Unit,
+    handleSocialDisconnect: () -> Unit,
+) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(SNUTTColors.SettingBackground),
     ) {
         SimpleTopBar(
             title = stringResource(R.string.social_link_title),
-            onClickNavigateBack = { navController.popBackStack() },
+            onClickNavigateBack = onBackClick,
         )
 
         Column(
@@ -187,72 +225,62 @@ fun SocialLinkPage() {
         ) {
             Margin(height = 10.dp)
 
-            if (socialLinkUiState.kakao == SocialLinkUiState.SocialProviders.LINKED) {
+            if (uiState.kakao == SocialLinkUiState.SocialProviders.LINKED) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_kakao),
                     titleColor = colorResource(R.color.theme_snutt_0),
                     hasNextPage = false,
-                    onClick = { socialLinkViewModel.changeDialogState(SocialLoginType.KAKAO) },
+                    onClick = { changeDialogState(SocialLoginType.KAKAO) },
                 )
             } else {
                 SettingItem(
                     title = stringResource(R.string.social_link_kakao),
                     hasNextPage = false,
-                    onClick = { handleKakaoConnect() },
+                    onClick = handleKakaoConnect,
                 )
             }
 
             Margin(height = 10.dp)
 
-            if (socialLinkUiState.google == SocialLinkUiState.SocialProviders.LINKED) {
+            if (uiState.google == SocialLinkUiState.SocialProviders.LINKED) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_google),
                     titleColor = colorResource(R.color.theme_snutt_0),
                     hasNextPage = false,
-                    onClick = { socialLinkViewModel.changeDialogState(SocialLoginType.GOOGLE) },
+                    onClick = { changeDialogState(SocialLoginType.GOOGLE) },
                 )
             } else {
                 SettingItem(
                     title = stringResource(R.string.social_link_google),
                     hasNextPage = false,
-                    onClick = {
-                        googleSignInClient.signOut().addOnCompleteListener {
-                            handleGoogleConnect()
-                        }
-                    },
+                    onClick = handleGoogleConnect,
                 )
             }
 
             Margin(height = 10.dp)
 
-            if (socialLinkUiState.facebook == SocialLinkUiState.SocialProviders.LINKED) {
+            if (uiState.facebook == SocialLinkUiState.SocialProviders.LINKED) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_facebook),
                     titleColor = colorResource(R.color.theme_snutt_0),
                     hasNextPage = false,
-                    onClick = { socialLinkViewModel.changeDialogState(SocialLoginType.FACEBOOK) },
+                    onClick = { changeDialogState(SocialLoginType.FACEBOOK) },
                 )
             } else {
                 SettingItem(
                     title = stringResource(R.string.social_link_facebook),
                     hasNextPage = false,
-                    onClick = { handleFacebookConnect() },
+                    onClick = handleFacebookConnect,
                 )
             }
         }
     }
 
-    if (disconnectSocialDialogState != SocialLoginType.NONE) {
+    if (dialogState != SocialLoginType.NONE) {
         CustomDialog(
-            onDismiss = { socialLinkViewModel.changeDialogState(SocialLoginType.NONE) },
-            onConfirm = {
-                coroutineScope.launch {
-                    LoginManager.getInstance().logOut()
-                    socialLinkViewModel.disconnectSocialLogin(disconnectSocialDialogState)
-                    socialLinkViewModel.changeDialogState(SocialLoginType.NONE)
-                }
-            },
-            title = context.getString(R.string.settings_user_config_social_disconnect_message, disconnectSocialDialogState.getString()),
+            onDismiss = { changeDialogState(SocialLoginType.NONE) },
+            onConfirm = handleSocialDisconnect,
+            title = stringResource(R.string.settings_user_config_social_disconnect_message, dialogState.getString()),
             content = {},
             positiveButtonText = stringResource(R.string.social_disconnect),
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
@@ -39,6 +39,7 @@ import com.wafflestudio.snutt2.lib.android.toast
 import com.wafflestudio.snutt2.lib.facebookLogin
 import com.wafflestudio.snutt2.model.SocialLoginType
 import com.wafflestudio.snutt2.model.getString
+import com.wafflestudio.snutt2.model.showDialog
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.views.LocalNavController
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
@@ -225,7 +226,7 @@ fun SocialLinkScreen(
         ) {
             Margin(height = 10.dp)
 
-            if (uiState.kakao == SocialLinkUiState.SocialProviders.LINKED) {
+            if (uiState.kakao.isLinked()) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_kakao),
                     titleColor = colorResource(R.color.theme_snutt_0),
@@ -242,7 +243,7 @@ fun SocialLinkScreen(
 
             Margin(height = 10.dp)
 
-            if (uiState.google == SocialLinkUiState.SocialProviders.LINKED) {
+            if (uiState.google.isLinked()) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_google),
                     titleColor = colorResource(R.color.theme_snutt_0),
@@ -259,7 +260,7 @@ fun SocialLinkScreen(
 
             Margin(height = 10.dp)
 
-            if (uiState.facebook == SocialLinkUiState.SocialProviders.LINKED) {
+            if (uiState.facebook.isLinked()) {
                 SettingItem(
                     title = stringResource(R.string.social_unlink_facebook),
                     titleColor = colorResource(R.color.theme_snutt_0),
@@ -276,7 +277,7 @@ fun SocialLinkScreen(
         }
     }
 
-    if (dialogState != SocialLoginType.NONE) {
+    if (dialogState.showDialog()) {
         CustomDialog(
             onDismiss = { changeDialogState(SocialLoginType.NONE) },
             onConfirm = handleSocialDisconnect,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkScreen.kt
@@ -168,10 +168,10 @@ fun SocialLinkRoute(
         Unit
     }
 
-    val handleSocialDisconnect = {
+    val handleSocialDisconnect = { type: SocialLoginType ->
         coroutineScope.launch {
             LoginManager.getInstance().logOut()
-            socialLinkViewModel.disconnectSocialLogin(disconnectSocialDialogState)
+            socialLinkViewModel.disconnectSocialLogin(type)
             socialLinkViewModel.changeDialogState(SocialLoginType.NONE)
         }
         Unit
@@ -208,7 +208,7 @@ fun SocialLinkScreen(
     handleFacebookConnect: () -> Unit,
     handleKakaoConnect: () -> Unit,
     handleGoogleConnect: () -> Unit,
-    handleSocialDisconnect: () -> Unit,
+    handleSocialDisconnect: (SocialLoginType) -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -226,64 +226,63 @@ fun SocialLinkScreen(
         ) {
             Margin(height = 10.dp)
 
-            if (uiState.kakao.isLinked()) {
-                SettingItem(
-                    title = stringResource(R.string.social_unlink_kakao),
-                    titleColor = colorResource(R.color.theme_snutt_0),
-                    hasNextPage = false,
-                    onClick = { changeDialogState(SocialLoginType.KAKAO) },
-                )
-            } else {
-                SettingItem(
-                    title = stringResource(R.string.social_link_kakao),
-                    hasNextPage = false,
-                    onClick = handleKakaoConnect,
-                )
-            }
+            SocialButtonItem(
+                type = SocialLoginType.KAKAO,
+                linkState = uiState.kakao,
+                onConnectClick = handleKakaoConnect,
+                onDisconnectClick = changeDialogState,
+            )
 
             Margin(height = 10.dp)
 
-            if (uiState.google.isLinked()) {
-                SettingItem(
-                    title = stringResource(R.string.social_unlink_google),
-                    titleColor = colorResource(R.color.theme_snutt_0),
-                    hasNextPage = false,
-                    onClick = { changeDialogState(SocialLoginType.GOOGLE) },
-                )
-            } else {
-                SettingItem(
-                    title = stringResource(R.string.social_link_google),
-                    hasNextPage = false,
-                    onClick = handleGoogleConnect,
-                )
-            }
+            SocialButtonItem(
+                type = SocialLoginType.GOOGLE,
+                linkState = uiState.google,
+                onConnectClick = handleGoogleConnect,
+                onDisconnectClick = changeDialogState,
+            )
 
             Margin(height = 10.dp)
 
-            if (uiState.facebook.isLinked()) {
-                SettingItem(
-                    title = stringResource(R.string.social_unlink_facebook),
-                    titleColor = colorResource(R.color.theme_snutt_0),
-                    hasNextPage = false,
-                    onClick = { changeDialogState(SocialLoginType.FACEBOOK) },
-                )
-            } else {
-                SettingItem(
-                    title = stringResource(R.string.social_link_facebook),
-                    hasNextPage = false,
-                    onClick = handleFacebookConnect,
-                )
-            }
+            SocialButtonItem(
+                type = SocialLoginType.FACEBOOK,
+                linkState = uiState.facebook,
+                onConnectClick = handleFacebookConnect,
+                onDisconnectClick = changeDialogState,
+            )
         }
     }
 
     if (dialogState.showDialog()) {
         CustomDialog(
             onDismiss = { changeDialogState(SocialLoginType.NONE) },
-            onConfirm = handleSocialDisconnect,
+            onConfirm = { handleSocialDisconnect(dialogState) },
             title = stringResource(R.string.settings_user_config_social_disconnect_message, dialogState.getString()),
             content = {},
             positiveButtonText = stringResource(R.string.social_disconnect),
+        )
+    }
+}
+
+@Composable
+fun SocialButtonItem(
+    type: SocialLoginType,
+    linkState: SocialLinkUiState.SocialProviders,
+    onConnectClick: () -> Unit,
+    onDisconnectClick: (SocialLoginType) -> Unit,
+) {
+    if (linkState.isLinked()) {
+        SettingItem(
+            title = stringResource(R.string.social_unlink, type.getString()),
+            titleColor = colorResource(R.color.theme_snutt_0),
+            hasNextPage = false,
+            onClick = { onDisconnectClick(type) },
+        )
+    } else {
+        SettingItem(
+            title = stringResource(R.string.social_link, type.getString()),
+            hasNextPage = false,
+            onClick = onConnectClick,
         )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkUiState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkUiState.kt
@@ -25,3 +25,5 @@ fun GetSocialProvidersResults.socialLinkUiState(): SocialLinkUiState = SocialLin
     kakao = if (kakao) SocialLinkUiState.SocialProviders.LINKED else SocialLinkUiState.SocialProviders.UNLINKED,
     google = if (google) SocialLinkUiState.SocialProviders.LINKED else SocialLinkUiState.SocialProviders.UNLINKED,
 )
+
+fun SocialLinkUiState.SocialProviders.isLinked() = (this == SocialLinkUiState.SocialProviders.LINKED)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkUiState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkUiState.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.snutt2.views.logged_in.home.settings
+
+import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
+
+data class SocialLinkUiState(
+    val facebook: SocialProviders,
+    val kakao: SocialProviders,
+    val google: SocialProviders,
+) {
+    enum class SocialProviders {
+        LINKED, UNLINKED
+    }
+
+    companion object {
+        val Default = SocialLinkUiState(
+            facebook = SocialProviders.UNLINKED,
+            kakao = SocialProviders.UNLINKED,
+            google = SocialProviders.UNLINKED,
+        )
+    }
+}
+
+fun GetSocialProvidersResults.socialLinkUiState(): SocialLinkUiState = SocialLinkUiState(
+    facebook = if (facebook) SocialLinkUiState.SocialProviders.LINKED else SocialLinkUiState.SocialProviders.UNLINKED,
+    kakao = if (kakao) SocialLinkUiState.SocialProviders.LINKED else SocialLinkUiState.SocialProviders.UNLINKED,
+    google = if (google) SocialLinkUiState.SocialProviders.LINKED else SocialLinkUiState.SocialProviders.UNLINKED,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
-import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
+import com.wafflestudio.snutt2.lib.network.ApiOnError
 import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
 import com.wafflestudio.snutt2.model.SocialLoginType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,6 +16,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SocialLinkViewModel @Inject constructor(
     private val userRepository: UserRepository,
+    private val apiOnError: ApiOnError,
 ) : ViewModel() {
     private val _socialProviders: MutableStateFlow<GetSocialProvidersResults> = MutableStateFlow(GetSocialProvidersResults(false, false, false, false, false))
     val socialProviders = _socialProviders.asStateFlow()
@@ -34,9 +35,7 @@ class SocialLinkViewModel @Inject constructor(
             runCatching {
                 fetchSocialProvidersNew()
             }.onFailure { e ->
-                if (e is ErrorParsedHttpException) {
-                    _toastState.emit(e.errorDTO?.displayMessage ?: "")
-                }
+                apiOnError(e)
                 _socialLinkUiState.emit(SocialLinkUiState.Default)
             }
         }
@@ -45,11 +44,7 @@ class SocialLinkViewModel @Inject constructor(
     suspend fun fetchSocialProvidersNew() {
         runCatching {
             _socialLinkUiState.emit(userRepository.getSocialProviders().socialLinkUiState())
-        }.onFailure { e ->
-            if (e is ErrorParsedHttpException) {
-                _toastState.emit(e.errorDTO?.displayMessage ?: "")
-            }
-        }
+        }.onFailure(apiOnError)
     }
 
     suspend fun fetchUserInfo() {
@@ -60,8 +55,14 @@ class SocialLinkViewModel @Inject constructor(
         _socialProviders.emit(userRepository.getSocialProviders())
     } // TODO: 삭제
 
-    suspend fun connectFacebook(token: String) {
-        userRepository.postUserFacebook(token)
+    fun connectFacebook(token: String) {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.postUserFacebook(token)
+                fetchUserInfo()
+                fetchSocialProvidersNew()
+            }.onFailure(apiOnError)
+        }
     }
 
     suspend fun connectKakao(token: String) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -75,12 +75,20 @@ class SocialLinkViewModel @Inject constructor(
         }
     }
 
-    suspend fun connectGoogle(token: String) {
-        userRepository.postUserGoogle(token)
+    fun connectGoogle(token: String) {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.postUserGoogle(token)
+                fetchUserInfo()
+                fetchSocialProvidersNew()
+            }.onFailure(apiOnError)
+        }
     }
 
     suspend fun getAccessTokenByAuthCode(authCode: String, clientId: String, clientSecret: String): String? {
-        return userRepository.getAccessTokenByAuthCode(authCode = authCode, clientId = clientId, clientSecret = clientSecret)
+        return runCatching {
+            userRepository.getAccessTokenByAuthCode(authCode = authCode, clientId = clientId, clientSecret = clientSecret)
+        }.getOrNull()
     }
 
     suspend fun disconnectSocialLogin(type: SocialLoginType) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
 import com.wafflestudio.snutt2.model.SocialLoginType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -20,6 +21,9 @@ class SocialLinkViewModel @Inject constructor(
 
     private val _disconnectSocialDialogState: MutableStateFlow<SocialLoginType> = MutableStateFlow(SocialLoginType.NONE)
     val disconnectSocialDialogState = _disconnectSocialDialogState.asStateFlow()
+
+    private val _toastState: MutableSharedFlow<String> = MutableSharedFlow()
+    val toastState = _toastState
 
     suspend fun fetchUserInfo() {
         userRepository.fetchUserInfo()
@@ -69,6 +73,12 @@ class SocialLinkViewModel @Inject constructor(
     fun changeDialogState(type: SocialLoginType) {
         viewModelScope.launch {
             _disconnectSocialDialogState.emit(type)
+        }
+    }
+
+    fun showToast(message: String) {
+        viewModelScope.launch {
+            _toastState.emit(message)
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
 import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
 import com.wafflestudio.snutt2.model.SocialLoginType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,13 +26,39 @@ class SocialLinkViewModel @Inject constructor(
     private val _toastState: MutableSharedFlow<String> = MutableSharedFlow()
     val toastState = _toastState
 
+    private val _socialLinkUiState: MutableStateFlow<SocialLinkUiState> = MutableStateFlow(SocialLinkUiState.Default)
+    val socialLinkUiState = _socialLinkUiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            runCatching {
+                fetchSocialProvidersNew()
+            }.onFailure { e ->
+                if (e is ErrorParsedHttpException) {
+                    _toastState.emit(e.errorDTO?.displayMessage ?: "")
+                }
+                _socialLinkUiState.emit(SocialLinkUiState.Default)
+            }
+        }
+    }
+
+    suspend fun fetchSocialProvidersNew() {
+        runCatching {
+            _socialLinkUiState.emit(userRepository.getSocialProviders().socialLinkUiState())
+        }.onFailure { e ->
+            if (e is ErrorParsedHttpException) {
+                _toastState.emit(e.errorDTO?.displayMessage ?: "")
+            }
+        }
+    }
+
     suspend fun fetchUserInfo() {
         userRepository.fetchUserInfo()
     }
 
     suspend fun fetchSocialProviders() {
         _socialProviders.emit(userRepository.getSocialProviders())
-    }
+    } // TODO: 삭제
 
     suspend fun connectFacebook(token: String) {
         userRepository.postUserFacebook(token)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -1,12 +1,14 @@
 package com.wafflestudio.snutt2.views.logged_in.home.settings
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
 import com.wafflestudio.snutt2.model.SocialLoginType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -15,6 +17,9 @@ class SocialLinkViewModel @Inject constructor(
 ) : ViewModel() {
     private val _socialProviders: MutableStateFlow<GetSocialProvidersResults> = MutableStateFlow(GetSocialProvidersResults(false, false, false, false, false))
     val socialProviders = _socialProviders.asStateFlow()
+
+    private val _disconnectSocialDialogState: MutableStateFlow<SocialLoginType> = MutableStateFlow(SocialLoginType.NONE)
+    val disconnectSocialDialogState = _disconnectSocialDialogState.asStateFlow()
 
     suspend fun fetchUserInfo() {
         userRepository.fetchUserInfo()
@@ -59,5 +64,11 @@ class SocialLinkViewModel @Inject constructor(
 
     private suspend fun disconnectGoogle() {
         userRepository.deleteUserGoogle()
+    }
+
+    fun changeDialogState(type: SocialLoginType) {
+        viewModelScope.launch {
+            _disconnectSocialDialogState.emit(type)
+        }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -65,8 +65,14 @@ class SocialLinkViewModel @Inject constructor(
         }
     }
 
-    suspend fun connectKakao(token: String) {
-        userRepository.postUserKakao(token)
+    fun connectKakao(token: String) {
+        viewModelScope.launch {
+            runCatching {
+                userRepository.postUserKakao(token)
+                fetchUserInfo()
+                fetchSocialProvidersNew()
+            }.onFailure(apiOnError)
+        }
     }
 
     suspend fun connectGoogle(token: String) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkViewModel.kt
@@ -33,7 +33,7 @@ class SocialLinkViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             runCatching {
-                fetchSocialProvidersNew()
+                fetchSocialProviders()
             }.onFailure { e ->
                 apiOnError(e)
                 _socialLinkUiState.emit(SocialLinkUiState.Default)
@@ -41,26 +41,22 @@ class SocialLinkViewModel @Inject constructor(
         }
     }
 
-    suspend fun fetchSocialProvidersNew() {
+    private suspend fun fetchSocialProviders() {
         runCatching {
             _socialLinkUiState.emit(userRepository.getSocialProviders().socialLinkUiState())
         }.onFailure(apiOnError)
     }
 
-    suspend fun fetchUserInfo() {
+    private suspend fun fetchUserInfo() {
         userRepository.fetchUserInfo()
     }
-
-    suspend fun fetchSocialProviders() {
-        _socialProviders.emit(userRepository.getSocialProviders())
-    } // TODO: 삭제
 
     fun connectFacebook(token: String) {
         viewModelScope.launch {
             runCatching {
                 userRepository.postUserFacebook(token)
                 fetchUserInfo()
-                fetchSocialProvidersNew()
+                fetchSocialProviders()
             }.onFailure(apiOnError)
         }
     }
@@ -70,7 +66,7 @@ class SocialLinkViewModel @Inject constructor(
             runCatching {
                 userRepository.postUserKakao(token)
                 fetchUserInfo()
-                fetchSocialProvidersNew()
+                fetchSocialProviders()
             }.onFailure(apiOnError)
         }
     }
@@ -80,7 +76,7 @@ class SocialLinkViewModel @Inject constructor(
             runCatching {
                 userRepository.postUserGoogle(token)
                 fetchUserInfo()
-                fetchSocialProvidersNew()
+                fetchSocialProviders()
             }.onFailure(apiOnError)
         }
     }
@@ -88,15 +84,21 @@ class SocialLinkViewModel @Inject constructor(
     suspend fun getAccessTokenByAuthCode(authCode: String, clientId: String, clientSecret: String): String? {
         return runCatching {
             userRepository.getAccessTokenByAuthCode(authCode = authCode, clientId = clientId, clientSecret = clientSecret)
-        }.getOrNull()
+        }.onFailure(apiOnError).getOrNull()
     }
 
-    suspend fun disconnectSocialLogin(type: SocialLoginType) {
-        when (type) {
-            SocialLoginType.FACEBOOK -> disconnectFacebook()
-            SocialLoginType.KAKAO -> disconnectKakao()
-            SocialLoginType.GOOGLE -> disconnectGoogle()
-            else -> {}
+    fun disconnectSocialLogin(type: SocialLoginType) {
+        viewModelScope.launch {
+            runCatching {
+                when (type) {
+                    SocialLoginType.FACEBOOK -> disconnectFacebook()
+                    SocialLoginType.KAKAO -> disconnectKakao()
+                    SocialLoginType.GOOGLE -> disconnectGoogle()
+                    else -> {}
+                }
+                fetchUserInfo()
+                fetchSocialProviders()
+            }.onFailure(apiOnError)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,12 +91,8 @@
     <string name="sign_in_sign_in_google_failed_unknown">구글 로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.</string>
     <string name="social_link_title">SNS 계정 연동 및 해제</string>
     <string name="social_link_account_already_using">이미 사용 중인 이메일입니다.\n%s 계정으로 시도해 보세요.</string>
-    <string name="social_link_kakao">카카오 계정 연동</string>
-    <string name="social_link_google">구글 계정 연동</string>
-    <string name="social_link_facebook">페이스북 계정 연동</string>
-    <string name="social_unlink_kakao">카카오 계정 연동 해제</string>
-    <string name="social_unlink_google">구글 계정 연동 해제</string>
-    <string name="social_unlink_facebook">페이스북 계정 연동 해제</string>
+    <string name="social_link">%s 계정 연동</string>
+    <string name="social_unlink">%s 계정 연동 해제</string>
     <string name="sign_in_kakao_failed_cancelled">카카오 로그인이 취소되었습니다.</string>
     <string name="sign_in_kakao_failed_unknown">카카오 로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.</string>
     <string name="sign_in_facebook_failed_cancelled">페이스북 로그인이 취소되었습니다.</string>


### PR DESCRIPTION
- launchSuspendApi 사용 X. 단, ApiOnError는 사용함. ViewModel에서... 그냥 이것저것 찾아본 결과 ViewModel에서 runCatching 하는게 최선이라고 결론
- toast state를 어디에서 관리할까 상당히 고민했는데 state 자체는 ViewModel에서 관리, 컴포저블에서 collect
- TutorialPage와의 호환성을 지키기 위한 흔적이 있음
- Preview 추가했고 잘 되긴 하는데 내부에서 가져다쓰는 SettingsItem이 아직 Preview가 안돼서 결과적으로 전체가 안됨