### PR TITLE
feat: ModalBottomSheetLayout 동작 및 상태관리 패턴 통일

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,65 @@ UiState를 구성하는 외부 데이터는 종류에 따라 아래와 같이 �
 - UiState는 영속적인 상태, UiEvent는 소비 후 사라지는 이벤트로 역할을 명확히 구분한다.
 - 컴포즈 UI 라이브러리의 상태(예: `ModalBottomSheetState`)는 Route가 소유한다. ViewModel은 직접 제어하지 않고 UiEvent를 통해 제어를 요청한다.
 
+**ModalBottomSheet**
+
+`ModalBottomSheetLayout` 사용 시 ViewModel의 UiState와 Compose의 `ModalBottomSheetState`라는 이중 상태가 발생한다. 상태 괴리를 최소화하기 위해 아래 원칙을 따른다. 의사결정 배경은 `docs/bottom-sheet-policy.md` 참조.
+
+원칙
+
+- `rememberModalBottomSheetState`로 생성하는 `sheetState`는 Route가 소유하되, 속성 직접 접근(`isVisible` 등)은 금지한다. `ModalBottomSheetLayout`에 전달하고 UiEvent 핸들러에서 `show()`/`hide()`를 호출하기 위한 배관(plumbing)으로만 취급한다.
+- `sheetState`의 상태 변경(`show()`/`hide()`)은 UiEvent 구독 핸들러 내에서만 수행한다.
+- 바텀시트를 사용하는 Route는 `BottomSheetDismissEffect`를 반드시 사용하여, 바텀시트가 닫힌 뒤(애니메이션 완료 후) ViewModel의 정리 함수(`onSheetDismissed`)를 호출한다.
+- UiState에서 바텀시트 상태(SheetType 등)를 None/Empty로 바꾸는 것은 `BottomSheetDismissEffect`의 side-effect로만 수행한다. 바텀시트를 닫는 시점에 즉시 변경하지 않는다.
+- BackHandler에서 바텀시트 열림 여부를 판단할 때는 UiState의 SheetType 필드를 사용한다.
+- BackHandler는 Route에서만 사용한다.
+    - 예외: 하위 컴포저블이 자체 로컬 상태 기반의 서브 네비게이션을 가지는 경우 (예: `TimeSelectSheet`의 시간 선택 모드)
+
+예시
+
+```kotlin
+// Route
+@Composable
+fun ExampleRoute(vm: ExampleViewModel = hiltViewModel()) {
+    val uiState by vm.uiState.collectAsStateWithLifecycle()
+    val sheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true,
+    )
+
+    BackHandler(enabled = uiState.sheetType != SheetType.None) {
+        vm.closeSheet()
+    }
+
+    BottomSheetDismissEffect(sheetState, vm::onSheetDismissed)
+
+    LaunchedEffect(Unit) {
+        vm.uiEvent.collect { event ->
+            when (event) {
+                is UiEvent.OpenSheet -> sheetState.show()
+                is UiEvent.CloseSheet -> sheetState.hide()
+            }
+        }
+    }
+
+    ExampleBottomSheetLayout(sheetState = sheetState, ...) { ... }
+}
+
+// ViewModel
+fun openSheet(data: Data) {
+    _uiState.update { it.copy(sheetType = SheetType.Detail(data)) }
+    viewModelScope.launch { _uiEvent.emit(UiEvent.OpenSheet) }
+}
+
+fun closeSheet() {
+    viewModelScope.launch { _uiEvent.emit(UiEvent.CloseSheet) }
+}
+
+fun onSheetDismissed() {
+    _uiState.update { it.copy(sheetType = SheetType.None) }
+}
+```
+
 ---
 
 ### **Data 레이어**

--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/BottomSheetDismissEffect.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/BottomSheetDismissEffect.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.snutt2.components.compose
+
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+
+/**
+ * 바텀시트가 닫힌 뒤(애니메이션 완료 후) [onDismissed]를 호출하는 사이드이펙트.
+ *
+ * ViewModel의 UiState(sheetType 등)를 바텀시트 닫기 애니메이션이 끝난 뒤에 정리할 때 사용한다.
+ * 닫기 전에 UiState를 즉시 변경하면 sheetContent가 먼저 비워져 UI가 어색해지는 문제를 방지한다.
+ */
+@Composable
+fun BottomSheetDismissEffect(
+    sheetState: ModalBottomSheetState,
+    onDismissed: () -> Unit,
+) {
+    val currentOnDismissed by rememberUpdatedState(onDismissed)
+    LaunchedEffect(Unit) {
+        snapshotFlow { sheetState.currentValue }
+            .distinctUntilChanged()
+            .drop(1)
+            .filter { it == ModalBottomSheetValue.Hidden }
+            .collect { currentOnDismissed() }
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkBottomSheetLayout.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -19,8 +18,8 @@ import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetail
 
@@ -40,12 +39,6 @@ fun BookmarkBottomSheetLayout(
     content: @Composable () -> Unit,
 ) {
     val analyticsLogger = LocalAnalyticsLogger.current
-
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onDismiss()
-        }
-    }
 
     ModalBottomSheetLayout(
         sheetContent = {
@@ -114,12 +107,6 @@ private fun BookmarkLectureDetailSheetContent(
     val analyticsLogger = LocalAnalyticsLogger.current
     val lecture = bottomSheetType.lecture
     val showCategoryPre2025 = (courseBook.year * 10 + courseBook.semester) > 20250L
-
-    LaunchedEffect(detailReviewSheetState.currentValue) {
-        if (detailReviewSheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onCloseDetailReview()
-        }
-    }
 
     ModalBottomSheetLayout(
         modifier = Modifier.logImpression(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
@@ -72,9 +72,9 @@ fun BookmarkRoute(
         }
     }
 
-    val bottomSheetType = (uiState as? BookmarkUiState.Success)?.bottomSheetType
-    BackHandler(enabled = bottomSheetType != null && bottomSheetType != BookmarkUiState.BottomSheetType.None) {
-        if (bottomSheetType is BookmarkUiState.BottomSheetType.LectureDetail && bottomSheetType.reviewVisible) {
+    val activeSheet = uiState.activeBottomSheet
+    BackHandler(enabled = activeSheet != null) {
+        if (activeSheet is BookmarkUiState.BottomSheetType.LectureDetail && activeSheet.reviewVisible) {
             viewModel.closeDetailReview()
         } else {
             viewModel.closeBottomSheet()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
@@ -72,11 +72,13 @@ fun BookmarkRoute(
         }
     }
 
-    BackHandler(
-        enabled = (uiState as? BookmarkUiState.Success)?.bottomSheetType
-            .let { it != null && it != BookmarkUiState.BottomSheetType.None },
-    ) {
-        viewModel.closeBottomSheet()
+    val bottomSheetType = (uiState as? BookmarkUiState.Success)?.bottomSheetType
+    BackHandler(enabled = bottomSheetType != null && bottomSheetType != BookmarkUiState.BottomSheetType.None) {
+        if (bottomSheetType is BookmarkUiState.BottomSheetType.LectureDetail && bottomSheetType.reviewVisible) {
+            viewModel.closeDetailReview()
+        } else {
+            viewModel.closeBottomSheet()
+        }
     }
 
     BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -77,6 +78,9 @@ fun BookmarkRoute(
     ) {
         viewModel.closeBottomSheet()
     }
+
+    BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)
+    BottomSheetDismissEffect(detailReviewSheetState, viewModel::onDetailReviewSheetDismissed)
 
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
@@ -314,10 +314,6 @@ class BookmarkViewModel @Inject constructor(
 
     fun closeBottomSheet() {
         viewModelScope.launch {
-            _uiState.update { current ->
-                if (current !is BookmarkUiState.Success) return@update current
-                current.copy(bottomSheetType = BookmarkUiState.BottomSheetType.None)
-            }
             _uiEvent.emit(BookmarkUiEvent.CloseBottomSheet)
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
@@ -318,6 +318,25 @@ class BookmarkViewModel @Inject constructor(
         }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { current ->
+            if (current !is BookmarkUiState.Success) return@update current
+            current.copy(bottomSheetType = BookmarkUiState.BottomSheetType.None)
+        }
+    }
+
+    fun onDetailReviewSheetDismissed() {
+        _uiState.update { state ->
+            if (state !is BookmarkUiState.Success) return@update state
+            val bt = state.bottomSheetType
+            if (bt is BookmarkUiState.BottomSheetType.LectureDetail) {
+                state.copy(bottomSheetType = bt.copy(reviewVisible = false))
+            } else {
+                state
+            }
+        }
+    }
+
     fun openDetailReview() {
         _uiState.update { state ->
             if (state !is BookmarkUiState.Success) return@update state

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
@@ -445,6 +445,11 @@ sealed interface BookmarkUiEvent {
 }
 
 sealed interface BookmarkUiState {
+    /** 현재 열려 있는 바텀시트 타입. 열린 시트가 없으면 null. */
+    val activeBottomSheet: BottomSheetType?
+        get() = (this as? Success)?.bottomSheetType
+            ?.takeIf { it != BottomSheetType.None }
+
     data object Loading : BookmarkUiState
 
     data class Success(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerBottomSheetLayout.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DrawerState
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.ModalDrawer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -15,8 +14,8 @@ import com.wafflestudio.snutt2.domainmodel.TableSummary
 import com.wafflestudio.snutt2.domainmodel.TableTheme
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.compose.HomeDrawerLoggingEffect
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.views.logged_in.home.drawer.bottom_sheet.CreateTableBottomSheet
 import com.wafflestudio.snutt2.views.logged_in.home.drawer.bottom_sheet.MoreActionSheet
 import com.wafflestudio.snutt2.views.logged_in.home.drawer.bottom_sheet.SelectThemeSheetContent
@@ -59,12 +58,6 @@ fun HomeDrawerBottomSheetLayout(
     content: @Composable () -> Unit,
 ) {
     val analyticsLogger = LocalAnalyticsLogger.current
-
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onDismiss()
-        }
-    }
     HomeDrawerLoggingEffect(drawerState)
     ModalBottomSheetLayout(
         sheetContent = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModel.kt
@@ -218,15 +218,6 @@ class HomeDrawerViewModel @Inject constructor(
                 handleError(it)
             }.onSuccess {
                 _uiEvent.emit(HomeDrawerUiEvent.CloseBottomSheet)
-                _uiState.update { state ->
-                    when (state) {
-                        is HomeDrawerUiState.Loaded -> state.copy(
-                            homeDrawerBottomSheetType = HomeDrawerBottomSheetType.Empty,
-                        )
-
-                        else -> state
-                    }
-                }
                 _uiEvent.emit(HomeDrawerUiEvent.CloseDrawer)
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModel.kt
@@ -468,6 +468,12 @@ class HomeDrawerViewModel @Inject constructor(
         }
     }
 
+    fun closeSheet() {
+        viewModelScope.launch {
+            _uiEvent.emit(HomeDrawerUiEvent.CloseBottomSheet)
+        }
+    }
+
     fun onSheetDismissed() {
         _uiState.update { state ->
             when (state) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModel.kt
@@ -468,6 +468,18 @@ class HomeDrawerViewModel @Inject constructor(
         }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { state ->
+            when (state) {
+                is HomeDrawerUiState.Loaded -> state.copy(
+                    homeDrawerBottomSheetType = HomeDrawerBottomSheetType.Empty,
+                )
+
+                else -> state
+            }
+        }
+    }
+
     private fun handleError(error: DomainError) { // TODO: 네트워크 오류일 때 재시도하기(지금은 앱 껐다 켜야 됨)
         val displayMessage = displayMessageResolver.getDisplayMessage(error)
         viewModelScope.launch {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/TimeTableRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/TimeTableRoute.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -103,6 +104,8 @@ fun TimeTableRoute(
             }
         }
     }
+
+    BottomSheetDismissEffect(sheetState, drawerViewModel::onSheetDismissed)
 
     LaunchedEffect(Unit) {
         timeTableViewModel.uiEvent.collect { uiEvent ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/TimeTableRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/TimeTableRoute.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.home.drawer
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,11 +14,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
-import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import com.wafflestudio.snutt2.domainmodel.LocalLecture
 import com.wafflestudio.snutt2.lib.android.toast
 import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
@@ -105,7 +106,17 @@ fun TimeTableRoute(
         }
     }
 
-    BottomSheetDismissEffect(sheetState, drawerViewModel::onSheetDismissed)
+    val isSheetOpen = (drawerUiState as? HomeDrawerUiState.Loaded)?.homeDrawerBottomSheetType != HomeDrawerBottomSheetType.Empty
+    BackHandler(enabled = isSheetOpen) {
+        drawerViewModel.closeSheet()
+    }
+
+    // FIXME: SelectTheme 시트의 상태가 drawerViewModel(시트 타입)과 timeTableViewModel(프리뷰 테마)에 걸쳐있어서,
+    //  dismiss 정리가 두 VM에 분산됨. 크로스-VM 의존 구조 개선 필요.
+    BottomSheetDismissEffect(sheetState) {
+        drawerViewModel.onSheetDismissed()
+        timeTableViewModel.resetPreviewTheme()
+    }
 
     LaunchedEffect(Unit) {
         timeTableViewModel.uiEvent.collect { uiEvent ->
@@ -120,12 +131,7 @@ fun TimeTableRoute(
     HomeDrawerBottomSheetLayout(
         uiState = drawerUiState,
         sheetState = sheetState,
-        onDismiss = {
-            scope.launch {
-                timeTableViewModel.resetPreviewTheme()
-                sheetState.hide()
-            }
-        },
+        onDismiss = drawerViewModel::closeSheet,
         onCreateNewTable = drawerViewModel::createNewTable,
         onClickChangeTableName = drawerViewModel::openChangeTableNameDialog,
         onClickSetPrimary = drawerViewModel::setPrimaryTable,
@@ -153,10 +159,8 @@ fun TimeTableRoute(
         },
         onClickApplyTheme = drawerViewModel::applyTheme,
         onClickDisposeTheme = {
-            scope.launch {
-                timeTableViewModel.resetPreviewTheme()
-                sheetState.hide()
-            }
+            timeTableViewModel.resetPreviewTheme()
+            drawerViewModel.closeSheet()
         },
         onClickAddTheme = drawerViewModel::navigateToThemeDetail,
     ) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/bottom_sheet/CreateNewTableSheetContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/bottom_sheet/CreateNewTableSheetContent.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.views.logged_in.home.drawer.bottom_sheet
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -47,10 +46,6 @@ fun CreateTableBottomSheet(
     val context = LocalContext.current
     var title by remember(sheetType) { mutableStateOf("") }
     var pickedCourseBook by remember { mutableStateOf((sheetType as? HomeDrawerBottomSheetType.CreateNewTable.SelectCourseBook)?.initialCourseBook) }
-
-    BackHandler {
-        onDismiss()
-    }
 
     var clearFocusFlag by remember { mutableStateOf(false) }
     LaunchedEffect(sheetState.isVisible) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage2.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
@@ -87,6 +88,11 @@ fun FriendsRoute(
             // intent data를 null로 설정해서 다시 처리되지 않도록 함
             activity?.intent?.data = null
         }
+    }
+
+    val isSheetOpen = (uiState as? FriendsUiState.Loaded)?.bottomSheetContent != FriendBottomSheetContent.Hidden
+    BackHandler(enabled = isSheetOpen) {
+        viewModel.closeBottomSheet()
     }
 
     BottomSheetDismissEffect(bottomSheetState, viewModel::onSheetDismissed)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage2.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -87,6 +88,8 @@ fun FriendsRoute(
             activity?.intent?.data = null
         }
     }
+
+    BottomSheetDismissEffect(bottomSheetState, viewModel::onSheetDismissed)
 
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsViewModel.kt
@@ -274,6 +274,15 @@ class FriendsViewModel @Inject constructor(
         }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { state ->
+            when (state) {
+                is FriendsUiState.Loaded -> state.copy(bottomSheetContent = FriendBottomSheetContent.Hidden)
+                else -> state
+            }
+        }
+    }
+
     fun showRequestWithNickname() {
         viewModelScope.launch {
             _uiState.update { state ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsViewModel.kt
@@ -270,12 +270,6 @@ class FriendsViewModel @Inject constructor(
 
     fun closeBottomSheet() {
         viewModelScope.launch {
-            _uiState.update { state ->
-                when (state) {
-                    is FriendsUiState.Loaded -> state.copy(bottomSheetContent = FriendBottomSheetContent.Hidden)
-                    else -> state
-                }
-            }
             _uiEvent.emit(FriendUiEvent.CloseBottomSheet)
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchBottomSheetLayout.kt
@@ -4,19 +4,18 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.components.compose.ModalBottomSheetPlaceholder
-import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.domainmodel.SearchTag
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
+import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
+import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.model.TagType
 import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.home.search.search_option.SearchOptionSheet
 
@@ -45,12 +44,6 @@ fun SearchBottomSheetLayout(
     content: @Composable () -> Unit,
 ) {
     val analyticsLogger = LocalAnalyticsLogger.current
-
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onDismiss()
-        }
-    }
 
     ModalBottomSheetLayout(
         sheetContent = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchLectureDetailSheetContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchLectureDetailSheetContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -18,8 +17,8 @@ import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.ui.SNUTTColors
+import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetail
 
@@ -45,12 +44,6 @@ fun SearchLectureDetailSheetContent(
     val isBookmarked = bookmarks.any { it.id == lecture.id }
     val isVacancyRegistered = vacancyList.any { it.id == lecture.id }
     val showCategoryPre2025 = (courseBook.year * 10 + courseBook.semester) > 20250L
-
-    LaunchedEffect(detailReviewSheetState.currentValue) {
-        if (detailReviewSheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onCloseDetailReview()
-        }
-    }
 
     ModalBottomSheetLayout(
         modifier = Modifier.logImpression(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
@@ -88,7 +88,16 @@ fun SearchRoute(
         enabled = uiState.bottomSheetType != SearchUiState.BottomSheetType.None ||
             uiState.pageMode == PageMode.Bookmark,
     ) {
-        viewModel.onClickBack()
+        val bt = uiState.bottomSheetType
+        if (bt != SearchUiState.BottomSheetType.None) {
+            if (bt is SearchUiState.BottomSheetType.LectureDetail && bt.reviewVisible) {
+                viewModel.closeDetailReview()
+            } else {
+                viewModel.closeBottomSheet()
+            }
+        } else {
+            viewModel.onClickBack()
+        }
     }
 
     BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
@@ -89,6 +90,9 @@ fun SearchRoute(
     ) {
         viewModel.onClickBack()
     }
+
+    BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)
+    BottomSheetDismissEffect(detailReviewSheetState, viewModel::onDetailReviewSheetDismissed)
 
     // UiEvent 처리
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
@@ -84,13 +84,10 @@ fun SearchRoute(
         }
     }
 
-    BackHandler(
-        enabled = uiState.bottomSheetType != SearchUiState.BottomSheetType.None ||
-            uiState.pageMode == PageMode.Bookmark,
-    ) {
-        val bt = uiState.bottomSheetType
-        if (bt != SearchUiState.BottomSheetType.None) {
-            if (bt is SearchUiState.BottomSheetType.LectureDetail && bt.reviewVisible) {
+    val activeSheet = uiState.activeBottomSheet
+    BackHandler(enabled = activeSheet != null || uiState.pageMode == PageMode.Bookmark) {
+        if (activeSheet != null) {
+            if (activeSheet is SearchUiState.BottomSheetType.LectureDetail && activeSheet.reviewVisible) {
                 viewModel.closeDetailReview()
             } else {
                 viewModel.closeBottomSheet()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -536,14 +536,12 @@ class SearchViewModel @Inject constructor(
 
     fun closeBottomSheet() {
         viewModelScope.launch {
-            _uiState.update { it.copy(bottomSheetType = SearchUiState.BottomSheetType.None) }
             _uiEvent.emit(SearchUiEvent.CloseBottomSheet)
         }
     }
 
     fun applyFilterAndClose() {
         storeRecentSearchedDepartments()
-        _uiState.update { it.copy(bottomSheetType = SearchUiState.BottomSheetType.None) }
         viewModelScope.launch { _uiEvent.emit(SearchUiEvent.CloseBottomSheet) }
         onSearch()
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -432,10 +432,6 @@ class SearchViewModel @Inject constructor(
     }
 
     fun onClickBack() {
-        if (_uiState.value.bottomSheetType != SearchUiState.BottomSheetType.None) {
-            closeBottomSheet()
-            return
-        }
         _uiState.update { current ->
             if (current.pageMode == PageMode.Bookmark) current.copy(pageMode = PageMode.Search) else current
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -540,6 +540,21 @@ class SearchViewModel @Inject constructor(
         }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { it.copy(bottomSheetType = SearchUiState.BottomSheetType.None) }
+    }
+
+    fun onDetailReviewSheetDismissed() {
+        _uiState.update { current ->
+            val bt = current.bottomSheetType
+            if (bt is SearchUiState.BottomSheetType.LectureDetail) {
+                current.copy(bottomSheetType = bt.copy(reviewVisible = false))
+            } else {
+                current
+            }
+        }
+    }
+
     fun applyFilterAndClose() {
         storeRecentSearchedDepartments()
         viewModelScope.launch { _uiEvent.emit(SearchUiEvent.CloseBottomSheet) }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -685,6 +685,10 @@ data class SearchUiState(
     val recentSearchedDepartments: List<Selectable<SearchTag>>,
     val draggedTimeBlock: List<List<Boolean>>,
 ) {
+    /** 현재 열려 있는 바텀시트 타입. 열린 시트가 없으면 null. */
+    val activeBottomSheet: BottomSheetType?
+        get() = bottomSheetType.takeIf { it != BottomSheetType.None }
+
     sealed interface BottomSheetType {
         data object None : BottomSheetType
         data object Filter : BottomSheetType

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigBottomSheetLayout.kt
@@ -3,9 +3,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.settings.theme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -27,15 +25,8 @@ internal fun ThemeConfigBottomSheetLayout(
     onClickApply: (TableTheme) -> Unit,
     onClickDuplicate: (CustomTheme) -> Unit,
     onClickDelete: (CustomTheme) -> Unit,
-    onDismiss: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onDismiss()
-        }
-    }
-
     ModalBottomSheetLayout(
         sheetState = sheetState,
         sheetContent = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -55,6 +56,8 @@ fun ThemeConfigRoute(
     ) {
         viewModel.onCloseBottomSheet()
     }
+
+    BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)
 
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigScreen.kt
@@ -51,9 +51,7 @@ fun ThemeConfigRoute(
         skipHalfExpanded = true,
     )
 
-    BackHandler(
-        enabled = uiState.bottomSheetType != ThemeConfigUiState.BottomSheetType.None,
-    ) {
+    BackHandler(enabled = uiState.bottomSheetType != ThemeConfigUiState.BottomSheetType.None) {
         viewModel.onCloseBottomSheet()
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigScreen.kt
@@ -74,7 +74,6 @@ fun ThemeConfigRoute(
         onClickApply = viewModel::onClickApply,
         onClickDuplicate = viewModel::onClickDuplicate,
         onClickDelete = viewModel::onClickDelete,
-        onDismiss = viewModel::onCloseBottomSheet,
     ) {
         ThemeConfigScreen(
             uiState = uiState,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigViewModel.kt
@@ -83,18 +83,12 @@ class ThemeConfigViewModel @Inject constructor(
 
     fun onCloseBottomSheet() {
         viewModelScope.launch {
-            _uiState.update { current ->
-                current.copy(bottomSheetType = ThemeConfigUiState.BottomSheetType.None)
-            }
             _uiEvent.emit(ThemeConfigUiEvent.CloseBottomSheet)
         }
     }
 
     fun onClickDetail(theme: TableTheme) {
         viewModelScope.launch {
-            _uiState.update { current ->
-                current.copy(bottomSheetType = ThemeConfigUiState.BottomSheetType.None)
-            }
             _uiEvent.emit(ThemeConfigUiEvent.CloseBottomSheet)
             _uiEvent.emit(ThemeConfigUiEvent.NavigateToDetail(theme))
         }
@@ -102,9 +96,6 @@ class ThemeConfigViewModel @Inject constructor(
 
     fun onClickApply(theme: TableTheme) {
         viewModelScope.launch {
-            _uiState.update { current ->
-                current.copy(bottomSheetType = ThemeConfigUiState.BottomSheetType.None)
-            }
             _uiEvent.emit(ThemeConfigUiEvent.CloseBottomSheet)
 
             val currentTableId = tableRepository.currentTable.value?.summary?.id ?: return@launch
@@ -117,9 +108,6 @@ class ThemeConfigViewModel @Inject constructor(
 
     fun onClickDuplicate(theme: CustomTheme) {
         viewModelScope.launch {
-            _uiState.update { current ->
-                current.copy(bottomSheetType = ThemeConfigUiState.BottomSheetType.None)
-            }
             _uiEvent.emit(ThemeConfigUiEvent.CloseBottomSheet)
             themeRepository.copyTheme(theme.id)
                 .onFailure { handleError(it) }
@@ -137,10 +125,7 @@ class ThemeConfigViewModel @Inject constructor(
 
         viewModelScope.launch {
             _uiState.update { current ->
-                current.copy(
-                    dialogState = ThemeConfigUiState.DialogState.None,
-                    bottomSheetType = ThemeConfigUiState.BottomSheetType.None,
-                )
+                current.copy(dialogState = ThemeConfigUiState.DialogState.None)
             }
             _uiEvent.emit(ThemeConfigUiEvent.CloseBottomSheet)
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/theme/ThemeConfigViewModel.kt
@@ -87,6 +87,12 @@ class ThemeConfigViewModel @Inject constructor(
         }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { current ->
+            current.copy(bottomSheetType = ThemeConfigUiState.BottomSheetType.None)
+        }
+    }
+
     fun onClickDetail(theme: TableTheme) {
         viewModelScope.launch {
             _uiEvent.emit(ThemeConfigUiEvent.CloseBottomSheet)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetail.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureDetail.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.views.logged_in.lecture_detail
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -73,8 +72,6 @@ fun LectureDetail(
     onFloatingButtonClick: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
-
-    BackHandler { onBackPressed() }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureBottomSheetLayout.kt
@@ -3,9 +3,7 @@ package com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.components.compose.ModalBottomSheetPlaceholder
 import com.wafflestudio.snutt2.domainmodel.LectureSession
@@ -21,12 +19,6 @@ fun AddCustomLectureBottomSheetLayout(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onCloseSheet()
-        }
-    }
-
     ModalBottomSheetLayout(
         sheetContent = {
             when (val sheetType = uiState.sheetType) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureRoute.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -57,6 +58,8 @@ fun AddCustomLectureRoute(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
     )
+
+    BottomSheetDismissEffect(sheetState, vm::onSheetDismissed)
 
     LaunchedEffect(Unit) {
         vm.uiEvent.collect { event ->

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureRoute.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
@@ -59,6 +60,10 @@ fun AddCustomLectureRoute(
         skipHalfExpanded = true,
     )
 
+    BackHandler(enabled = uiState.sheetType != AddCustomLectureUiState.SheetType.None) {
+        vm.closeSheet()
+    }
+
     BottomSheetDismissEffect(sheetState, vm::onSheetDismissed)
 
     LaunchedEffect(Unit) {
@@ -107,7 +112,7 @@ fun AddCustomLectureRoute(
                 onConfirmDeleteSession = vm::confirmDeleteSession,
                 onConfirmForceCreate = vm::confirmForceCreateLecture,
                 onBackPressed = {
-                    if (uiState.sheetType !is AddCustomLectureUiState.SheetType.None) {
+                    if (uiState.sheetType != AddCustomLectureUiState.SheetType.None) {
                         vm.closeSheet()
                     } else {
                         onNavigateBack()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureViewModel.kt
@@ -163,7 +163,6 @@ class AddCustomLectureViewModel @Inject constructor(
 
     fun closeSheet() {
         viewModelScope.launch { _uiEvent.emit(AddCustomLectureUiEvent.CloseBottomSheet) }
-        _uiState.update { it.copy(sheetType = AddCustomLectureUiState.SheetType.None) }
     }
 
     // endregion

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/AddCustomLectureViewModel.kt
@@ -165,6 +165,10 @@ class AddCustomLectureViewModel @Inject constructor(
         viewModelScope.launch { _uiEvent.emit(AddCustomLectureUiEvent.CloseBottomSheet) }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { it.copy(sheetType = AddCustomLectureUiState.SheetType.None) }
+    }
+
     // endregion
 
     // region 에러 처리

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailBottomSheetLayout.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -31,12 +30,6 @@ fun CurrentTableLectureDetailBottomSheetLayout(
     content: @Composable () -> Unit,
 ) {
     val analyticsLogger = LocalAnalyticsLogger.current
-
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
-            onCloseSheet()
-        }
-    }
 
     ModalBottomSheetLayout(
         sheetContent = {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailRoute.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.SnackbarResult
@@ -81,6 +82,20 @@ fun CurrentTableLectureDetailRoute(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
     )
+
+    val handleBack = {
+        if (uiState.sheetType != CurrentTableLectureDetailUiState.SheetType.None) {
+            vm.closeSheet()
+        } else if (uiState.editMode) {
+            vm.requestExitEditMode()
+        } else {
+            onNavigateBack()
+        }
+    }
+
+    BackHandler {
+        handleBack()
+    }
 
     BottomSheetDismissEffect(sheetState, vm::onSheetDismissed)
 
@@ -192,15 +207,7 @@ fun CurrentTableLectureDetailRoute(
                 onConfirmDeleteLecture = vm::confirmDeleteLecture,
                 onConfirmResetLecture = vm::confirmResetLecture,
                 onConfirmForceUpdate = vm::confirmForceUpdateLecture,
-                onBackPressed = {
-                    if (uiState.sheetType !is CurrentTableLectureDetailUiState.SheetType.None) {
-                        vm.closeSheet()
-                    } else if (uiState.editMode) {
-                        vm.requestExitEditMode()
-                    } else {
-                        onNavigateBack()
-                    }
-                },
+                onBackPressed = handleBack,
                 onEditModeToggle = {
                     focusManager.clearFocus()
                     vm.toggleEditMode()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailRoute.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -80,6 +81,8 @@ fun CurrentTableLectureDetailRoute(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
     )
+
+    BottomSheetDismissEffect(sheetState, vm::onSheetDismissed)
 
     @SuppressLint("LocalContextGetResourceValueCall")
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailViewModel.kt
@@ -548,7 +548,6 @@ class CurrentTableLectureDetailViewModel @Inject constructor(
         viewModelScope.launch {
             _uiEvent.emit(CurrentTableLectureDetailUiEvent.CloseBottomSheet)
         }
-        _uiState.update { it.copy(sheetType = CurrentTableLectureDetailUiState.SheetType.None) }
     }
 
     private suspend fun fetchBuildings(lecture: Lecture): List<LectureBuildingDto> {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailViewModel.kt
@@ -550,6 +550,10 @@ class CurrentTableLectureDetailViewModel @Inject constructor(
         }
     }
 
+    fun onSheetDismissed() {
+        _uiState.update { it.copy(sheetType = CurrentTableLectureDetailUiState.SheetType.None) }
+    }
+
     private suspend fun fetchBuildings(lecture: Lecture): List<LectureBuildingDto> {
         val places = lecture.lectureSessions.map { it.place }.distinct()
         var buildings: List<LectureBuildingDto> = emptyList()

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -62,6 +63,10 @@ fun DeeplinkBookmarkLectureDetailRoute(
                 "Snutt",
             )
         }
+    }
+
+    BackHandler(enabled = sheetState.isVisible) {
+        vm.closeReview()
     }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -64,6 +65,10 @@ fun DeeplinkTimetableLectureDetailRoute(
                 "Snutt",
             )
         }
+    }
+
+    BackHandler(enabled = sheetState.isVisible) {
+        vm.closeReview()
     }
 
     LaunchedEffect(Unit) {

--- a/docs/bottom-sheet-policy.md
+++ b/docs/bottom-sheet-policy.md
@@ -1,0 +1,72 @@
+# ModalBottomSheet 상태 관리 정책
+
+## 배경
+
+ModalBottomSheetLayout을 사용하면 두 개의 상태가 공존한다.
+
+| 상태 | 소유자 | 의미 |
+|---|---|---|
+| `uiState.sheetType` | ViewModel | "어떤 시트를 보여줘야 하는가" (의도) |
+| `sheetState` (`ModalBottomSheetState`) | Compose | 시트의 애니메이션·가시성 등 표시 상태 |
+
+이 둘은 본질적으로 동기화가 불가능하다. `sheetState.hide()` 호출 후 애니메이션이 진행되는 동안 두 상태가 괴리되며, 이를 무시하면 다음과 같은 문제가 발생한다.
+
+## 문제
+
+### 1. 닫기 시점에 UiState를 즉시 갱신하면 UI 깨짐
+
+바텀시트를 닫을 때 `sheetType`을 None으로 즉시 바꾸면, 닫기 애니메이션이 끝나기 전에 `sheetContent`가 비워진다. 시트가 슬라이드 다운되는 도중 내용이 사라지는 시각적 결함이 발생한다.
+
+### 2. UiState를 갱신하지 않으면 상태 괴리
+
+반대로 `sheetType`을 갱신하지 않으면, 시트가 이미 닫힌 뒤에도 ViewModel은 "시트가 열려 있다"고 인식한다. BackHandler 등 로직에서 잘못된 분기가 발생할 수 있다.
+
+### 3. 시트가 닫히는 경로가 다양함
+
+바텀시트는 다음 경로로 닫힐 수 있다:
+1. ViewModel 비즈니스 로직에 의해 (UiEvent → Route → `sheetState.hide()`)
+2. UI에서 hoist된 이벤트에 의해 (닫기 버튼 등 → ViewModel → UiEvent → Route)
+3. ModalBottomSheetLayout 자체적으로 (scrim 클릭 등, `sheetGesturesEnabled = true`인 경우)
+
+모든 경로에서 일관된 상태 정리가 필요하다.
+
+## 결정
+
+### `BottomSheetDismissEffect` 패턴 도입
+
+`snapshotFlow`로 `sheetState.currentValue`를 관찰하여, 값이 `Hidden`으로 확정된 뒤에 ViewModel의 정리 함수를 호출한다. 이 로직을 `BottomSheetDismissEffect` 유틸로 캡슐화한다.
+
+```kotlin
+// Route에서 사용
+BottomSheetDismissEffect(sheetState, vm::onSheetDismissed)
+
+// ViewModel에서 정리
+fun onSheetDismissed() {
+    _uiState.update { it.copy(sheetType = SheetType.None) }
+}
+```
+
+이 패턴을 통해:
+- 시트 닫기 애니메이션이 완료된 뒤에만 UiState가 정리되므로 UI 깨짐이 없다.
+- 닫히는 경로와 무관하게 `currentValue == Hidden` 시점에 항상 실행되므로 누락이 없다.
+- ViewModel은 `closeSheet()`(명령)과 `onSheetDismissed()`(사후 정리)로 역할이 분리된다.
+
+### `sheetState` 직접 접근 금지
+
+`sheetState`의 속성(`isVisible`, `currentValue` 등)을 Route 로직에서 직접 읽지 않는다. 이를 허용하면 ViewModel의 UiState와 `sheetState` 중 어느 것이 진실의 원천(source of truth)인지 모호해지고, 시트 열림/닫힘 판단이 두 곳에 분산된다.
+
+- BackHandler 조건: `uiState.sheetType != None` 사용 (`sheetState.isVisible` 아님)
+- `sheetState`는 `ModalBottomSheetLayout`에 전달하고, UiEvent 핸들러에서 `show()`/`hide()`를 호출하기 위한 배관으로만 취급한다.
+- `sheetState`의 관찰은 `BottomSheetDismissEffect` 내부에 캡슐화한다.
+
+`sheetState.isVisible` 대신 UiState를 사용하는 이유: ViewModel이 "시트를 열겠다"는 의도를 설정한 뒤 `sheetState.show()`가 실제로 호출되기까지 수 프레임의 지연이 있다. 이 구간에서 `sheetState.isVisible`은 아직 false이지만, 사용자가 백키를 누르면 의도를 취소하는 것이 자연스럽다. UiState의 SheetType은 의도를 즉시 반영하므로 이 경우를 올바르게 처리한다.
+
+### BackHandler는 Route에서만 사용
+
+시스템 백 키 처리는 Route에서 통합 관리한다. 예외적으로, 하위 컴포저블이 자체 로컬 상태 기반의 서브 네비게이션을 가지는 경우(예: `TimeSelectSheet`의 시간 선택 ↔ 일반 모드 전환)에는 해당 컴포저블에서 BackHandler를 사용할 수 있다.
+
+## 관련 파일
+
+- `BottomSheetDismissEffect.kt`: snapshotFlow 기반 dismiss 감지 유틸
+- `CurrentTableLectureDetailRoute.kt`: 대표적인 적용 예시
+- `TimeTableRoute.kt`: 크로스-VM dismiss 처리 예시 (FIXME 참조)


### PR DESCRIPTION
## 변경사항
- ModalBottomSheetLayout 를 쓰다 보니까, rememberModalBottomSheetState 를 어쩔 수 없이 써야 해서 상태를 ViewModel에 100% 일원화하지 못하고 이중화 및 괴리가 생김
- 바텀시트 상태의 SSOT 를 최대한 ViewModel 로 두기 위해 다음을 진행
  - BottomSheetDismissEffect 유틸을 만들어서, compose 단 상태의 관찰을 캡슐화하고, "진짜 UI상 바텀시트가 닫혔을 때" 의 side-effect 를 지정할 수 있게 한다.
  - 이 side-effect 에서, 뷰모델과의 상태 동기화 (uiState.sheetType 을 None 으로 바꾸는 행위) 가 일어남
  - 이외의 장소에서는 sheetState.visible 에 접근하지 말기.
- sheetState.show 및 sheetState.hide 또한, UiEvent 구독 시에만 호출하도록 제한

- 이 패턴에 맞춰서 모든 바텀시트 사용처 통일하고, BackHandler 사용 패턴도 통일


4c7bb72b9136c7c829ab158a6cf0e6a270c39541 이거 보면 됨