### PR TITLE
shareScreenshot 방식 변경

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/ScreenshotUtil.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/ScreenshotUtil.kt
@@ -5,32 +5,42 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.net.Uri
-import android.view.View
 import androidx.core.content.FileProvider
 import com.facebook.FacebookSdk
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.SNUTTUtils.displayHeight
+import com.wafflestudio.snutt2.SNUTTUtils.displayWidth
+import com.wafflestudio.snutt2.components.view.TimetableView
+import com.wafflestudio.snutt2.lib.network.dto.core.TableDto
+import com.wafflestudio.snutt2.model.TableTrimParam
 import java.io.File
 import java.io.FileOutputStream
 
-fun shareScreenshotFromView(
-    view: View,
+fun shareScreenshot(
+    table: TableDto,
+    tableTrimParam: TableTrimParam,
     context: Context,
-    topBarHeight: Int,
-    bannerHeight: Int,
-    timetableHeight: Int,
 ) {
+    val view = TimetableView(context)
+    view.theme = table.theme
+    view.lectures = table.lectureList
+    view.trimParam = tableTrimParam
+
+    val width = context.displayWidth.toInt()
+    val height = context.displayHeight.toInt()
+    view.measure(width, height)
+    view.layout(0, 0, width, height)
+
     val bitmap =
         Bitmap.createBitmap(
-            view.measuredWidth,
-            view.measuredHeight,
+            view.width,
+            view.height,
             Bitmap.Config.ARGB_8888,
         )
     val canvas = Canvas(bitmap)
     view.draw(canvas)
 
-    // FIXME: 이 방법의 문제점 -> 위아래를 잘라내야 한다.
-    val bitmapResized = Bitmap.createBitmap(bitmap, 0, topBarHeight + bannerHeight, bitmap.width, timetableHeight)
-    val uri = bitmapToUri(bitmapResized, context)
+    val uri = bitmapToUri(bitmap, context)
     val shareIntent: Intent = Intent().apply {
         action = Intent.ACTION_SEND
         putExtra(Intent.EXTRA_STREAM, uri)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/timetable/TimetablePage.kt
@@ -15,16 +15,12 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -43,7 +39,7 @@ import com.wafflestudio.snutt2.components.compose.clicks
 import com.wafflestudio.snutt2.lib.data.SNUTTStringUtils.getCreditSumFromLectureList
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.lib.shareScreenshotFromView
+import com.wafflestudio.snutt2.lib.shareScreenshot
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.SNUTTTypography
 import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
@@ -59,10 +55,11 @@ import kotlinx.coroutines.launch
 fun TimetablePage(uncheckedNotification: Boolean) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
-    val view = LocalView.current
+
     val navController = LocalNavController.current
     val drawerState = LocalDrawerState.current
     val table = LocalTableState.current.table
+    val tableTrimParam = LocalTableState.current.trimParam
     val remoteConfig = LocalRemoteConfig.current
     val composableStates = ComposableStatesWithScope(scope)
     val tableListViewModel = hiltViewModel<TableListViewModel>()
@@ -70,20 +67,12 @@ fun TimetablePage(uncheckedNotification: Boolean) {
     val vacancyNotificationBannerEnabled by remoteConfig.vacancyNotificationBannerEnabled.collectAsState(false)
     val analyticsLogger = LocalAnalyticsLogger.current
 
-    var timetableHeight by remember { mutableStateOf(0) }
-    var topBarHeight by remember { mutableStateOf(0) }
-    var bannerHeight by remember { mutableStateOf(0) }
-
     Column(
         modifier = Modifier
             .background(SNUTTColors.White900)
             .logImpression(AnalyticsScreen.TimetableHome),
     ) {
         TopBar(
-            // top bar 높이 측정
-            modifier = Modifier.onGloballyPositioned {
-                topBarHeight = it.size.height
-            },
             title = {
                 Text(
                     text = table.title,
@@ -131,12 +120,10 @@ fun TimetablePage(uncheckedNotification: Boolean) {
                     modifier = Modifier
                         .size(30.dp)
                         .clicks {
-                            shareScreenshotFromView(
-                                view,
+                            shareScreenshot(
+                                table,
+                                tableTrimParam,
                                 context,
-                                topBarHeight,
-                                if (vacancyNotificationBannerEnabled) bannerHeight else 0,
-                                timetableHeight,
                             )
                             analyticsLogger.logScreen(AnalyticsScreen.TimetableShare) // 안드로이드에는 TimetableShare 화면이 따로 없지만, iOS와의 통일성을 위해 공유 버튼 클릭 시 로깅한다.
                         },
@@ -156,15 +143,12 @@ fun TimetablePage(uncheckedNotification: Boolean) {
                 onClick = {
                     navController.navigate(NavigationDestination.VacancyNotification)
                 },
-                modifier = Modifier
-                    .onGloballyPositioned { bannerHeight = it.size.height },
             )
         }
         Box(
             modifier = Modifier
                 .weight(1f)
-                .fillMaxWidth()
-                .onGloballyPositioned { timetableHeight = it.size.height }, // timetable 높이 측정
+                .fillMaxWidth(),
         ) {
             TimeTable(selectedLecture = null)
         }


### PR DESCRIPTION
### 기존 방식
- 현재 보여지고 있는 시간표 화면을 View로 담아서 `shareScreenshotFromView()`로 전달한다.
- 여기에는 TopBar, Banner가 포함되기 때문에, `topBarHeight`, `bannerHeight`, `timetableHeight` 값을 외부에서 계산해서 넣어준다.
- 이 잘라진 Bitmap을 Uri로 변환하여 공유할 수 있다.

### 바뀐 방식
- table을 `shareScreenshot()`으로 전달한다.
- 그러면 내부에서 시간표만 담는 `TimeTableView`를 생성한다. (기존에는 위젯에 사용하던 코드)
- 이걸 Bitmap으로 그려서 Uri로 변환하면 된다.

### 장점과 한계점
- 현재 화면에 보여지고 있지 않은 table이더라도, 어떤 table이든 전달하면 사진으로 만들 수 있다.
- `topBarHeight`, `bannerHeight`, `timetableHeight` 값을 계산하지 않아도 된다.
- targetSDK 35 변경의 영향을 받지 않는다. 기존 방식과 sdk 35가 합쳐지면, statusBar 만큼이 잘리는 현상이 있었다.
- 위젯에 사용하던 코드라 이곳저곳 마음에 들지 않는 곳이 있다.
- 외부 라이브러리를 통해 컴포저블 함수를 바로 스크린샷 하는 방식도 고민해봤으나 기존 코드와 잘 맞지 않아 기각했다.