### PR TITLE
버전 코드 계산 방식 변경

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,2 +1,20 @@
 plugins { `kotlin-dsl` }
-repositories { mavenCentral() }
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    val junitJupiterVersion = "5.10.3" // 현재 최신 안정 버전 (확인 후 사용)
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events("PASSED", "SKIPPED", "FAILED", "STANDARD_OUT", "STANDARD_ERROR")
+        showStandardStreams = true // System.out, System.err 출력
+    }
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    val junitJupiterVersion = "5.10.3" // 현재 최신 안정 버전 (확인 후 사용)
+    val junitJupiterVersion = "5.10.3"
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
 }
@@ -15,6 +15,6 @@ tasks.test {
     useJUnitPlatform()
     testLogging {
         events("PASSED", "SKIPPED", "FAILED", "STANDARD_OUT", "STANDARD_ERROR")
-        showStandardStreams = true // System.out, System.err 출력
+        showStandardStreams = true
     }
 }

--- a/buildSrc/src/main/kotlin/SemVer.kt
+++ b/buildSrc/src/main/kotlin/SemVer.kt
@@ -6,10 +6,12 @@ object SemVer {
         val major = semVerRegex.find(semanticVersion)?.groupValues?.get(1)?.toLongOrNull() ?: 0L
         val minor = semVerRegex.find(semanticVersion)?.groupValues?.get(2)?.toLongOrNull() ?: 0L
         val patch = semVerRegex.find(semanticVersion)?.groupValues?.get(3)?.toLongOrNull() ?: 0L
+        // group 4는 "rc-N" 전체이고, group 5가 N이다.
+        val rc = semVerRegex.find(semanticVersion)?.groupValues?.get(5)?.toLongOrNull() ?: 99L
 
-        return listOf(major, minor, patch)
+        return listOf(major, minor, patch, rc)
             .fold(0L) { acc, next ->
                 acc * 100 + next
-            } + 2010000000L
+            } + 2100000000L
     }
 }

--- a/buildSrc/src/main/kotlin/SemVer.kt
+++ b/buildSrc/src/main/kotlin/SemVer.kt
@@ -12,6 +12,6 @@ object SemVer {
         return listOf(major, minor, patch, rc)
             .fold(0L) { acc, next ->
                 acc * 100 + next
-            } + 2100000000L
+            } + 2010000000L
     }
 }

--- a/buildSrc/src/test/kotlin/SemVerTest.kt
+++ b/buildSrc/src/test/kotlin/SemVerTest.kt
@@ -1,0 +1,50 @@
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("sementic version -> version code 변환 코드 테스트")
+class SemVerTest {
+    @Test
+    @DisplayName("기본 형식의 버전이 올바르게 변환되어야 한다")
+    fun semVerTest1() {
+        assert(
+            SemVer.sementicVersionToSerializedCode("3.9.2-rc.1").toInt()
+                == 2013090201
+        )
+    }
+
+    @Test
+    @DisplayName("두 자리의 rc 버전이 올바르게 변환되어야 한다")
+    fun semVerTest2() {
+        assert(
+            SemVer.sementicVersionToSerializedCode("4.3.8-rc.11").toInt()
+                == 2014030811
+        )
+    }
+
+    @Test
+    @DisplayName("rc가 없는 버전은 해당 마이너 버전의 최대인 99로 처리되어야 한다")
+    fun semVerTest3() {
+        assert(
+            SemVer.sementicVersionToSerializedCode("3.9.2").toInt()
+                == 2013090299
+        )
+    }
+
+    @Test
+    @DisplayName("두 자리의 마이너 버전이 올바르게 변환되어야 한다")
+    fun semVerTest4() {
+        assert(
+            SemVer.sementicVersionToSerializedCode("3.10.1-rc.1").toInt()
+                == 2013100101
+        )
+    }
+
+    @Test
+    @DisplayName("두 자리의 메이저 버전이 올바르게 변환되어야 하며, 앞에서 세 번째 자리에 반영된다")
+    fun semVerTest5() {
+        assert(
+            SemVer.sementicVersionToSerializedCode("10.0.0-rc.1").toInt()
+                == 2020000001
+        )
+    }
+}


### PR DESCRIPTION
원래 방식
- Aa.Bb.Cc -> 2010AaBbCc

바뀐 방식
- Aa.Bb.Cc-rc.Nn -> 20(A+1)aBbCcNn
- NN의 default는 99이므로, rc는 98까지 가능