### PR TITLE
강의상세 비고 잘리는 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailItem.kt
@@ -34,7 +34,8 @@ fun LectureDetailItem(
     onValueChange: (String) -> Unit = {},
     hint: String? = stringResource(R.string.lecture_detail_hint_nothing),
     enabled: Boolean = false,
-    textStyle: TextStyle = SNUTTTypography.body1.copy(fontSize = 15.sp),
+    editable: Boolean = true,
+    textStyle: TextStyle = SNUTTTypography.body1.copy(fontSize = 15.sp, color = if (editable) SNUTTColors.Black900 else SNUTTColors.Gray600),
     focusManager: FocusManager = LocalFocusManager.current,
     singleLine: Boolean = true,
     keyboardOptions: KeyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -57,7 +58,7 @@ fun LectureDetailItem(
         } else {
             Text(
                 text = value.ifBlank { hint ?: "" },
-                style = textStyle,
+                style = if (value == "") textStyle.copy(color = SNUTTColors.Gray200) else textStyle,
                 maxLines = if (singleLine) 1 else Int.MAX_VALUE,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailItem.kt
@@ -58,7 +58,7 @@ fun LectureDetailItem(
             Text(
                 text = value.ifBlank { hint ?: "" },
                 style = textStyle,
-                maxLines = 1,
+                maxLines = if (singleLine) 1 else Int.MAX_VALUE,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetailPage.kt
@@ -475,26 +475,17 @@ fun LectureDetailPage(
                         LectureDetailItem(
                             title = stringResource(R.string.lecture_detail_course_number),
                             value = editingLectureDetail.course_number ?: "",
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
-                            ),
+                            editable = false,
                         )
                         LectureDetailItem(
                             title = stringResource(R.string.lecture_detail_lecture_number),
                             value = editingLectureDetail.lecture_number ?: "",
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
-                            ),
+                            editable = false,
                         )
                         LectureDetailItem(
                             title = editingLectureDetail.getQuotaTitle(context),
                             value = editingLectureDetail.getFullQuota(),
-                            textStyle = SNUTTTypography.body1.copy(
-                                fontSize = 15.sp,
-                                color = if (modeType is ModeType.Editing) SNUTTColors.Gray200 else SNUTTColors.Black900,
-                            ),
+                            editable = false,
                         )
                     }
                     LectureDetailItem(


### PR DESCRIPTION
- 강의상세 비고 잘리는 버그 수정
- #467 에서 LectureDetailItem을 다같이 쓰는 줄 모르고 singleLine option을 무시했었음
- 고려해서 수정