### PR TITLE
DomainError 변환 함수에 Timber와 Firebase 로그 추가

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/ExceptionMapper.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/ExceptionMapper.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.lib.network
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import com.google.firebase.crashlytics.internal.common.CrashlyticsCore
 import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
 import kotlinx.coroutines.CancellationException
 import okio.IOException

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/ExceptionMapper.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/ExceptionMapper.kt
@@ -1,10 +1,15 @@
 package com.wafflestudio.snutt2.lib.network
 
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.internal.common.CrashlyticsCore
 import com.wafflestudio.snutt2.lib.network.call_adapter.ErrorParsedHttpException
 import kotlinx.coroutines.CancellationException
 import okio.IOException
+import timber.log.Timber
 
 fun Exception.toDomainError(): DomainError {
+    Timber.e(this)
+
     return when (this) {
         is IOException -> NetworkDisconnect("")
         is CancellationException -> Nothing("")
@@ -26,6 +31,9 @@ fun Exception.toDomainError(): DomainError {
                 else -> Unknown(displayMessage)
             }
         }
-        else -> Unknown("")
+        else -> {
+            FirebaseCrashlytics.getInstance().recordException(this)
+            Unknown("")
+        }
     }
 }


### PR DESCRIPTION
- 3.9.3에 UT 반영을 포함하지 않아서, #464 가 머지되지 않을 것이므로 별도 PR로 수정
- DomainError 변환 과정에서 기존과 동일하게 로그 기록