### PR TITLE
시간대 검색에서, 빈 시간대 선택 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TimeSelectSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TimeSelectSheet.kt
@@ -84,7 +84,8 @@ fun TimeSelectSheet(
             }
         }
         backgroundLectureTimes.forEach {
-            for (timeIndex in (it.startMinute - TableTrimParam.SearchOption.hourFrom * 60) / 30..(it.endMinute - TableTrimParam.SearchOption.hourFrom * 60) / 30) {
+            // endMinute에서 1을 빼주는데, endMinute이 30의 배수인 경우, 경계 값의 다음 block은 timeIndex에 포함되지 않아야하기 때문이다.
+            for (timeIndex in (it.startMinute - TableTrimParam.SearchOption.hourFrom * 60) / 30..(it.endMinute - TableTrimParam.SearchOption.hourFrom * 60 - 1) / 30) {
                 draggedTimeBlock[it.day][timeIndex].value = false
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TimeSelectSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/search_option/TimeSelectSheet.kt
@@ -56,6 +56,8 @@ import com.wafflestudio.snutt2.views.LocalTableState
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.DrawLectures
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.DrawTableGrid
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TimetableCanvasObjects
+import kotlin.math.max
+import kotlin.math.min
 
 @Composable
 fun TimeSelectSheet(
@@ -83,9 +85,16 @@ fun TimeSelectSheet(
                 draggedTimeBlock[i][j].value = true
             }
         }
+
+        val offsetMinute = TableTrimParam.SearchOption.hourFrom * 60
+        val maxStartMinute = TableTrimParam.SearchOption.hourFrom * 60
+        val minEndMinute = (TableTrimParam.SearchOption.hourTo + 1) * 60 // TableTrimParam.SearchOption.hourTo가 22라는 것은 23:00까지 검색을 허용하겠다는 것이므로 1을 더해준다.
         backgroundLectureTimes.forEach {
-            // endMinute에서 1을 빼주는데, endMinute이 30의 배수인 경우, 경계 값의 다음 block은 timeIndex에 포함되지 않아야하기 때문이다.
-            for (timeIndex in (it.startMinute - TableTrimParam.SearchOption.hourFrom * 60) / 30..(it.endMinute - TableTrimParam.SearchOption.hourFrom * 60 - 1) / 30) {
+            // 아래 두 줄과 비슷한 기능을 하는 ClassTimeDto.trimByTrimParam 확장 함수가 있어서, 이걸 쓸 수 있는 방향으로 개선해도 좋을 듯 하다.
+            val startMinute = max(it.startMinute, maxStartMinute)
+            val endMinute = min(it.endMinute, minEndMinute)
+            for (timeMinute in startMinute until endMinute step 30) {
+                val timeIndex = (timeMinute - offsetMinute) / 30
                 draggedTimeBlock[it.day][timeIndex].value = false
             }
         }


### PR DESCRIPTION
- endMinute이 30의 배수인 경우, 다음 block 까지 선택되고 있었음. Exception과 상관없이 의도되지 않은 동작.
- 특수하게 그 끝이 23:00이면 더 이상 block이 없기에 빈 시간대 선택하기'를 하면 list index out of bounds Exception 발생 중이었음
- 위와 별개로, 강의 시간이 시간대 검색 허용 범위를 벗어난 경우에도 '빈 시간대 선택하기'를 하면 같은 Exception 발생 중이었음
- ([파베 링크](https://console.firebase.google.com/u/0/project/snutt-792f1/crashlytics/app/android:com.wafflestudio.snutt2.live/issues/f55687ed9c47a8e6fbe012742eafa518?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE&time=last-seven-days&sessionEventKey=6891986903CE0001472E79BDB6759026_2113419554433180621))