### PR TITLE
refactor: SettingsPage 개편 (Route-Screen 구조 + uiState)

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -79,7 +79,7 @@ val LocalNavBottomSheetState = compositionLocalOf<ModalBottomSheetState> {
 }
 
 val LocalAnalyticsLogger = compositionLocalOf<AnalyticsLogger> {
-    object: AnalyticsLogger {
+    object : AnalyticsLogger {
         override fun logEvent(event: AnalyticsEvent) {}
         override fun logScreen(screen: AnalyticsScreen) {}
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/GlobalContext.kt
@@ -11,7 +11,9 @@ import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.components.compose.BottomSheet
 import com.wafflestudio.snutt2.components.compose.ModalState
 import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
+import com.wafflestudio.snutt2.lib.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.lib.logging.AnalyticsLogger
+import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.network.ApiOnError
 import com.wafflestudio.snutt2.lib.network.ApiOnProgress
 import com.wafflestudio.snutt2.ui.ThemeMode
@@ -77,5 +79,8 @@ val LocalNavBottomSheetState = compositionLocalOf<ModalBottomSheetState> {
 }
 
 val LocalAnalyticsLogger = compositionLocalOf<AnalyticsLogger> {
-    throw RuntimeException("")
+    object: AnalyticsLogger {
+        override fun logEvent(event: AnalyticsEvent) {}
+        override fun logScreen(screen: AnalyticsScreen) {}
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -178,6 +178,9 @@ fun HomePage() {
                         onNavigateThemeMarket = {
                             navController.navigate(NavigationDestination.ThemeMarket)
                         },
+                        onNavigatePushPreference = {
+                            navController.navigate(NavigationDestination.PushPreferences)
+                        },
                         onNavigateLectureDiary = {
                             navController.navigate(NavigationDestination.LectureDiary)
                         },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -1,13 +1,25 @@
 package com.wafflestudio.snutt2.views.logged_in.home
 
+import NavigationDestination
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.DrawerValue
+import androidx.compose.material.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -22,17 +34,27 @@ import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
 import com.wafflestudio.snutt2.provider.TimetableWidgetProvider
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.isDarkMode
-import com.wafflestudio.snutt2.views.*
+import com.wafflestudio.snutt2.views.LocalApiOnError
+import com.wafflestudio.snutt2.views.LocalApiOnProgress
+import com.wafflestudio.snutt2.views.LocalBottomSheetState
+import com.wafflestudio.snutt2.views.LocalDrawerState
+import com.wafflestudio.snutt2.views.LocalHomePageController
+import com.wafflestudio.snutt2.views.LocalNavController
+import com.wafflestudio.snutt2.views.LocalPopupState
+import com.wafflestudio.snutt2.views.LocalReviewWebView
+import com.wafflestudio.snutt2.views.LocalTableState
+import com.wafflestudio.snutt2.views.launchSuspendApi
 import com.wafflestudio.snutt2.views.logged_in.home.friend.FriendsPage
 import com.wafflestudio.snutt2.views.logged_in.home.popups.Popup
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewPage
 import com.wafflestudio.snutt2.views.logged_in.home.search.SearchPage
 import com.wafflestudio.snutt2.views.logged_in.home.search.SearchViewModel
-import com.wafflestudio.snutt2.views.logged_in.home.settings.SettingsPage
+import com.wafflestudio.snutt2.views.logged_in.home.settings.SettingsRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TableState
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimetablePage
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimetableViewModel
+import com.wafflestudio.snutt2.views.navigateAsOrigin
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -48,6 +70,7 @@ fun HomePage() {
     val apiOnError = LocalApiOnError.current
     val popupState = LocalPopupState.current
     val bottomSheet = LocalBottomSheetState.current
+    val navController = LocalNavController.current
 
     val homeViewModel = hiltViewModel<HomeViewModel>()
     val userViewModel = hiltViewModel<UserViewModel>()
@@ -134,8 +157,52 @@ fun HomePage() {
                             ReviewPage()
                         }
                     }
+
                     HomeItem.Friends -> FriendsPage()
-                    HomeItem.Settings -> SettingsPage()
+                    HomeItem.Settings -> SettingsRoute(
+                        onNavigateUserConfig = {
+                            navController.navigate(NavigationDestination.UserConfig)
+                        },
+                        onNavigateThemeModeSelect = {
+                            navController.navigate(NavigationDestination.ThemeModeSelect)
+                        },
+                        onNavigateTimeTableConfig = {
+                            navController.navigate(NavigationDestination.TimeTableConfig)
+                        },
+                        onNavigateThemeConfig = {
+                            navController.navigate(NavigationDestination.ThemeConfig)
+                        },
+                        onNavigateVacancyNotification = {
+                            navController.navigate(NavigationDestination.VacancyNotification)
+                        },
+                        onNavigateThemeMarket = {
+                            navController.navigate(NavigationDestination.ThemeMarket)
+                        },
+                        onNavigateLectureDiary = {
+                            navController.navigate(NavigationDestination.LectureDiary)
+                        },
+                        onNavigateTeamInfo = {
+                            navController.navigate(NavigationDestination.TeamInfo)
+                        },
+                        onNavigateAppReport = {
+                            navController.navigate(NavigationDestination.AppReport)
+                        },
+                        onNavigateOpenLicenses = {
+                            navController.navigate(NavigationDestination.OpenLicenses)
+                        },
+                        onNavigateServiceInfo = {
+                            navController.navigate(NavigationDestination.ServiceInfo)
+                        },
+                        onNavigatePersonalInformationPolicy = {
+                            navController.navigate(NavigationDestination.PersonalInformationPolicy)
+                        },
+                        onNavigateNetworkLog = {
+                            navController.navigate(NavigationDestination.NetworkLog)
+                        },
+                        onNavigateOnboardAsOrigin = {
+                            navController.navigateAsOrigin(NavigationDestination.Onboard)
+                        },
+                    )
                 }
 
                 Box(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.views.logged_in.home.settings
 
-import NavigationDestination
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -14,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -25,7 +23,6 @@ import com.wafflestudio.snutt2.BuildConfig
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.*
 import com.wafflestudio.snutt2.lib.featureflag.FeatureFlag
-import com.wafflestudio.snutt2.lib.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.logImpression
 import com.wafflestudio.snutt2.ui.SNUTTColors
@@ -33,11 +30,10 @@ import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.onSurfaceVariant
 import com.wafflestudio.snutt2.views.*
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
-import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsRoute(
-    userViewModel: UserViewModel = hiltViewModel(),
+    viewModel: SettingsViewModel = hiltViewModel(),
     onNavigateUserConfig: () -> Unit,
     onNavigateThemeModeSelect: () -> Unit,
     onNavigateTimeTableConfig: () -> Unit,
@@ -53,7 +49,10 @@ fun SettingsRoute(
     onNavigateNetworkLog: () -> Unit,
     onNavigateOnboardAsOrigin: () -> Unit,
 ) {
+    val uiState by viewModel.settingsUiState.collectAsState()
+
     SettingsPage(
+        uiState = uiState,
         onClickUserConfig = onNavigateUserConfig,
         onClickThemeModeSelect = onNavigateThemeModeSelect,
         onClickTimeTableConfig = onNavigateTimeTableConfig,
@@ -76,6 +75,7 @@ fun SettingsRoute(
 
 @Composable
 fun SettingsPage(
+    uiState: SettingsUiState,
     onClickUserConfig: () -> Unit,
     onClickThemeModeSelect: () -> Unit,
     onClickTimeTableConfig: () -> Unit,
@@ -91,15 +91,7 @@ fun SettingsPage(
     onClickNetworkLog: () -> Unit,
     onConfirmLogout: () -> Unit,
 ) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val apiOnProgress = LocalApiOnProgress.current
-    val apiOnError = LocalApiOnError.current
-    val analyticsLogger = LocalAnalyticsLogger.current
-    val viewModel = hiltViewModel<UserViewModel>()
     var logoutDialogState by remember { mutableStateOf(false) }
-    val themeMode by viewModel.themeMode.collectAsState()
-    val user by userViewModel.userInfo.collectAsState()
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -115,176 +115,170 @@ fun SettingsScreen(
     onConfirmLogout: () -> Unit,
     onDismissLogout: () -> Unit,
 ) {
-    when (uiState) {
-        SettingsUiState.Loading -> {}
-        SettingsUiState.Error -> {}
-        is SettingsUiState.Success -> {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(SNUTTColors.SettingBackground)
-                    .logImpression(AnalyticsScreen.SettingsHome),
-            ) {
-                TopBar(
-                    // FIXME: 설정 글자가 중간에서 살짝 아래에 위치
-                    title = {
-                        Text(
-                            text = stringResource(R.string.timetable_app_bar_setting),
-                            style = SNUTTTypography.h2,
-                        )
-                    },
-                    navigationIcon = {
-                        HorizontalMoreIcon(
-                            modifier = Modifier.size(30.dp),
-                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                        )
-                    },
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SNUTTColors.SettingBackground)
+            .logImpression(AnalyticsScreen.SettingsHome),
+    ) {
+        TopBar(
+            // FIXME: 설정 글자가 중간에서 살짝 아래에 위치
+            title = {
+                Text(
+                    text = stringResource(R.string.timetable_app_bar_setting),
+                    style = SNUTTTypography.h2,
                 )
-                Column(
-                    modifier = Modifier
-                        .verticalScroll(rememberScrollState()),
+            },
+            navigationIcon = {
+                HorizontalMoreIcon(
+                    modifier = Modifier.size(30.dp),
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                )
+            },
+        )
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Margin(height = 10.dp)
+            SettingItem(
+                title = stringResource(R.string.user_settings_app_bar_title),
+                modifier = Modifier.height(66.dp),
+                leadingIcon = {
+                    PersonIcon(
+                        modifier = Modifier
+                            .size(22.dp)
+                            .padding(end = 5.dp),
+                    )
+                },
+                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                onClick = onClickUserConfig,
+            ) {
+                Text(
+                    text = uiState.userName,
+                    style = SNUTTTypography.body1.copy(
+                        color = SNUTTColors.Black500,
+                    ),
+                )
+            }
+            Margin(height = 10.dp)
+            SettingColumn {
+                SettingItem(
+                    title = stringResource(R.string.settings_select_color_mode_title),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickThemeModeSelect,
                 ) {
-                    Margin(height = 10.dp)
-                    SettingItem(
-                        title = stringResource(R.string.user_settings_app_bar_title),
-                        modifier = Modifier.height(66.dp),
-                        leadingIcon = {
-                            PersonIcon(
-                                modifier = Modifier
-                                    .size(22.dp)
-                                    .padding(end = 5.dp),
-                            )
-                        },
-                        settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                        onClick = onClickUserConfig,
-                    ) {
-                        Text(
-                            text = uiState.userName,
-                            style = SNUTTTypography.body1.copy(
-                                color = SNUTTColors.Black500,
-                            ),
-                        )
-                    }
-                    Margin(height = 10.dp)
-                    SettingColumn {
-                        SettingItem(
-                            title = stringResource(R.string.settings_select_color_mode_title),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickThemeModeSelect,
-                        ) {
-                            Text(
-                                text = uiState.themeModeName,
-                                style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
-                            )
-                        }
-                        SettingItem(
-                            title = stringResource(R.string.timetable_settings_app_bar_title),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickTimeTableConfig,
-                        )
-                        SettingItem(
-                            title = stringResource(R.string.settings_timetable_theme_config_title),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickThemeConfig,
-                        )
-                    }
-                    Margin(height = 10.dp)
-                    SettingColumn {
-                        SettingItem(
-                            title = stringResource(R.string.settings_item_vacancy),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            hasNextPage = true,
-                            onClick = onClickVacancyNotification,
-                        )
-                        if (FeatureFlag.THEME_MARKET.isEnabled) {
-                            SettingItem(
-                                title = stringResource(R.string.settings_item_theme_market),
-                                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                                hasNextPage = true,
-                                onClick = onClickThemeMarket,
-                            )
-                        }
-                        if (FeatureFlag.LECTURE_DIARY.isEnabled) {
-                            SettingItem(
-                                title = stringResource(R.string.settings_item_lecture_diary),
-                                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                                hasNextPage = true,
-                                onClick = onClickLectureDiary,
-                            )
-                        }
-                    }
-                    Margin(height = 10.dp)
-                    SettingColumn {
-                        SettingItem(
-                            title = stringResource(R.string.settings_version_info),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            hasNextPage = false,
-                        ) {
-                            Text(
-                                text = BuildConfig.VERSION_NAME,
-                                style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
-                            )
-                        }
-                        SettingItem(
-                            title = stringResource(R.string.settings_team_info),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickTeamInfo,
-                        )
-                    }
-                    Margin(height = 10.dp)
-                    SettingItem(
-                        title = stringResource(R.string.settings_app_report_title),
-                        settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                        onClick = onClickAppReport,
+                    Text(
+                        text = uiState.themeModeName,
+                        style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
                     )
-                    Margin(height = 10.dp)
-                    SettingColumn {
-                        SettingItem(
-                            title = stringResource(R.string.settings_licenses_title),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickOpenLicenses,
-                        )
-                        SettingItem(
-                            title = stringResource(R.string.settings_service_info),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickServiceInfo,
-                        )
-                        SettingItem(
-                            title = stringResource(R.string.settings_personal_information_policy),
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickPersonalInformationPolicy,
-                        )
-                    }
-                    Margin(height = 10.dp)
+                }
+                SettingItem(
+                    title = stringResource(R.string.timetable_settings_app_bar_title),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickTimeTableConfig,
+                )
+                SettingItem(
+                    title = stringResource(R.string.settings_timetable_theme_config_title),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickThemeConfig,
+                )
+            }
+            Margin(height = 10.dp)
+            SettingColumn {
+                SettingItem(
+                    title = stringResource(R.string.settings_item_vacancy),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    hasNextPage = true,
+                    onClick = onClickVacancyNotification,
+                )
+                if (FeatureFlag.THEME_MARKET.isEnabled) {
                     SettingItem(
-                        title = stringResource(R.string.settings_logout_title),
-                        titleColor = SNUTTColors.Red,
+                        title = stringResource(R.string.settings_item_theme_market),
                         settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                        onClick = onClickLogout,
+                        hasNextPage = true,
+                        onClick = onClickThemeMarket,
                     )
-
-                    if (BuildConfig.DEBUG) {
-                        Margin(height = 10.dp)
-                        SettingItem(
-                            title = "네트워크 로그",
-                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
-                            onClick = onClickNetworkLog,
-                        )
-                    }
-                    Margin(height = 10.dp)
+                }
+                if (FeatureFlag.LECTURE_DIARY.isEnabled) {
+                    SettingItem(
+                        title = stringResource(R.string.settings_item_lecture_diary),
+                        settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                        hasNextPage = true,
+                        onClick = onClickLectureDiary,
+                    )
                 }
             }
-
-            if (uiState.showLogoutDialog) {
-                CustomDialog(
-                    onDismiss = onDismissLogout,
-                    onConfirm = onConfirmLogout,
-                    title = stringResource(R.string.settings_logout_title),
-                    positiveButtonText = stringResource(R.string.settings_logout_title),
+            Margin(height = 10.dp)
+            SettingColumn {
+                SettingItem(
+                    title = stringResource(R.string.settings_version_info),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    hasNextPage = false,
                 ) {
-                    Text(text = stringResource(R.string.settings_logout_message), style = SNUTTTypography.body2)
+                    Text(
+                        text = BuildConfig.VERSION_NAME,
+                        style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
+                    )
                 }
+                SettingItem(
+                    title = stringResource(R.string.settings_team_info),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickTeamInfo,
+                )
             }
+            Margin(height = 10.dp)
+            SettingItem(
+                title = stringResource(R.string.settings_app_report_title),
+                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                onClick = onClickAppReport,
+            )
+            Margin(height = 10.dp)
+            SettingColumn {
+                SettingItem(
+                    title = stringResource(R.string.settings_licenses_title),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickOpenLicenses,
+                )
+                SettingItem(
+                    title = stringResource(R.string.settings_service_info),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickServiceInfo,
+                )
+                SettingItem(
+                    title = stringResource(R.string.settings_personal_information_policy),
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickPersonalInformationPolicy,
+                )
+            }
+            Margin(height = 10.dp)
+            SettingItem(
+                title = stringResource(R.string.settings_logout_title),
+                titleColor = SNUTTColors.Red,
+                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                onClick = onClickLogout,
+            )
+
+            if (BuildConfig.DEBUG) {
+                Margin(height = 10.dp)
+                SettingItem(
+                    title = "네트워크 로그",
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickNetworkLog,
+                )
+            }
+            Margin(height = 10.dp)
+        }
+    }
+
+    if (uiState.showLogoutDialog) {
+        CustomDialog(
+            onDismiss = onDismissLogout,
+            onConfirm = onConfirmLogout,
+            title = stringResource(R.string.settings_logout_title),
+            positiveButtonText = stringResource(R.string.settings_logout_title),
+        ) {
+            Text(text = stringResource(R.string.settings_logout_message), style = SNUTTTypography.body2)
         }
     }
 }
@@ -385,6 +379,6 @@ fun NewBadge(
 @Composable
 fun SettingsPagePreview() {
     SettingsScreen(
-        uiState = SettingsUiState.Success("양주현", "다크", false, listOf("빈자리 알림")), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
+        uiState = SettingsUiState("양주현", "다크", false, listOf("빈자리 알림")), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
     )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -1,13 +1,27 @@
 package com.wafflestudio.snutt2.views.logged_in.home.settings
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -21,14 +35,19 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wafflestudio.snutt2.BuildConfig
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.components.compose.*
+import com.wafflestudio.snutt2.components.compose.CustomDialog
+import com.wafflestudio.snutt2.components.compose.HorizontalMoreIcon
+import com.wafflestudio.snutt2.components.compose.PersonIcon
+import com.wafflestudio.snutt2.components.compose.RightArrowIcon
+import com.wafflestudio.snutt2.components.compose.TopBar
+import com.wafflestudio.snutt2.components.compose.clicks
 import com.wafflestudio.snutt2.lib.featureflag.FeatureFlag
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.logImpression
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.onSurfaceVariant
-import com.wafflestudio.snutt2.views.*
+import com.wafflestudio.snutt2.views.LocalRemoteConfig
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
 
 @Composable
@@ -136,7 +155,7 @@ fun SettingsPage(
                         onClick = onClickUserConfig,
                     ) {
                         Text(
-                            text = user?.nickname.toString(),
+                            text = uiState.userName,
                             style = SNUTTTypography.body1.copy(
                                 color = SNUTTColors.Black500,
                             ),
@@ -149,7 +168,7 @@ fun SettingsPage(
                             onClick = onClickThemeModeSelect,
                         ) {
                             Text(
-                                text = themeMode.toString(),
+                                text = uiState.themeMode.name,
                                 style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
                             )
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.home.settings
 
+import NavigationDestination
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -35,10 +36,55 @@ import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
 import kotlinx.coroutines.launch
 
 @Composable
+fun SettingsRoute(
+    onNavigateUserConfig: () -> Unit,
+    onNavigateThemeModeSelect: () -> Unit,
+    onNavigateTimeTableConfig: () -> Unit,
+    onNavigateThemeConfig: () -> Unit,
+    onNavigateVacancyNotification: () -> Unit,
+    onNavigateThemeMarket: () -> Unit,
+    onNavigateLectureDiary: () -> Unit,
+    onNavigateTeamInfo: () -> Unit,
+    onNavigateAppReport: () -> Unit,
+    onNavigateOpenLicenses: () -> Unit,
+    onNavigateServiceInfo: () -> Unit,
+    onNavigatePersonalInformationPolicy: () -> Unit,
+    onNavigateNetworkLog: () -> Unit,
+) {
+    SettingsPage(
+        onClickUserConfig = onNavigateUserConfig,
+        onClickThemeModeSelect = onNavigateThemeModeSelect,
+        onClickTimeTableConfig = onNavigateTimeTableConfig,
+        onClickThemeConfig = onNavigateThemeConfig,
+        onClickVacancyNotification = onNavigateVacancyNotification,
+        onClickThemeMarket = onNavigateThemeMarket,
+        onClickLectureDiary = onNavigateLectureDiary,
+        onClickTeamInfo = onNavigateTeamInfo,
+        onClickAppReport = onNavigateAppReport,
+        onClickOpenLicenses = onNavigateOpenLicenses,
+        onClickServiceInfo = onNavigateServiceInfo,
+        onClickPersonalInformationPolicy = onNavigatePersonalInformationPolicy,
+        onClickNetworkLog = onNavigateNetworkLog,
+    )
+}
+
+@Composable
 fun SettingsPage(
     userViewModel: UserViewModel = hiltViewModel(),
+    onClickUserConfig: () -> Unit,
+    onClickThemeModeSelect: () -> Unit,
+    onClickTimeTableConfig: () -> Unit,
+    onClickThemeConfig: () -> Unit,
+    onClickVacancyNotification: () -> Unit,
+    onClickThemeMarket: () -> Unit,
+    onClickLectureDiary: () -> Unit,
+    onClickTeamInfo: () -> Unit,
+    onClickAppReport: () -> Unit,
+    onClickOpenLicenses: () -> Unit,
+    onClickServiceInfo: () -> Unit,
+    onClickPersonalInformationPolicy: () -> Unit,
+    onClickNetworkLog: () -> Unit,
 ) {
-    val navController = LocalNavController.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val apiOnProgress = LocalApiOnProgress.current
@@ -85,11 +131,7 @@ fun SettingsPage(
                             .padding(end = 5.dp),
                     )
                 },
-                onClick = {
-                    navController.navigate(
-                        NavigationDestination.UserConfig,
-                    )
-                },
+                onClick = onClickUserConfig,
             ) {
                 Text(
                     text = user?.nickname.toString(),
@@ -102,11 +144,7 @@ fun SettingsPage(
             SettingColumn {
                 SettingItem(
                     title = stringResource(R.string.settings_select_color_mode_title),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.ThemeModeSelect,
-                        )
-                    },
+                    onClick = onClickThemeModeSelect,
                 ) {
                     Text(
                         text = themeMode.toString(),
@@ -115,19 +153,11 @@ fun SettingsPage(
                 }
                 SettingItem(
                     title = stringResource(R.string.timetable_settings_app_bar_title),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.TimeTableConfig,
-                        )
-                    },
+                    onClick = onClickTimeTableConfig,
                 )
                 SettingItem(
                     title = stringResource(R.string.settings_timetable_theme_config_title),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.ThemeConfig,
-                        )
-                    },
+                    onClick = onClickThemeConfig,
                 )
             }
             Margin(height = 10.dp)
@@ -135,32 +165,20 @@ fun SettingsPage(
                 SettingItem(
                     title = stringResource(R.string.settings_item_vacancy),
                     hasNextPage = true,
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.VacancyNotification,
-                        )
-                    },
+                    onClick = onClickVacancyNotification,
                 )
                 if (FeatureFlag.THEME_MARKET.isEnabled) {
                     SettingItem(
                         title = stringResource(R.string.settings_item_theme_market),
                         hasNextPage = true,
-                        onClick = {
-                            navController.navigate(
-                                NavigationDestination.ThemeMarket,
-                            )
-                        },
+                        onClick = onClickThemeMarket,
                     )
                 }
                 if (FeatureFlag.LECTURE_DIARY.isEnabled) {
                     SettingItem(
                         title = stringResource(R.string.settings_item_lecture_diary),
                         hasNextPage = true,
-                        onClick = {
-                            navController.navigate(
-                                NavigationDestination.LectureDiary,
-                            )
-                        },
+                        onClick = onClickLectureDiary,
                     )
                 }
             }
@@ -177,47 +195,27 @@ fun SettingsPage(
                 }
                 SettingItem(
                     title = stringResource(R.string.settings_team_info),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.TeamInfo,
-                        )
-                    },
+                    onClick = onClickTeamInfo,
                 )
             }
             Margin(height = 10.dp)
             SettingItem(
                 title = stringResource(R.string.settings_app_report_title),
-                onClick = {
-                    navController.navigate(
-                        NavigationDestination.AppReport,
-                    )
-                },
+                onClick = onClickAppReport,
             )
             Margin(height = 10.dp)
             SettingColumn {
                 SettingItem(
                     title = stringResource(R.string.settings_licenses_title),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.OpenLicenses,
-                        )
-                    },
+                    onClick = onClickOpenLicenses,
                 )
                 SettingItem(
                     title = stringResource(R.string.settings_service_info),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.ServiceInfo,
-                        )
-                    },
+                    onClick = onClickServiceInfo,
                 )
                 SettingItem(
                     title = stringResource(R.string.settings_personal_information_policy),
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.PersonalInformationPolicy,
-                        )
-                    },
+                    onClick = onClickPersonalInformationPolicy,
                 )
             }
             Margin(height = 10.dp)
@@ -233,9 +231,7 @@ fun SettingsPage(
                 Margin(height = 10.dp)
                 SettingItem(
                     title = "네트워크 로그",
-                    onClick = {
-                        navController.navigate(NavigationDestination.NetworkLog)
-                    },
+                    onClick = onClickNetworkLog,
                 )
             }
             Margin(height = 10.dp)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -364,4 +365,12 @@ fun NewBadge(
                 ),
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsPagePreview() {
+    SettingsPage(
+        uiState = SettingsUiState.Success("양주현", "다크", false), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
+    )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsRoute(
+    userViewModel: UserViewModel = hiltViewModel(),
     onNavigateUserConfig: () -> Unit,
     onNavigateThemeModeSelect: () -> Unit,
     onNavigateTimeTableConfig: () -> Unit,
@@ -50,6 +51,7 @@ fun SettingsRoute(
     onNavigateServiceInfo: () -> Unit,
     onNavigatePersonalInformationPolicy: () -> Unit,
     onNavigateNetworkLog: () -> Unit,
+    onNavigateOnboardAsOrigin: () -> Unit,
 ) {
     SettingsPage(
         onClickUserConfig = onNavigateUserConfig,
@@ -65,12 +67,15 @@ fun SettingsRoute(
         onClickServiceInfo = onNavigateServiceInfo,
         onClickPersonalInformationPolicy = onNavigatePersonalInformationPolicy,
         onClickNetworkLog = onNavigateNetworkLog,
+        onConfirmLogout = {
+            // TODO
+            onNavigateOnboardAsOrigin()
+        },
     )
 }
 
 @Composable
 fun SettingsPage(
-    userViewModel: UserViewModel = hiltViewModel(),
     onClickUserConfig: () -> Unit,
     onClickThemeModeSelect: () -> Unit,
     onClickTimeTableConfig: () -> Unit,
@@ -84,6 +89,7 @@ fun SettingsPage(
     onClickServiceInfo: () -> Unit,
     onClickPersonalInformationPolicy: () -> Unit,
     onClickNetworkLog: () -> Unit,
+    onConfirmLogout: () -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -241,17 +247,7 @@ fun SettingsPage(
     if (logoutDialogState) {
         CustomDialog(
             onDismiss = { logoutDialogState = false },
-            onConfirm = {
-                scope.launch {
-                    launchSuspendApi(apiOnProgress, apiOnError) {
-                        analyticsLogger.logEvent(AnalyticsEvent.Logout)
-                        viewModel.forceLogout()
-                        viewModel.performLogout()
-                        logoutDialogState = false
-                        navController.navigateAsOrigin(NavigationDestination.Onboard)
-                    }
-                }
-            },
+            onConfirm = onConfirmLogout,
             title = stringResource(R.string.settings_logout_title),
             positiveButtonText = stringResource(R.string.settings_logout_title),
         ) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -387,6 +387,6 @@ fun NewBadge(
 @Composable
 fun SettingsPagePreview() {
     SettingsScreen(
-        uiState = SettingsUiState("양주현", "다크", false, listOf("빈자리 알림")), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
+        uiState = SettingsUiState("양주현", "다크", false, listOf("빈자리 알림")), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickPushPreference = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
     )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -17,11 +17,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -70,6 +68,12 @@ fun SettingsRoute(
 ) {
     val uiState by viewModel.settingsUiState.collectAsState()
 
+    LaunchedEffect(Unit) {
+        viewModel.logoutFinishedUiEvent.collect {
+            onNavigateOnboardAsOrigin()
+        }
+    }
+
     SettingsPage(
         uiState = uiState,
         onClickUserConfig = onNavigateUserConfig,
@@ -85,10 +89,9 @@ fun SettingsRoute(
         onClickServiceInfo = onNavigateServiceInfo,
         onClickPersonalInformationPolicy = onNavigatePersonalInformationPolicy,
         onClickNetworkLog = onNavigateNetworkLog,
-        onConfirmLogout = {
-            // TODO
-            onNavigateOnboardAsOrigin()
-        },
+        onClickLogout = viewModel::showLogoutDialog,
+        onConfirmLogout = viewModel::performLogout,
+        onDismissLogout = viewModel::hideLogoutDialog,
     )
 }
 
@@ -108,10 +111,10 @@ fun SettingsPage(
     onClickServiceInfo: () -> Unit,
     onClickPersonalInformationPolicy: () -> Unit,
     onClickNetworkLog: () -> Unit,
+    onClickLogout: () -> Unit,
     onConfirmLogout: () -> Unit,
+    onDismissLogout: () -> Unit,
 ) {
-    var logoutDialogState by remember { mutableStateOf(false) }
-
     when (uiState) {
         SettingsUiState.Loading -> {}
         SettingsUiState.Error -> {}
@@ -243,9 +246,7 @@ fun SettingsPage(
                     SettingItem(
                         title = stringResource(R.string.settings_logout_title),
                         titleColor = SNUTTColors.Red,
-                        onClick = {
-                            logoutDialogState = true
-                        },
+                        onClick = onClickLogout,
                     )
 
                     if (BuildConfig.DEBUG) {
@@ -258,17 +259,17 @@ fun SettingsPage(
                     Margin(height = 10.dp)
                 }
             }
-        }
-    }
 
-    if (logoutDialogState) {
-        CustomDialog(
-            onDismiss = { logoutDialogState = false },
-            onConfirm = onConfirmLogout,
-            title = stringResource(R.string.settings_logout_title),
-            positiveButtonText = stringResource(R.string.settings_logout_title),
-        ) {
-            Text(text = stringResource(R.string.settings_logout_message), style = SNUTTTypography.body2)
+            if (uiState.showLogoutDialog) {
+                CustomDialog(
+                    onDismiss = onDismissLogout,
+                    onConfirm = onConfirmLogout,
+                    title = stringResource(R.string.settings_logout_title),
+                    positiveButtonText = stringResource(R.string.settings_logout_title),
+                ) {
+                    Text(text = stringResource(R.string.settings_logout_message), style = SNUTTTypography.body2)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -74,7 +74,7 @@ fun SettingsRoute(
         }
     }
 
-    SettingsPage(
+    SettingsScreen(
         uiState = uiState,
         onClickUserConfig = onNavigateUserConfig,
         onClickThemeModeSelect = onNavigateThemeModeSelect,
@@ -96,7 +96,7 @@ fun SettingsRoute(
 }
 
 @Composable
-fun SettingsPage(
+fun SettingsScreen(
     uiState: SettingsUiState,
     onClickUserConfig: () -> Unit,
     onClickThemeModeSelect: () -> Unit,
@@ -384,7 +384,7 @@ fun NewBadge(
 @Preview(showBackground = true)
 @Composable
 fun SettingsPagePreview() {
-    SettingsPage(
+    SettingsScreen(
         uiState = SettingsUiState.Success("양주현", "다크", false, listOf("빈자리 알림")), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
     )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -57,6 +57,7 @@ fun SettingsRoute(
     onNavigateThemeConfig: () -> Unit,
     onNavigateVacancyNotification: () -> Unit,
     onNavigateThemeMarket: () -> Unit,
+    onNavigatePushPreference: () -> Unit,
     onNavigateLectureDiary: () -> Unit,
     onNavigateTeamInfo: () -> Unit,
     onNavigateAppReport: () -> Unit,
@@ -82,6 +83,7 @@ fun SettingsRoute(
         onClickThemeConfig = onNavigateThemeConfig,
         onClickVacancyNotification = onNavigateVacancyNotification,
         onClickThemeMarket = onNavigateThemeMarket,
+        onClickPushPreference = onNavigatePushPreference,
         onClickLectureDiary = onNavigateLectureDiary,
         onClickTeamInfo = onNavigateTeamInfo,
         onClickAppReport = onNavigateAppReport,
@@ -104,6 +106,7 @@ fun SettingsScreen(
     onClickThemeConfig: () -> Unit,
     onClickVacancyNotification: () -> Unit,
     onClickThemeMarket: () -> Unit,
+    onClickPushPreference: () -> Unit,
     onClickLectureDiary: () -> Unit,
     onClickTeamInfo: () -> Unit,
     onClickAppReport: () -> Unit,
@@ -203,11 +206,7 @@ fun SettingsScreen(
                 SettingItem(
                     title = stringResource(R.string.settings_item_push_preferences),
                     hasNextPage = true,
-                    onClick = {
-                        navController.navigate(
-                            NavigationDestination.PushPreferences,
-                        )
-                    },
+                    onClick = onClickPushPreference,
                 )
                 if (FeatureFlag.LECTURE_DIARY.isEnabled) {
                     SettingItem(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -93,146 +93,152 @@ fun SettingsPage(
 ) {
     var logoutDialogState by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(SNUTTColors.SettingBackground)
-            .logImpression(AnalyticsScreen.SettingsHome),
-    ) {
-        TopBar(
-            // FIXME: 설정 글자가 중간에서 살짝 아래에 위치
-            title = {
-                Text(
-                    text = stringResource(R.string.timetable_app_bar_setting),
-                    style = SNUTTTypography.h2,
-                )
-            },
-            navigationIcon = {
-                HorizontalMoreIcon(
-                    modifier = Modifier.size(30.dp),
-                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                )
-            },
-        )
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState()),
-        ) {
-            Margin(height = 10.dp)
-            SettingItem(
-                title = stringResource(R.string.user_settings_app_bar_title),
-                modifier = Modifier.height(66.dp),
-                leadingIcon = {
-                    PersonIcon(
-                        modifier = Modifier
-                            .size(22.dp)
-                            .padding(end = 5.dp),
-                    )
-                },
-                onClick = onClickUserConfig,
+    when (uiState) {
+        SettingsUiState.Loading -> {}
+        SettingsUiState.Error -> {}
+        is SettingsUiState.Success -> {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(SNUTTColors.SettingBackground)
+                    .logImpression(AnalyticsScreen.SettingsHome),
             ) {
-                Text(
-                    text = user?.nickname.toString(),
-                    style = SNUTTTypography.body1.copy(
-                        color = SNUTTColors.Black500,
-                    ),
+                TopBar(
+                    // FIXME: 설정 글자가 중간에서 살짝 아래에 위치
+                    title = {
+                        Text(
+                            text = stringResource(R.string.timetable_app_bar_setting),
+                            style = SNUTTTypography.h2,
+                        )
+                    },
+                    navigationIcon = {
+                        HorizontalMoreIcon(
+                            modifier = Modifier.size(30.dp),
+                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                        )
+                    },
                 )
-            }
-            Margin(height = 10.dp)
-            SettingColumn {
-                SettingItem(
-                    title = stringResource(R.string.settings_select_color_mode_title),
-                    onClick = onClickThemeModeSelect,
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState()),
                 ) {
-                    Text(
-                        text = themeMode.toString(),
-                        style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
-                    )
-                }
-                SettingItem(
-                    title = stringResource(R.string.timetable_settings_app_bar_title),
-                    onClick = onClickTimeTableConfig,
-                )
-                SettingItem(
-                    title = stringResource(R.string.settings_timetable_theme_config_title),
-                    onClick = onClickThemeConfig,
-                )
-            }
-            Margin(height = 10.dp)
-            SettingColumn {
-                SettingItem(
-                    title = stringResource(R.string.settings_item_vacancy),
-                    hasNextPage = true,
-                    onClick = onClickVacancyNotification,
-                )
-                if (FeatureFlag.THEME_MARKET.isEnabled) {
+                    Margin(height = 10.dp)
                     SettingItem(
-                        title = stringResource(R.string.settings_item_theme_market),
-                        hasNextPage = true,
-                        onClick = onClickThemeMarket,
-                    )
-                }
-                if (FeatureFlag.LECTURE_DIARY.isEnabled) {
+                        title = stringResource(R.string.user_settings_app_bar_title),
+                        modifier = Modifier.height(66.dp),
+                        leadingIcon = {
+                            PersonIcon(
+                                modifier = Modifier
+                                    .size(22.dp)
+                                    .padding(end = 5.dp),
+                            )
+                        },
+                        onClick = onClickUserConfig,
+                    ) {
+                        Text(
+                            text = user?.nickname.toString(),
+                            style = SNUTTTypography.body1.copy(
+                                color = SNUTTColors.Black500,
+                            ),
+                        )
+                    }
+                    Margin(height = 10.dp)
+                    SettingColumn {
+                        SettingItem(
+                            title = stringResource(R.string.settings_select_color_mode_title),
+                            onClick = onClickThemeModeSelect,
+                        ) {
+                            Text(
+                                text = themeMode.toString(),
+                                style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
+                            )
+                        }
+                        SettingItem(
+                            title = stringResource(R.string.timetable_settings_app_bar_title),
+                            onClick = onClickTimeTableConfig,
+                        )
+                        SettingItem(
+                            title = stringResource(R.string.settings_timetable_theme_config_title),
+                            onClick = onClickThemeConfig,
+                        )
+                    }
+                    Margin(height = 10.dp)
+                    SettingColumn {
+                        SettingItem(
+                            title = stringResource(R.string.settings_item_vacancy),
+                            hasNextPage = true,
+                            onClick = onClickVacancyNotification,
+                        )
+                        if (FeatureFlag.THEME_MARKET.isEnabled) {
+                            SettingItem(
+                                title = stringResource(R.string.settings_item_theme_market),
+                                hasNextPage = true,
+                                onClick = onClickThemeMarket,
+                            )
+                        }
+                        if (FeatureFlag.LECTURE_DIARY.isEnabled) {
+                            SettingItem(
+                                title = stringResource(R.string.settings_item_lecture_diary),
+                                hasNextPage = true,
+                                onClick = onClickLectureDiary,
+                            )
+                        }
+                    }
+                    Margin(height = 10.dp)
+                    SettingColumn {
+                        SettingItem(
+                            title = stringResource(R.string.settings_version_info),
+                            hasNextPage = false,
+                        ) {
+                            Text(
+                                text = BuildConfig.VERSION_NAME,
+                                style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
+                            )
+                        }
+                        SettingItem(
+                            title = stringResource(R.string.settings_team_info),
+                            onClick = onClickTeamInfo,
+                        )
+                    }
+                    Margin(height = 10.dp)
                     SettingItem(
-                        title = stringResource(R.string.settings_item_lecture_diary),
-                        hasNextPage = true,
-                        onClick = onClickLectureDiary,
+                        title = stringResource(R.string.settings_app_report_title),
+                        onClick = onClickAppReport,
                     )
-                }
-            }
-            Margin(height = 10.dp)
-            SettingColumn {
-                SettingItem(
-                    title = stringResource(R.string.settings_version_info),
-                    hasNextPage = false,
-                ) {
-                    Text(
-                        text = BuildConfig.VERSION_NAME,
-                        style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
+                    Margin(height = 10.dp)
+                    SettingColumn {
+                        SettingItem(
+                            title = stringResource(R.string.settings_licenses_title),
+                            onClick = onClickOpenLicenses,
+                        )
+                        SettingItem(
+                            title = stringResource(R.string.settings_service_info),
+                            onClick = onClickServiceInfo,
+                        )
+                        SettingItem(
+                            title = stringResource(R.string.settings_personal_information_policy),
+                            onClick = onClickPersonalInformationPolicy,
+                        )
+                    }
+                    Margin(height = 10.dp)
+                    SettingItem(
+                        title = stringResource(R.string.settings_logout_title),
+                        titleColor = SNUTTColors.Red,
+                        onClick = {
+                            logoutDialogState = true
+                        },
                     )
-                }
-                SettingItem(
-                    title = stringResource(R.string.settings_team_info),
-                    onClick = onClickTeamInfo,
-                )
-            }
-            Margin(height = 10.dp)
-            SettingItem(
-                title = stringResource(R.string.settings_app_report_title),
-                onClick = onClickAppReport,
-            )
-            Margin(height = 10.dp)
-            SettingColumn {
-                SettingItem(
-                    title = stringResource(R.string.settings_licenses_title),
-                    onClick = onClickOpenLicenses,
-                )
-                SettingItem(
-                    title = stringResource(R.string.settings_service_info),
-                    onClick = onClickServiceInfo,
-                )
-                SettingItem(
-                    title = stringResource(R.string.settings_personal_information_policy),
-                    onClick = onClickPersonalInformationPolicy,
-                )
-            }
-            Margin(height = 10.dp)
-            SettingItem(
-                title = stringResource(R.string.settings_logout_title),
-                titleColor = SNUTTColors.Red,
-                onClick = {
-                    logoutDialogState = true
-                },
-            )
 
-            if (BuildConfig.DEBUG) {
-                Margin(height = 10.dp)
-                SettingItem(
-                    title = "네트워크 로그",
-                    onClick = onClickNetworkLog,
-                )
+                    if (BuildConfig.DEBUG) {
+                        Margin(height = 10.dp)
+                        SettingItem(
+                            title = "네트워크 로그",
+                            onClick = onClickNetworkLog,
+                        )
+                    }
+                    Margin(height = 10.dp)
+                }
             }
-            Margin(height = 10.dp)
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -46,7 +46,6 @@ import com.wafflestudio.snutt2.lib.logging.logImpression
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.ui.onSurfaceVariant
-import com.wafflestudio.snutt2.views.LocalRemoteConfig
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.Margin
 
 @Composable
@@ -156,6 +155,7 @@ fun SettingsPage(
                                     .padding(end = 5.dp),
                             )
                         },
+                        settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                         onClick = onClickUserConfig,
                     ) {
                         Text(
@@ -169,6 +169,7 @@ fun SettingsPage(
                     SettingColumn {
                         SettingItem(
                             title = stringResource(R.string.settings_select_color_mode_title),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickThemeModeSelect,
                         ) {
                             Text(
@@ -178,10 +179,12 @@ fun SettingsPage(
                         }
                         SettingItem(
                             title = stringResource(R.string.timetable_settings_app_bar_title),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickTimeTableConfig,
                         )
                         SettingItem(
                             title = stringResource(R.string.settings_timetable_theme_config_title),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickThemeConfig,
                         )
                     }
@@ -189,12 +192,14 @@ fun SettingsPage(
                     SettingColumn {
                         SettingItem(
                             title = stringResource(R.string.settings_item_vacancy),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             hasNextPage = true,
                             onClick = onClickVacancyNotification,
                         )
                         if (FeatureFlag.THEME_MARKET.isEnabled) {
                             SettingItem(
                                 title = stringResource(R.string.settings_item_theme_market),
+                                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                                 hasNextPage = true,
                                 onClick = onClickThemeMarket,
                             )
@@ -202,6 +207,7 @@ fun SettingsPage(
                         if (FeatureFlag.LECTURE_DIARY.isEnabled) {
                             SettingItem(
                                 title = stringResource(R.string.settings_item_lecture_diary),
+                                settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                                 hasNextPage = true,
                                 onClick = onClickLectureDiary,
                             )
@@ -211,6 +217,7 @@ fun SettingsPage(
                     SettingColumn {
                         SettingItem(
                             title = stringResource(R.string.settings_version_info),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             hasNextPage = false,
                         ) {
                             Text(
@@ -220,26 +227,31 @@ fun SettingsPage(
                         }
                         SettingItem(
                             title = stringResource(R.string.settings_team_info),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickTeamInfo,
                         )
                     }
                     Margin(height = 10.dp)
                     SettingItem(
                         title = stringResource(R.string.settings_app_report_title),
+                        settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                         onClick = onClickAppReport,
                     )
                     Margin(height = 10.dp)
                     SettingColumn {
                         SettingItem(
                             title = stringResource(R.string.settings_licenses_title),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickOpenLicenses,
                         )
                         SettingItem(
                             title = stringResource(R.string.settings_service_info),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickServiceInfo,
                         )
                         SettingItem(
                             title = stringResource(R.string.settings_personal_information_policy),
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickPersonalInformationPolicy,
                         )
                     }
@@ -247,6 +259,7 @@ fun SettingsPage(
                     SettingItem(
                         title = stringResource(R.string.settings_logout_title),
                         titleColor = SNUTTColors.Red,
+                        settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                         onClick = onClickLogout,
                     )
 
@@ -254,6 +267,7 @@ fun SettingsPage(
                         Margin(height = 10.dp)
                         SettingItem(
                             title = "네트워크 로그",
+                            settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                             onClick = onClickNetworkLog,
                         )
                     }
@@ -310,10 +324,10 @@ fun SettingItem(
     titleColor: Color = MaterialTheme.colors.onSurface,
     leadingIcon: @Composable () -> Unit = {},
     hasNextPage: Boolean = true,
+    settingPageNewBadgeTitles: List<String> = emptyList(),
     onClick: (() -> Unit)? = null,
     content: @Composable () -> Unit = {},
 ) {
-    val newSettingItems by LocalRemoteConfig.current.settingPageNewBadgeTitles.collectAsState(emptyList())
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -330,7 +344,7 @@ fun SettingItem(
                 color = titleColor,
             ),
         )
-        if (newSettingItems.contains(title)) {
+        if (settingPageNewBadgeTitles.contains(title)) {
             NewBadge(Modifier.padding(start = 5.dp))
         }
         Spacer(modifier = Modifier.weight(1f))
@@ -371,6 +385,6 @@ fun NewBadge(
 @Composable
 fun SettingsPagePreview() {
     SettingsPage(
-        uiState = SettingsUiState.Success("양주현", "다크", false), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
+        uiState = SettingsUiState.Success("양주현", "다크", false, listOf("빈자리 알림")), onClickUserConfig = {}, onClickThemeModeSelect = {}, onClickTimeTableConfig = {}, onClickThemeConfig = {}, onClickVacancyNotification = {}, onClickThemeMarket = {}, onClickLectureDiary = {}, onClickTeamInfo = {}, onClickAppReport = {}, onClickOpenLicenses = {}, onClickServiceInfo = {}, onClickPersonalInformationPolicy = {}, onClickNetworkLog = {}, onClickLogout = {}, onConfirmLogout = {}, onDismissLogout = {},
     )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsPage.kt
@@ -171,7 +171,7 @@ fun SettingsPage(
                             onClick = onClickThemeModeSelect,
                         ) {
                             Text(
-                                text = uiState.themeMode.name,
+                                text = uiState.themeModeName,
                                 style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
                             )
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -37,7 +37,7 @@ class SettingsViewModel @Inject constructor(
 
     fun hideLogoutDialog() {
         viewModelScope.launch {
-            showLogoutDialog.emit(true)
+            showLogoutDialog.emit(false)
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -48,10 +48,11 @@ class SettingsViewModel @Inject constructor(
                 analyticsLogger.logEvent(AnalyticsEvent.Logout)
                 userRepository.postForceLogout()
                 userRepository.performLogout()
-                showLogoutDialog.emit(false)
-                _logoutFinishedUiEvent.emit(Unit)
             }.onFailure {
                 showLogoutDialog.emit(false)
+            }.onSuccess {
+                showLogoutDialog.emit(false)
+                _logoutFinishedUiEvent.emit(Unit)
             }
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.settings
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.lib.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.lib.logging.AnalyticsLogger
@@ -21,6 +22,7 @@ class SettingsViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val userRepository: UserRepository,
     private val analyticsLogger: AnalyticsLogger,
+    private val remoteConfig: RemoteConfig,
 ) : ViewModel() {
 
     private val showLogoutDialog = MutableStateFlow(false)
@@ -58,7 +60,8 @@ class SettingsViewModel @Inject constructor(
         userRepository.user,
         userRepository.themeMode,
         showLogoutDialog,
-    ) { user, themeMode, showLogoutDialog ->
+        remoteConfig.settingPageNewBadgeTitles,
+    ) { user, themeMode, showLogoutDialog, settingPageNewBadgeTitles ->
         if (user == null) {
             return@combine SettingsUiState.Error
         }
@@ -67,6 +70,7 @@ class SettingsViewModel @Inject constructor(
             user.nickname?.nickname ?: "",
             themeMode.toString(),
             showLogoutDialog,
+            settingPageNewBadgeTitles,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.Loading)
 
@@ -78,6 +82,7 @@ sealed interface SettingsUiState {
         val userName: String,
         val themeModeName: String,
         val showLogoutDialog: Boolean,
+        val settingPageNewBadgeTitles: List<String>,
     ) : SettingsUiState
 
     data object Loading : SettingsUiState

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -4,23 +4,62 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.lib.logging.AnalyticsEvent
+import com.wafflestudio.snutt2.lib.logging.AnalyticsLogger
 import com.wafflestudio.snutt2.ui.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
-    userRepository: UserRepository,
+    private val userRepository: UserRepository,
+    private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
+
+    private val showLogoutDialog = MutableStateFlow(false)
+
+    private val _logoutFinishedUiEvent: MutableSharedFlow<Unit> = MutableSharedFlow(replay = 1)
+    val logoutFinishedUiEvent = _logoutFinishedUiEvent.asSharedFlow()
+
+    fun showLogoutDialog() {
+        viewModelScope.launch {
+            showLogoutDialog.emit(true)
+        }
+    }
+
+    fun hideLogoutDialog() {
+        viewModelScope.launch {
+            showLogoutDialog.emit(true)
+        }
+    }
+
+    fun performLogout() {
+        viewModelScope.launch {
+            runCatching {
+                analyticsLogger.logEvent(AnalyticsEvent.Logout)
+                userRepository.postForceLogout()
+                userRepository.performLogout()
+                showLogoutDialog.emit(false)
+                _logoutFinishedUiEvent.emit(Unit)
+            }.onFailure {
+                showLogoutDialog.emit(false)
+            }
+        }
+    }
 
     val settingsUiState = combine(
         userRepository.user,
         userRepository.themeMode,
-    ) { user, themeMode ->
+        showLogoutDialog,
+    ) { user, themeMode, showLogoutDialog ->
         if (user == null) {
             return@combine SettingsUiState.Error
         }
@@ -28,6 +67,7 @@ class SettingsViewModel @Inject constructor(
         SettingsUiState.Success(
             user.nickname?.nickname ?: "",
             themeMode,
+            showLogoutDialog,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.Loading)
 
@@ -38,6 +78,7 @@ sealed interface SettingsUiState {
     data class Success(
         val userName: String,
         val themeMode: ThemeMode,
+        val showLogoutDialog: Boolean,
     ) : SettingsUiState
 
     data object Loading : SettingsUiState

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -73,9 +73,7 @@ class SettingsViewModel @Inject constructor(
             settingPageNewBadgeTitles,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.Loading)
-
 }
-
 
 sealed interface SettingsUiState {
     data class Success(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -64,26 +64,25 @@ class SettingsViewModel @Inject constructor(
         remoteConfig.settingPageNewBadgeTitles,
     ) { user, themeMode, showLogoutDialog, settingPageNewBadgeTitles ->
         if (user == null) {
-            return@combine SettingsUiState.Error
+            return@combine SettingsUiState.DEFAULT
         }
 
-        SettingsUiState.Success(
+        SettingsUiState(
             user.nickname?.nickname ?: "",
             themeMode.toString(),
             showLogoutDialog,
             settingPageNewBadgeTitles,
         )
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.Loading)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.DEFAULT)
 }
 
-sealed interface SettingsUiState {
-    data class Success(
-        val userName: String,
-        val themeModeName: String,
-        val showLogoutDialog: Boolean,
-        val settingPageNewBadgeTitles: List<String>,
-    ) : SettingsUiState
-
-    data object Loading : SettingsUiState
-    data object Error : SettingsUiState
+data class SettingsUiState(
+    val userName: String,
+    val themeModeName: String,
+    val showLogoutDialog: Boolean,
+    val settingPageNewBadgeTitles: List<String>,
+) {
+    companion object {
+        val DEFAULT = SettingsUiState("", "", false, emptyList())
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.snutt2.views.logged_in.home.settings
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.ui.ThemeMode
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    userRepository: UserRepository,
+) : ViewModel() {
+
+    val settingsUiState = combine(
+        userRepository.user,
+        userRepository.themeMode,
+    ) { user, themeMode ->
+        if (user == null) {
+            return@combine SettingsUiState.Error
+        }
+
+        SettingsUiState.Success(
+            user.nickname?.nickname ?: "",
+            themeMode,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.Loading)
+
+}
+
+
+sealed interface SettingsUiState {
+    data class Success(
+        val userName: String,
+        val themeMode: ThemeMode,
+    ) : SettingsUiState
+
+    data object Loading : SettingsUiState
+    data object Error : SettingsUiState
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.lib.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.lib.logging.AnalyticsLogger
-import com.wafflestudio.snutt2.ui.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -66,7 +65,7 @@ class SettingsViewModel @Inject constructor(
 
         SettingsUiState.Success(
             user.nickname?.nickname ?: "",
-            themeMode,
+            themeMode.toString(),
             showLogoutDialog,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.Loading)
@@ -77,7 +76,7 @@ class SettingsViewModel @Inject constructor(
 sealed interface SettingsUiState {
     data class Success(
         val userName: String,
-        val themeMode: ThemeMode,
+        val themeModeName: String,
         val showLogoutDialog: Boolean,
     ) : SettingsUiState
 


### PR DESCRIPTION
## 변경사항
- Route - Screen 구조로 바꾸고, uiState 만들어주기
- RemoteConfig 를 compositionalLocal 로 주입받고 있는 부분을 떼내고, uiState 로 내려주기
   - 리팩토링의 목적도 있지만, Preview 가 못 그려지는 문제도 있었던 부분

### 리뷰포인트
커밋별로 보면 좀 편함

대부분은 기계적인 작업이라 영양가는 없지만, 로그아웃 동작 개편한 거는 한번 보면 좋을듯 3e7dd051f62dfcb765884037003041545e72db87
현도랑은 저번에 얘기했던거지만, uiState 말고 uiEvent 도 두고 사용하기로 했고 요걸 적용했어  (뷰모델에서 로그아웃 관련 로직이 모두 끝나면 다이얼로그를 닫아줘야 하기 때문에, 이를 uiEvent 로 처리)
기존에는 로그아웃 다이얼로그를 보여주는 상태를 로컬 상태로 했지만, 로그아웃 비즈니스 로직(api 쏘고 로깅하고 등) 이 다이얼로그를 보여주는 상태에 영향을 주기 때문에 로컬 상태가 아니라 uiState 로 올렸어
