### PR TITLE
onDispose에서 UiEvent 초기화

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -82,14 +83,17 @@ fun UserConfigRoute(
         }
     }
 
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.resetToastMessage()
+        }
+    }
+
     UserConfigScreen(
         modifier = modifier,
         uiState = uiState,
         onNavigateBack = onNavigateBack,
-        onNavigateChangeNickname = {
-            onNavigateChangeNickname()
-            viewModel.resetToastMessage()
-        },
+        onNavigateChangeNickname = onNavigateChangeNickname,
         onCopyNicknameToClipboard = {
             copyToClipboard(
                 context = context,
@@ -106,10 +110,7 @@ fun UserConfigRoute(
         onClickLeave = viewModel::showLeaveDialog,
         onConfirmLeave = viewModel::leave,
         onDismissLeave = viewModel::hideLeaveDialog,
-        onNavigateSocialLink = {
-            onNavigateSocialLink()
-            viewModel.resetToastMessage()
-        },
+        onNavigateSocialLink = onNavigateSocialLink,
     )
 }
 


### PR DESCRIPTION
- UserConfigPage 리팩토링 하면서 발생한 현상 ([링크](https://github.com/wafflestudio/snutt-android/pull/448#discussion_r2186848979))
- 정확히는 그런 현상이 발생하기 때문에 조금 불안정할 수 있는 임시 해결책을 사용했었음
- UserConfigPage에서 하위 페이지로 이동해 dispose 될 때 UiEvent를 초기화하는 방식으로 해결