### PR TITLE
사용자 이름에 태그가 안 보이는 현상 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SettingsViewModel.kt
@@ -68,7 +68,7 @@ class SettingsViewModel @Inject constructor(
         }
 
         SettingsUiState(
-            user.nickname?.nickname ?: "",
+            user.nickname.toString(),
             themeMode.toString(),
             showLogoutDialog,
             settingPageNewBadgeTitles,


### PR DESCRIPTION
- 더보기 탭에서 내 계정 옆에, 원래 태그까지 보여주고 있었는데 리팩토링 과정에서 없어져서 수정