### PR TITLE
탭 전환 시 검색탭 상태 날아가는 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -49,6 +49,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.popups.Popup
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewPage
 import com.wafflestudio.snutt2.views.logged_in.home.search.SearchPage
 import com.wafflestudio.snutt2.views.logged_in.home.search.SearchViewModel
+import com.wafflestudio.snutt2.views.logged_in.home.search.rememberSearchResultListState
 import com.wafflestudio.snutt2.views.logged_in.home.settings.SettingsRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.UserViewModel
 import com.wafflestudio.snutt2.views.logged_in.home.timetable.TableState
@@ -91,6 +92,7 @@ fun HomePage() {
     val reviewPageReviewWebViewContainer = remember { ReviewWebViewContainer(context, userViewModel.accessToken, isDarkMode) }
     // HomePage에서 collect 까지 해 줘야 탭 전환했을 때 검색 현황이 유지됨
     val searchResultPagingItems = searchViewModel.queryResults.collectAsLazyPagingItems()
+    val searchResultListState = rememberSearchResultListState(searchResultPagingItems)
 
     LaunchedEffect(Unit) {
         scope.launch(Dispatchers.IO) {
@@ -151,7 +153,7 @@ fun HomePage() {
             ) {
                 when (pageController.homePageState.value) {
                     HomeItem.Timetable -> TimetablePage(uncheckedNotification)
-                    HomeItem.Search -> SearchPage(searchResultPagingItems)
+                    HomeItem.Search -> SearchPage(searchResultPagingItems, searchResultListState)
                     is HomeItem.Review -> {
                         CompositionLocalProvider(LocalReviewWebView provides reviewPageReviewWebViewContainer) {
                             ReviewPage()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchPage.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun SearchPage(
     searchResultPagingItems: LazyPagingItems<DataWithState<LectureDto, LectureState>>,
+    searchResultListState: SearchResultListState,
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -244,6 +245,7 @@ fun SearchPage(
                     SearchPageMode.Search -> SearchResultList(
                         scope,
                         searchResultPagingItems,
+                        searchResultListState,
                         searchViewModel,
                         timetableViewModel,
                         tableListViewModel,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 fun SearchResultList(
     scope: CoroutineScope,
     searchResultPagingItems: LazyPagingItems<DataWithState<LectureDto, LectureState>>,
+    searchResultListState: SearchResultListState,
     searchViewModel: SearchViewModel,
     timetableViewModel: TimetableViewModel,
     tableListViewModel: TableListViewModel,
@@ -46,8 +47,6 @@ fun SearchResultList(
     val selectedTags by searchViewModel.selectedTags.collectAsState()
     val lazyListState = searchViewModel.lazyListState
     val keyBoardController = LocalSoftwareKeyboardController.current
-
-    val searchResultListState = rememberSearchResultListState(searchResultPagingItems)
 
     Column {
         AnimatedLazyRow(itemList = selectedTags, itemKey = { it.toItemKey() }) {


### PR DESCRIPTION
- 문제
  - 재현 영상: https://wafflestudio.slack.com/archives/C0PAVPS5T/p1754664840841059?thread_ts=1754646722.265489&cid=C0PAVPS5T
  - 로그심기 하면서 SearchResultListState 라는 걸 composable의 상태로 추가했는데
  - 얘를 SearchPage에서 들고 있다 보니
  - 다른 탭 갔다 오면 SearchResultListState가 날아가는 문제가 발생..
- 해결
  - searchResultPagingItems처럼 HomePage에서 상태 들고 있도록 변경
  - 근본적인 해결은 리팩을 해야할듯.. searchResultPagingItems 를 sealed class로 두거나, 탭 구조를 개편하거나