### PR TITLE
Firebase App Id를 env로 가져오도록 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,8 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Upload artifact to Firebase App Distribution
         run: ./gradlew appDistributionUploadLiveRelease
+        env:
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID_LIVE }}
       - name: Set Message
         run: |
           PROPERTY=$(head -n 1 version.properties)
@@ -122,6 +124,8 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Upload artifact to Firebase App Distribution
         run: ./gradlew appDistributionUploadStagingRelease
+        env:
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID_STAGING }}
       - name: Slack Upload APK
         uses: MeilCli/slack-upload-file@v3
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ android {
                 artifactType = "APK"
                 testers = "urban"
                 serviceCredentialsFile = "gcp-service-account-staging.json"
+                appId = System.getenv("FIREBASE_APP_ID")
             }
         }
 
@@ -102,6 +103,7 @@ android {
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "AAB"
                 serviceCredentialsFile = "gcp-service-account-live.json"
+                appId = System.getenv("FIREBASE_APP_ID")
             }
         }
     }


### PR DESCRIPTION
- 3.9.3에 UT 반영을 포함하지 않아서, #464 가 머지되지 않을 것이므로 별도 PR로 수정
- 기존에는 google-services.json을 읽어서 자동으로 가져오고 있었으나, 그 방식이 잘 작동하지 않도록 바뀌어서 수정