### PR TITLE
feat: 강의평 바텀시트는 최상위 바텀시트에서 별도 Route 로 뜨게 하기

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/domainmodel/Lecture.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domainmodel/Lecture.kt
@@ -34,6 +34,9 @@ data class SearchedLecture(
     override val registrationCount: Long,
     override val wasFull: Boolean,
 
+    // FIXME: 사실 reviewInfo 는 SyllabusLecture 도 가진다.
+    // 하지만 SearchedLecture 는 태생부터 reviewInfo 정보를 전부 가지는 반면,
+    // SyllabusLecture 는 처음에는 reviewInfo.id 값만 있고 rating 과 reviewCount 는 별도 API 로 불러와야 한다. (originalLectureId 사용)
     val reviewInfo: LectureReviewInfo,
 ) : Lecture(), LectureSyllabusInfo, LectureVacancyInfo
 

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/logging/AnalyticsScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/logging/AnalyticsScreen.kt
@@ -105,4 +105,19 @@ sealed class DetailScreenReferrer {
             is LectureDetail -> "lectureDetail"
         }
     }
+
+    companion object {
+        /** [encode]의 역연산. Search만 query 파라미터를 포함하므로 prefix 매칭으로 처리한다. */
+        fun decode(value: String): DetailScreenReferrer? {
+            return when {
+                value.startsWith("search=") -> Search(value.removePrefix("search="))
+                value == "notification" -> Notification
+                value == "bookmark" -> Bookmark
+                value == "timetable" -> Timetable
+                value == "lectureList" -> LectureList
+                value == "lectureDetail" -> LectureDetail
+                else -> null
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/NavigationDestination.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/NavigationDestination.kt
@@ -162,6 +162,14 @@ sealed interface NavigationDestination {
     data class ThemeDetail(val themeId: String = "", val theme: Int = -1) : NavigationDestination
 
     @Serializable
+    @DeepLinkPath("review")
+    data class Review(
+        val reviewId: String,
+        val lectureId: String = "",
+        val referrer: String = "",
+    ) : NavigationDestination
+
+    @Serializable
     @DeepLinkPath("social_link")
     data object SocialLink : NavigationDestination
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootNavGraph.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootNavGraph.kt
@@ -29,6 +29,7 @@ import com.wafflestudio.snutt2.navigation.getDeepLinkPath
 import com.wafflestudio.snutt2.test.TestRoute
 import com.wafflestudio.snutt2.views.logged_in.home.HomePageRoute
 import com.wafflestudio.snutt2.views.logged_in.home.bookmark.BookmarkRoute
+import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewBottomSheetRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.AppReportPage
 import com.wafflestudio.snutt2.views.logged_in.home.settings.ChangeNicknamePage
 import com.wafflestudio.snutt2.views.logged_in.home.settings.LectureReminderRoute
@@ -47,7 +48,6 @@ import com.wafflestudio.snutt2.views.logged_in.home.settings.diary.diary_history
 import com.wafflestudio.snutt2.views.logged_in.home.settings.diary.diary_write.DiaryWriteRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.theme.ThemeConfigRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.theme.ThemeDetailRoute
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewBottomSheetRoute
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table.AddCustomLectureRoute
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table.CurrentTableLectureDetailRoute
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table.LectureColorSelectorRoute
@@ -111,11 +111,11 @@ internal fun NavGraphBuilder.buildRootNavGraph(
             onNavigatePersonalInformationPolicy = { navController.navigate(NavigationDestination.PersonalInformationPolicy) },
             onNavigateNetworkLog = { navController.navigate(NavigationDestination.NetworkLog) },
             onNavigateTest = { navController.navigate(NavigationDestination.Test) },
-            onNavigateToReview = { reviewId, lectureId ->
+            onNavigateToReview = { lecture ->
                 navController.navigate(
                     NavigationDestination.Review(
-                        reviewId = reviewId,
-                        lectureId = lectureId,
+                        reviewId = lecture.reviewInfo.id,
+                        lectureId = lecture.id,
                     ),
                 )
             },
@@ -193,11 +193,11 @@ internal fun NavGraphBuilder.buildRootNavGraph(
         BookmarkRoute(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToOnboard = { navController.navigateAsOrigin(NavigationDestination.Onboard) },
-            onNavigateToReview = { reviewId, lectureId ->
+            onNavigateToReview = { lecture ->
                 navController.navigate(
                     NavigationDestination.Review(
-                        reviewId = reviewId,
-                        lectureId = lectureId,
+                        reviewId = lecture.reviewInfo.id,
+                        lectureId = lecture.id,
                         referrer = DetailScreenReferrer.Bookmark.encode(),
                     ),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/views/RootNavGraph.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/RootNavGraph.kt
@@ -47,6 +47,7 @@ import com.wafflestudio.snutt2.views.logged_in.home.settings.diary.diary_history
 import com.wafflestudio.snutt2.views.logged_in.home.settings.diary.diary_write.DiaryWriteRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.theme.ThemeConfigRoute
 import com.wafflestudio.snutt2.views.logged_in.home.settings.theme.ThemeDetailRoute
+import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewBottomSheetRoute
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table.AddCustomLectureRoute
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table.CurrentTableLectureDetailRoute
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table.LectureColorSelectorRoute
@@ -110,6 +111,14 @@ internal fun NavGraphBuilder.buildRootNavGraph(
             onNavigatePersonalInformationPolicy = { navController.navigate(NavigationDestination.PersonalInformationPolicy) },
             onNavigateNetworkLog = { navController.navigate(NavigationDestination.NetworkLog) },
             onNavigateTest = { navController.navigate(NavigationDestination.Test) },
+            onNavigateToReview = { reviewId, lectureId ->
+                navController.navigate(
+                    NavigationDestination.Review(
+                        reviewId = reviewId,
+                        lectureId = lectureId,
+                    ),
+                )
+            },
         )
     }
 
@@ -168,6 +177,15 @@ internal fun NavGraphBuilder.buildRootNavGraph(
             },
             onNavigateLectureReminder = { navController.navigate(NavigationDestination.LectureReminder) },
             onNavigateOnboard = { navController.navigateAsOrigin(NavigationDestination.Onboard) },
+            onNavigateToReview = { reviewId, lectureId ->
+                navController.navigate(
+                    NavigationDestination.Review(
+                        reviewId = reviewId,
+                        lectureId = lectureId,
+                        referrer = (referrer ?: DetailScreenReferrer.LectureDetail).encode(),
+                    ),
+                )
+            },
         )
     }
 
@@ -175,6 +193,15 @@ internal fun NavGraphBuilder.buildRootNavGraph(
         BookmarkRoute(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToOnboard = { navController.navigateAsOrigin(NavigationDestination.Onboard) },
+            onNavigateToReview = { reviewId, lectureId ->
+                navController.navigate(
+                    NavigationDestination.Review(
+                        reviewId = reviewId,
+                        lectureId = lectureId,
+                        referrer = DetailScreenReferrer.Bookmark.encode(),
+                    ),
+                )
+            },
         )
     }
 
@@ -216,16 +243,40 @@ internal fun NavGraphBuilder.buildRootNavGraph(
         )
     }
 
+    bottomSheet<NavigationDestination.Review> {
+        ReviewBottomSheetRoute(
+            onNavigateBack = { navController.popBackStack() },
+        )
+    }
+
     composableAnimated<NavigationDestination.DeeplinkTimetableLectureDetail>(scheme) {
         DeeplinkTimetableLectureDetailRoute(
             onNavigateBack = { navController.popBackStack() },
             onNavigateHome = { navController.navigateAsOrigin(NavigationDestination.Home()) },
+            onNavigateToReview = { reviewId, lectureId ->
+                navController.navigate(
+                    NavigationDestination.Review(
+                        reviewId = reviewId,
+                        lectureId = lectureId,
+                        referrer = DetailScreenReferrer.Notification.encode(),
+                    ),
+                )
+            },
         )
     }
 
     composableAnimated<NavigationDestination.DeeplinkBookmarkLectureDetail>(scheme) {
         DeeplinkBookmarkLectureDetailRoute(
             onNavigateBack = { navController.popBackStack() },
+            onNavigateToReview = { reviewId, lectureId ->
+                navController.navigate(
+                    NavigationDestination.Review(
+                        reviewId = reviewId,
+                        lectureId = lectureId,
+                        referrer = DetailScreenReferrer.Bookmark.encode(),
+                    ),
+                )
+            },
         )
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -57,6 +57,7 @@ fun HomePageRoute(
     onNavigatePersonalInformationPolicy: () -> Unit,
     onNavigateNetworkLog: () -> Unit,
     onNavigateTest: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -119,6 +120,7 @@ fun HomePageRoute(
         onNavigatePersonalInformationPolicy = onNavigatePersonalInformationPolicy,
         onNavigateNetworkLog = onNavigateNetworkLog,
         onNavigateTest = onNavigateTest,
+        onNavigateToReview = onNavigateToReview,
         onPopupClickFewDays = viewModel::closePopupWithHiddenDays,
         onPopupClickClose = viewModel::closePopup,
         onPopupClickImage = viewModel::onPopupImageClick,
@@ -154,6 +156,7 @@ private fun HomePageNewScreen(
     onNavigatePersonalInformationPolicy: () -> Unit,
     onNavigateNetworkLog: () -> Unit,
     onNavigateTest: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
     onPopupClickFewDays: () -> Unit,
     onPopupClickClose: () -> Unit,
     onPopupClickImage: () -> Unit,
@@ -199,6 +202,7 @@ private fun HomePageNewScreen(
             bottomBar = bottomBar,
             onNavigateVacancy = onNavigateVacancyNotification,
             onNavigateOnboardAsOrigin = onNavigateOnboardAsOrigin,
+            onNavigateToReview = onNavigateToReview,
         )
 
         is HomeItem.Review -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePage.kt
@@ -20,6 +20,7 @@ import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.domainmodel.LocalLecture
+import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.isDarkMode
@@ -57,7 +58,7 @@ fun HomePageRoute(
     onNavigatePersonalInformationPolicy: () -> Unit,
     onNavigateNetworkLog: () -> Unit,
     onNavigateTest: () -> Unit,
-    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToReview: (SearchedLecture) -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -156,7 +157,7 @@ private fun HomePageNewScreen(
     onNavigatePersonalInformationPolicy: () -> Unit,
     onNavigateNetworkLog: () -> Unit,
     onNavigateTest: () -> Unit,
-    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToReview: (SearchedLecture) -> Unit,
     onPopupClickFewDays: () -> Unit,
     onPopupClickClose: () -> Unit,
     onPopupClickImage: () -> Unit,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkBottomSheetLayout.kt
@@ -1,45 +1,34 @@
 package com.wafflestudio.snutt2.views.logged_in.home.bookmark
 
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.components.compose.ModalBottomSheetPlaceholder
 import com.wafflestudio.snutt2.domainmodel.CourseBook
 import com.wafflestudio.snutt2.domainmodel.LectureWithReminderOption
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.domainmodel.TableTheme
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
 import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetail
+import androidx.compose.foundation.layout.Box
 
 @Composable
 fun BookmarkBottomSheetLayout(
     uiState: BookmarkUiState,
     sheetState: ModalBottomSheetState,
-    detailReviewSheetState: ModalBottomSheetState,
-    detailReviewWebViewContainer: ReviewWebViewContainer,
-    reviewWebViewContainer: ReviewWebViewContainer,
     onDismiss: () -> Unit,
     onBookmarkToggle: (lecture: SearchedLecture) -> Unit,
     onVacancyToggle: (lecture: SearchedLecture) -> Unit,
     onSyllabus: (SearchedLecture) -> Unit,
-    onReviewFromDetail: () -> Unit,
-    onCloseDetailReview: () -> Unit,
+    onReview: (SearchedLecture) -> Unit,
     content: @Composable () -> Unit,
 ) {
-    val analyticsLogger = LocalAnalyticsLogger.current
-
     ModalBottomSheetLayout(
         sheetContent = {
             val successState = uiState as? BookmarkUiState.Success
@@ -50,29 +39,12 @@ fun BookmarkBottomSheetLayout(
                         tableTheme = successState.tableTheme,
                         courseBook = successState.currentTable.summary.courseBook,
                         disableMapFeature = successState.disableMapFeature,
-                        detailReviewSheetState = detailReviewSheetState,
-                        detailReviewWebViewContainer = detailReviewWebViewContainer,
                         onDismiss = onDismiss,
                         onBookmarkToggle = onBookmarkToggle,
                         onVacancyToggle = onVacancyToggle,
                         onSyllabus = onSyllabus,
-                        onReviewFromDetail = onReviewFromDetail,
-                        onCloseDetailReview = onCloseDetailReview,
+                        onReview = onReview,
                     )
-                }
-
-                is BookmarkUiState.BottomSheetType.Review -> {
-                    LaunchedEffect(Unit) {
-                        analyticsLogger.logScreen(
-                            AnalyticsScreen.ReviewDetail(
-                                ReviewDetailParameter(
-                                    lectureId = bottomSheetType.lecture.id,
-                                    referrer = DetailScreenReferrer.Bookmark,
-                                ),
-                            ),
-                        )
-                    }
-                    ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = reviewWebViewContainer)
                 }
 
                 else -> {
@@ -95,20 +67,16 @@ private fun BookmarkLectureDetailSheetContent(
     tableTheme: TableTheme,
     courseBook: CourseBook,
     disableMapFeature: Boolean,
-    detailReviewSheetState: ModalBottomSheetState,
-    detailReviewWebViewContainer: ReviewWebViewContainer,
     onDismiss: () -> Unit,
     onBookmarkToggle: (lecture: SearchedLecture) -> Unit,
     onVacancyToggle: (lecture: SearchedLecture) -> Unit,
     onSyllabus: (SearchedLecture) -> Unit,
-    onReviewFromDetail: () -> Unit,
-    onCloseDetailReview: () -> Unit,
+    onReview: (SearchedLecture) -> Unit,
 ) {
-    val analyticsLogger = LocalAnalyticsLogger.current
     val lecture = bottomSheetType.lecture
     val showCategoryPre2025 = (courseBook.year * 10 + courseBook.semester) > 20250L
 
-    ModalBottomSheetLayout(
+    Box(
         modifier = Modifier.logImpression(
             AnalyticsScreen.LectureDetail(
                 LectureDetailParameter(
@@ -117,66 +85,45 @@ private fun BookmarkLectureDetailSheetContent(
                 ),
             ),
         ),
-        sheetContent = {
-            LaunchedEffect(detailReviewSheetState.isVisible) {
-                if (detailReviewSheetState.isVisible) {
-                    analyticsLogger.logScreen(
-                        AnalyticsScreen.ReviewDetail(
-                            ReviewDetailParameter(
-                                lectureId = lecture.id,
-                                referrer = DetailScreenReferrer.Bookmark,
-                            ),
-                        ),
-                    )
-                }
-            }
-            ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = detailReviewWebViewContainer)
-        },
-        sheetState = detailReviewSheetState,
-        sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
-        scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
-        sheetGesturesEnabled = false,
     ) {
-        LectureDetail(
-            lecture = lecture,
-            editMode = false,
-            tableTheme = tableTheme,
-            reviewInfo = lecture.reviewInfo,
-            buildings = bottomSheetType.buildings,
-            isBookmarked = bottomSheetType.isBookmarked,
-            vacancyRegistered = bottomSheetType.isVacancyRegistered,
-            showCategoryPre2025 = showCategoryPre2025,
-            disableMapFeature = disableMapFeature,
-            showLectureReminderPicker = false,
-            lectureWithReminderOption = LectureWithReminderOption.Default,
-            enableLectureReminderPicker = false,
-            showFloatingButton = false,
-            onBackPressed = {
-                if (bottomSheetType.reviewVisible) onCloseDetailReview() else onDismiss()
-            },
-            onEditModeToggle = {},
-            onBookmarkToggle = { onBookmarkToggle(lecture) },
-            onVacancyToggle = { onVacancyToggle(lecture) },
-            onCourseTitleChange = {},
-            onInstructorChange = {},
-            onColorClick = {},
-            onReminderOptionChange = {},
-            onCreditChange = {},
-            onDepartmentChange = {},
-            onAcademicYearChange = {},
-            onClassificationChange = {},
-            onCategoryChange = {},
-            onCategoryPre2025Change = {},
-            onRemarkChange = {},
-            onEditTime = { _, _ -> },
-            onLocationChange = { _, _ -> },
-            onDeleteSession = {},
-            onAddSession = {},
-            onSyllabus = { onSyllabus(lecture) },
-            onReview = onReviewFromDetail,
-            onDelete = {},
-            onReset = {},
-            onFloatingButtonClick = {},
-        )
+    LectureDetail(
+        lecture = lecture,
+        editMode = false,
+        tableTheme = tableTheme,
+        reviewInfo = lecture.reviewInfo,
+        buildings = bottomSheetType.buildings,
+        isBookmarked = bottomSheetType.isBookmarked,
+        vacancyRegistered = bottomSheetType.isVacancyRegistered,
+        showCategoryPre2025 = showCategoryPre2025,
+        disableMapFeature = disableMapFeature,
+        showLectureReminderPicker = false,
+        lectureWithReminderOption = LectureWithReminderOption.Default,
+        enableLectureReminderPicker = false,
+        showFloatingButton = false,
+        onBackPressed = onDismiss,
+        onEditModeToggle = {},
+        onBookmarkToggle = { onBookmarkToggle(lecture) },
+        onVacancyToggle = { onVacancyToggle(lecture) },
+        onCourseTitleChange = {},
+        onInstructorChange = {},
+        onColorClick = {},
+        onReminderOptionChange = {},
+        onCreditChange = {},
+        onDepartmentChange = {},
+        onAcademicYearChange = {},
+        onClassificationChange = {},
+        onCategoryChange = {},
+        onCategoryPre2025Change = {},
+        onRemarkChange = {},
+        onEditTime = { _, _ -> },
+        onLocationChange = { _, _ -> },
+        onDeleteSession = {},
+        onAddSession = {},
+        onSyllabus = { onSyllabus(lecture) },
+        onReview = { onReview(lecture) },
+        onDelete = {},
+        onReset = {},
+        onFloatingButtonClick = {},
+    )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
@@ -24,8 +23,6 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.lib.android.toast
-import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.ui.isDarkMode
 import com.wafflestudio.snutt2.views.logged_in.home.search.BookmarkList
@@ -37,52 +34,24 @@ fun BookmarkRoute(
     viewModel: BookmarkViewModel = hiltViewModel(),
     onNavigateToOnboard: () -> Unit,
     onNavigateBack: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val isDarkMode = isDarkMode()
 
     val sheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
     )
-    // FIXME: (SearchRoute와 동일) 이 상태의 관리 주체는 SearchRoute 인가, 아니면 강의상세 바텀시트인가...
-    val detailReviewSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true,
-    )
-
-    val reviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, viewModel.accessToken, isDarkMode).apply {
-            this.webView.addJavascriptInterface(
-                CloseBridge(onClose = { scope.launch { viewModel.closeBottomSheet() } }),
-                "Snutt",
-            )
-        }
-    }
-
-    val detailReviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, viewModel.accessToken, isDarkMode).apply {
-            this.webView.addJavascriptInterface(
-                CloseBridge(onClose = { scope.launch { viewModel.closeDetailReview() } }),
-                "Snutt",
-            )
-        }
-    }
 
     val activeSheet = uiState.activeBottomSheet
     BackHandler(enabled = activeSheet != null) {
-        if (activeSheet is BookmarkUiState.BottomSheetType.LectureDetail && activeSheet.reviewVisible) {
-            viewModel.closeDetailReview()
-        } else {
-            viewModel.closeBottomSheet()
-        }
+        viewModel.closeBottomSheet()
     }
 
     BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)
-    BottomSheetDismissEffect(detailReviewSheetState, viewModel::onDetailReviewSheetDismissed)
 
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event ->
@@ -92,31 +61,11 @@ fun BookmarkRoute(
                 BookmarkUiEvent.NavigateToOnboard -> onNavigateToOnboard()
 
                 BookmarkUiEvent.OpenBottomSheet -> {
-                    val successState = uiState as? BookmarkUiState.Success ?: return@collect
-                    val bottomSheetType = successState.bottomSheetType
-                    if (bottomSheetType is BookmarkUiState.BottomSheetType.Review) {
-                        val reviewId = bottomSheetType.lecture.reviewInfo.id
-                        val url = context.getString(R.string.review_base_url) + "/detail?id=$reviewId&on_back=close"
-                        reviewWebViewContainer.openPage(url)
-                    }
                     scope.launch { sheetState.show() }
                 }
 
                 BookmarkUiEvent.CloseBottomSheet -> {
                     scope.launch { sheetState.hide() }
-                }
-
-                BookmarkUiEvent.OpenDetailReviewSheet -> {
-                    val successState = uiState as? BookmarkUiState.Success ?: return@collect
-                    val bt = successState.bottomSheetType as? BookmarkUiState.BottomSheetType.LectureDetail ?: return@collect
-                    val reviewId = bt.lecture.reviewInfo.id
-                    val url = context.getString(R.string.review_base_url) + "/detail?id=$reviewId&on_back=close"
-                    detailReviewWebViewContainer.openPage(url)
-                    scope.launch { detailReviewSheetState.show() }
-                }
-
-                BookmarkUiEvent.CloseDetailReviewSheet -> {
-                    scope.launch { detailReviewSheetState.hide() }
                 }
 
                 is BookmarkUiEvent.OpenUrl -> {
@@ -133,17 +82,17 @@ fun BookmarkRoute(
         onBookmarkToggle = viewModel::onClickBookmark,
         onVacancyToggle = viewModel::onClickVacancy,
         onSyllabus = viewModel::openSyllabus,
-        onReviewFromDetail = viewModel::openDetailReview,
-        onCloseDetailReview = viewModel::closeDetailReview,
-        detailReviewSheetState = detailReviewSheetState,
-        detailReviewWebViewContainer = detailReviewWebViewContainer,
-        reviewWebViewContainer = reviewWebViewContainer,
+        onReview = { lecture ->
+            onNavigateToReview(lecture.reviewInfo.id, lecture.id)
+        },
     ) {
         BookmarkScreen(
             uiState = uiState,
             onNavigateBack = onNavigateBack,
             onClickLectureDetail = viewModel::openLectureDetailSheet,
-            onClickReview = viewModel::openReviewSheet,
+            onClickReview = { lecture ->
+                onNavigateToReview(lecture.reviewInfo.id, lecture.id)
+            },
             onClickBookmark = viewModel::onClickBookmark,
             onClickVacancy = viewModel::onClickVacancy,
             onToggleLectureContained = viewModel::onToggleLectureContained,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkPage.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -20,6 +19,7 @@ import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import com.wafflestudio.snutt2.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.lib.android.toast
@@ -34,7 +34,7 @@ fun BookmarkRoute(
     viewModel: BookmarkViewModel = hiltViewModel(),
     onNavigateToOnboard: () -> Unit,
     onNavigateBack: () -> Unit,
-    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToReview: (SearchedLecture) -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -82,17 +82,13 @@ fun BookmarkRoute(
         onBookmarkToggle = viewModel::onClickBookmark,
         onVacancyToggle = viewModel::onClickVacancy,
         onSyllabus = viewModel::openSyllabus,
-        onReview = { lecture ->
-            onNavigateToReview(lecture.reviewInfo.id, lecture.id)
-        },
+        onReview = onNavigateToReview,
     ) {
         BookmarkScreen(
             uiState = uiState,
             onNavigateBack = onNavigateBack,
             onClickLectureDetail = viewModel::openLectureDetailSheet,
-            onClickReview = { lecture ->
-                onNavigateToReview(lecture.reviewInfo.id, lecture.id)
-            },
+            onClickReview = onNavigateToReview,
             onClickBookmark = viewModel::onClickBookmark,
             onClickVacancy = viewModel::onClickVacancy,
             onToggleLectureContained = viewModel::onToggleLectureContained,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/bookmark/BookmarkViewModel.kt
@@ -77,8 +77,6 @@ class BookmarkViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<BookmarkUiState> = MutableStateFlow(BookmarkUiState.Loading)
     val uiState: StateFlow<BookmarkUiState> = _uiState.asStateFlow()
 
-    val accessToken: StateFlow<String> get() = userRepository.accessToken
-
     init {
         viewModelScope.launch {
             combine(
@@ -302,16 +300,6 @@ class BookmarkViewModel @Inject constructor(
         }
     }
 
-    fun openReviewSheet(lecture: SearchedLecture) {
-        viewModelScope.launch {
-            _uiState.update { current ->
-                if (current !is BookmarkUiState.Success) return@update current
-                current.copy(bottomSheetType = BookmarkUiState.BottomSheetType.Review(lecture))
-            }
-            _uiEvent.emit(BookmarkUiEvent.OpenBottomSheet)
-        }
-    }
-
     fun closeBottomSheet() {
         viewModelScope.launch {
             _uiEvent.emit(BookmarkUiEvent.CloseBottomSheet)
@@ -323,40 +311,6 @@ class BookmarkViewModel @Inject constructor(
             if (current !is BookmarkUiState.Success) return@update current
             current.copy(bottomSheetType = BookmarkUiState.BottomSheetType.None)
         }
-    }
-
-    fun onDetailReviewSheetDismissed() {
-        _uiState.update { state ->
-            if (state !is BookmarkUiState.Success) return@update state
-            val bt = state.bottomSheetType
-            if (bt is BookmarkUiState.BottomSheetType.LectureDetail) {
-                state.copy(bottomSheetType = bt.copy(reviewVisible = false))
-            } else {
-                state
-            }
-        }
-    }
-
-    fun openDetailReview() {
-        _uiState.update { state ->
-            if (state !is BookmarkUiState.Success) return@update state
-            val bt = state.bottomSheetType
-            if (bt is BookmarkUiState.BottomSheetType.LectureDetail) {
-                state.copy(bottomSheetType = bt.copy(reviewVisible = true))
-            } else state
-        }
-        viewModelScope.launch { _uiEvent.emit(BookmarkUiEvent.OpenDetailReviewSheet) }
-    }
-
-    fun closeDetailReview() {
-        _uiState.update { state ->
-            if (state !is BookmarkUiState.Success) return@update state
-            val bt = state.bottomSheetType
-            if (bt is BookmarkUiState.BottomSheetType.LectureDetail) {
-                state.copy(bottomSheetType = bt.copy(reviewVisible = false))
-            } else state
-        }
-        viewModelScope.launch { _uiEvent.emit(BookmarkUiEvent.CloseDetailReviewSheet) }
     }
 
     fun openSyllabus(lecture: SearchedLecture) {
@@ -439,8 +393,6 @@ sealed interface BookmarkUiEvent {
     data object NavigateToOnboard : BookmarkUiEvent
     data object OpenBottomSheet : BookmarkUiEvent
     data object CloseBottomSheet : BookmarkUiEvent
-    data object OpenDetailReviewSheet : BookmarkUiEvent
-    data object CloseDetailReviewSheet : BookmarkUiEvent
     data class OpenUrl(val url: String) : BookmarkUiEvent
 }
 
@@ -479,11 +431,9 @@ sealed interface BookmarkUiState {
         data class LectureDetail(
             val lecture: SearchedLecture,
             val buildings: List<LectureBuildingDto> = emptyList(),
-            val reviewVisible: Boolean = false,
             val isBookmarked: Boolean = false,
             val isVacancyRegistered: Boolean = false,
         ) : BottomSheetType
 
-        data class Review(val lecture: SearchedLecture) : BottomSheetType
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewBottomSheetRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewBottomSheetRoute.kt
@@ -1,0 +1,80 @@
+package com.wafflestudio.snutt2.views.logged_in.home.reviews
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
+import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
+import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
+import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
+import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
+import com.wafflestudio.snutt2.lib.logging.logImpression
+import com.wafflestudio.snutt2.ui.isDarkMode
+
+@Composable
+fun ReviewBottomSheetRoute(
+    onNavigateBack: () -> Unit,
+    viewModel: ReviewBottomSheetViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val isDarkMode = isDarkMode()
+
+    val reviewWebViewContainer = remember {
+        ReviewWebViewContainer(context, viewModel.accessToken, isDarkMode).apply {
+            webView.addJavascriptInterface(
+                CloseBridge(onClose = { viewModel.close() }),
+                "Snutt",
+            )
+        }
+    }
+
+    val url = context.getString(R.string.review_base_url) + "/detail?id=${viewModel.reviewId}&on_back=close"
+
+    LaunchedEffect(Unit) {
+        reviewWebViewContainer.openPage(url)
+    }
+
+    BackHandler {
+        if (reviewWebViewContainer.webView.canGoBack()) {
+            reviewWebViewContainer.webView.goBack()
+        } else {
+            viewModel.close()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { event ->
+            when (event) {
+                ReviewBottomSheetUiEvent.NavigateBack -> onNavigateBack()
+            }
+        }
+    }
+
+    val referrer = DetailScreenReferrer.decode(viewModel.referrer)
+
+    ReviewWebView(
+        modifier = Modifier
+            .then(
+                if (viewModel.lectureId.isNotEmpty() && referrer != null) {
+                    Modifier.logImpression(
+                        AnalyticsScreen.ReviewDetail(
+                            ReviewDetailParameter(
+                                lectureId = viewModel.lectureId,
+                                referrer = referrer,
+                            ),
+                        ),
+                    )
+                } else {
+                    Modifier
+                },
+            )
+            .fillMaxHeight(0.95f),
+        reviewWebViewContainer = reviewWebViewContainer,
+    )
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewBottomSheetViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/reviews/ReviewBottomSheetViewModel.kt
@@ -1,0 +1,42 @@
+package com.wafflestudio.snutt2.views.logged_in.home.reviews
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.views.NavigationDestination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ReviewBottomSheetViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    userRepository: UserRepository,
+) : ViewModel() {
+
+    private val route = savedStateHandle.toRoute<NavigationDestination.Review>()
+
+    val accessToken: StateFlow<String> = userRepository.accessToken
+
+    val reviewId: String = route.reviewId
+    val lectureId: String = route.lectureId
+    val referrer: String = route.referrer
+
+    private val _uiEvent = MutableSharedFlow<ReviewBottomSheetUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    fun close() {
+        viewModelScope.launch {
+            _uiEvent.emit(ReviewBottomSheetUiEvent.NavigateBack)
+        }
+    }
+}
+
+sealed interface ReviewBottomSheetUiEvent {
+    data object NavigateBack : ReviewBottomSheetUiEvent
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchBottomSheetLayout.kt
@@ -1,22 +1,17 @@
 package com.wafflestudio.snutt2.views.logged_in.home.search
 
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.components.compose.ModalBottomSheetPlaceholder
 import com.wafflestudio.snutt2.domainmodel.SearchTag
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.model.TagType
 import com.wafflestudio.snutt2.ui.SNUTTColors
 import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.home.search.search_option.SearchOptionSheet
 
 @Composable
@@ -35,12 +30,8 @@ fun SearchBottomSheetLayout(
     onBookmarkToggle: (lecture: SearchedLecture, isBookmarked: Boolean) -> Unit,
     onVacancyToggle: (lecture: SearchedLecture, isVacancyRegistered: Boolean) -> Unit,
     onSyllabus: (SearchedLecture) -> Unit,
-    onReviewFromDetail: () -> Unit,
-    onCloseDetailReview: () -> Unit,
-    detailReviewSheetState: ModalBottomSheetState,
-    detailReviewWebViewContainer: ReviewWebViewContainer,
+    onReview: (SearchedLecture) -> Unit,
 
-    reviewWebViewContainer: ReviewWebViewContainer,
     content: @Composable () -> Unit,
 ) {
     val analyticsLogger = LocalAnalyticsLogger.current
@@ -84,29 +75,12 @@ fun SearchBottomSheetLayout(
                         tableTheme = uiState.tableTheme,
                         courseBook = uiState.courseBook,
                         disableMapFeature = uiState.disableMapFeature,
-                        detailReviewSheetState = detailReviewSheetState,
-                        detailReviewWebViewContainer = detailReviewWebViewContainer,
                         onDismiss = onDismiss,
                         onBookmarkToggle = onBookmarkToggle,
                         onVacancyToggle = onVacancyToggle,
                         onSyllabus = onSyllabus,
-                        onReviewFromDetail = onReviewFromDetail,
-                        onCloseDetailReview = onCloseDetailReview,
+                        onReview = onReview,
                     )
-                }
-
-                is SearchUiState.BottomSheetType.Review -> {
-                    LaunchedEffect(Unit) {
-                        analyticsLogger.logScreen(
-                            AnalyticsScreen.ReviewDetail(
-                                ReviewDetailParameter(
-                                    lectureId = bottomSheetType.lecture.id,
-                                    referrer = bottomSheetType.referrer,
-                                ),
-                            ),
-                        )
-                    }
-                    ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = reviewWebViewContainer)
                 }
             }
         },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchLectureDetailSheetContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchLectureDetailSheetContent.kt
@@ -1,25 +1,15 @@
 package com.wafflestudio.snutt2.views.logged_in.home.search
 
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.domainmodel.CourseBook
 import com.wafflestudio.snutt2.domainmodel.LectureWithReminderOption
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.domainmodel.TableTheme
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
-import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetail
 
 @Composable
@@ -30,22 +20,18 @@ fun SearchLectureDetailSheetContent(
     tableTheme: TableTheme,
     courseBook: CourseBook,
     disableMapFeature: Boolean,
-    detailReviewSheetState: ModalBottomSheetState,
-    detailReviewWebViewContainer: ReviewWebViewContainer,
     onDismiss: () -> Unit,
     onBookmarkToggle: (lecture: SearchedLecture, isBookmarked: Boolean) -> Unit,
     onVacancyToggle: (lecture: SearchedLecture, isVacancyRegistered: Boolean) -> Unit,
     onSyllabus: (SearchedLecture) -> Unit,
-    onReviewFromDetail: () -> Unit,
-    onCloseDetailReview: () -> Unit,
+    onReview: (SearchedLecture) -> Unit,
 ) {
-    val analyticsLogger = LocalAnalyticsLogger.current
     val lecture = bottomSheetType.lecture
     val isBookmarked = bookmarks.any { it.id == lecture.id }
     val isVacancyRegistered = vacancyList.any { it.id == lecture.id }
     val showCategoryPre2025 = (courseBook.year * 10 + courseBook.semester) > 20250L
 
-    ModalBottomSheetLayout(
+    Box(
         modifier = Modifier.logImpression(
             AnalyticsScreen.LectureDetail(
                 LectureDetailParameter(
@@ -54,25 +40,6 @@ fun SearchLectureDetailSheetContent(
                 ),
             ),
         ),
-        sheetContent = {
-            LaunchedEffect(detailReviewSheetState.isVisible) {
-                if (detailReviewSheetState.isVisible) {
-                    analyticsLogger.logScreen(
-                        AnalyticsScreen.ReviewDetail(
-                            ReviewDetailParameter(
-                                lectureId = lecture.id,
-                                referrer = DetailScreenReferrer.LectureDetail,
-                            ),
-                        ),
-                    )
-                }
-            }
-            ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = detailReviewWebViewContainer)
-        },
-        sheetState = detailReviewSheetState,
-        sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
-        scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
-        sheetGesturesEnabled = false,
     ) {
         LectureDetail(
             lecture = lecture,
@@ -88,9 +55,7 @@ fun SearchLectureDetailSheetContent(
             lectureWithReminderOption = LectureWithReminderOption.Default,
             enableLectureReminderPicker = false,
             showFloatingButton = false,
-            onBackPressed = {
-                if (bottomSheetType.reviewVisible) onCloseDetailReview() else onDismiss()
-            },
+            onBackPressed = onDismiss,
             onEditModeToggle = {},
             onBookmarkToggle = { onBookmarkToggle(lecture, isBookmarked) },
             onVacancyToggle = { onVacancyToggle(lecture, isVacancyRegistered) },
@@ -110,7 +75,7 @@ fun SearchLectureDetailSheetContent(
             onDeleteSession = {},
             onAddSession = {},
             onSyllabus = { onSyllabus(lecture) },
-            onReview = onReviewFromDetail,
+            onReview = { onReview(lecture) },
             onDelete = {},
             onReset = {},
             onFloatingButtonClick = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
@@ -25,10 +24,12 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.components.compose.BottomSheetDismissEffect
 import com.wafflestudio.snutt2.components.compose.snackbar.CustomSnackBarDuration
 import com.wafflestudio.snutt2.components.compose.snackbar.CustomSnackBarHostState
 import com.wafflestudio.snutt2.components.compose.snackbar.SnackBarScaffold
 import com.wafflestudio.snutt2.components.compose.snackbar.dismiss
+import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.lib.android.toast
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -40,7 +41,7 @@ fun SearchRoute(
     bottomBar: @Composable () -> Unit,
     onNavigateVacancy: () -> Unit,
     onNavigateOnboardAsOrigin: () -> Unit,
-    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToReview: (SearchedLecture) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -147,9 +148,7 @@ fun SearchRoute(
                 onBookmarkToggle = viewModel::onClickBookmark,
                 onVacancyToggle = viewModel::onClickVacancy,
                 onSyllabus = viewModel::openSyllabus,
-                onReview = { lecture ->
-                    onNavigateToReview(lecture.reviewInfo.id, lecture.id)
-                },
+                onReview = onNavigateToReview,
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
                     Box(modifier = Modifier.weight(1f)) {
@@ -165,9 +164,7 @@ fun SearchRoute(
                             onToggleTagAndQuery = viewModel::onToggleTagAndQuery,
                             onToggleLectureSelection = viewModel::onToggleLectureSelection,
                             onClickLectureDetail = viewModel::openLectureDetailSheet,
-                            onClickReview = { lecture ->
-                                onNavigateToReview(lecture.reviewInfo.id, lecture.id)
-                            },
+                            onClickReview = onNavigateToReview,
                             onClickBookmark = viewModel::onClickBookmark,
                             onClickVacancy = viewModel::onClickVacancy,
                             onToggleLectureContained = viewModel::onToggleLectureContained,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchRoute.kt
@@ -30,9 +30,6 @@ import com.wafflestudio.snutt2.components.compose.snackbar.CustomSnackBarHostSta
 import com.wafflestudio.snutt2.components.compose.snackbar.SnackBarScaffold
 import com.wafflestudio.snutt2.components.compose.snackbar.dismiss
 import com.wafflestudio.snutt2.lib.android.toast
-import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
-import com.wafflestudio.snutt2.ui.isDarkMode
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.launch
@@ -43,6 +40,7 @@ fun SearchRoute(
     bottomBar: @Composable () -> Unit,
     onNavigateVacancy: () -> Unit,
     onNavigateOnboardAsOrigin: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -54,51 +52,21 @@ fun SearchRoute(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
     )
-    // FIXME: 이 상태의 관리 주체는 SearchRoute 인가, 아니면 강의상세 바텀시트인가...
-    val detailReviewSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true,
-    )
 
     var lazyListState by remember { mutableStateOf(LazyListState(0, 0)) }
     val snackBarHostState = remember { CustomSnackBarHostState() }
     val hazeState = rememberHazeState()
-    val isDarkMode = isDarkMode()
-
-    val reviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, viewModel.accessToken, isDarkMode).apply {
-            this.webView.addJavascriptInterface(
-                CloseBridge(onClose = { scope.launch { viewModel.closeBottomSheet() } }),
-                "Snutt",
-            )
-        }
-    }
-
-    // FIXME: 위와 동일 고민) 이것의 관리 주체는 SearchRoute 인가, 아니면 강의상세 바텀시트인가...
-    val detailReviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, viewModel.accessToken, isDarkMode).apply {
-            this.webView.addJavascriptInterface(
-                CloseBridge(onClose = { scope.launch { viewModel.closeDetailReview() } }),
-                "Snutt",
-            )
-        }
-    }
 
     val activeSheet = uiState.activeBottomSheet
     BackHandler(enabled = activeSheet != null || uiState.pageMode == PageMode.Bookmark) {
         if (activeSheet != null) {
-            if (activeSheet is SearchUiState.BottomSheetType.LectureDetail && activeSheet.reviewVisible) {
-                viewModel.closeDetailReview()
-            } else {
-                viewModel.closeBottomSheet()
-            }
+            viewModel.closeBottomSheet()
         } else {
             viewModel.onClickBack()
         }
     }
 
     BottomSheetDismissEffect(sheetState, viewModel::onSheetDismissed)
-    BottomSheetDismissEffect(detailReviewSheetState, viewModel::onDetailReviewSheetDismissed)
 
     // UiEvent 처리
     LaunchedEffect(Unit) {
@@ -113,29 +81,11 @@ fun SearchRoute(
                 }
 
                 is SearchUiEvent.OpenBottomSheet -> {
-                    val bottomSheetType = uiState.bottomSheetType
-                    if (bottomSheetType is SearchUiState.BottomSheetType.Review) {
-                        val reviewId = bottomSheetType.lecture.reviewInfo.id
-                        val url = context.getString(R.string.review_base_url) + "/detail?id=$reviewId&on_back=close"
-                        reviewWebViewContainer.openPage(url)
-                    }
                     scope.launch { sheetState.show() }
                 }
 
                 is SearchUiEvent.CloseBottomSheet -> {
                     scope.launch { sheetState.hide() }
-                }
-
-                is SearchUiEvent.OpenDetailReviewSheet -> {
-                    val bt = uiState.bottomSheetType as? SearchUiState.BottomSheetType.LectureDetail ?: return@collect
-                    val reviewId = bt.lecture.reviewInfo.id
-                    val url = context.getString(R.string.review_base_url) + "/detail?id=$reviewId&on_back=close"
-                    detailReviewWebViewContainer.openPage(url)
-                    scope.launch { detailReviewSheetState.show() }
-                }
-
-                is SearchUiEvent.CloseDetailReviewSheet -> {
-                    scope.launch { detailReviewSheetState.hide() }
                 }
 
                 is SearchUiEvent.OpenUrl -> {
@@ -197,11 +147,9 @@ fun SearchRoute(
                 onBookmarkToggle = viewModel::onClickBookmark,
                 onVacancyToggle = viewModel::onClickVacancy,
                 onSyllabus = viewModel::openSyllabus,
-                onReviewFromDetail = viewModel::openDetailReview,
-                onCloseDetailReview = viewModel::closeDetailReview,
-                detailReviewSheetState = detailReviewSheetState,
-                detailReviewWebViewContainer = detailReviewWebViewContainer,
-                reviewWebViewContainer = reviewWebViewContainer,
+                onReview = { lecture ->
+                    onNavigateToReview(lecture.reviewInfo.id, lecture.id)
+                },
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
                     Box(modifier = Modifier.weight(1f)) {
@@ -217,7 +165,9 @@ fun SearchRoute(
                             onToggleTagAndQuery = viewModel::onToggleTagAndQuery,
                             onToggleLectureSelection = viewModel::onToggleLectureSelection,
                             onClickLectureDetail = viewModel::openLectureDetailSheet,
-                            onClickReview = viewModel::openReviewSheet,
+                            onClickReview = { lecture ->
+                                onNavigateToReview(lecture.reviewInfo.id, lecture.id)
+                            },
                             onClickBookmark = viewModel::onClickBookmark,
                             onClickVacancy = viewModel::onClickVacancy,
                             onToggleLectureContained = viewModel::onToggleLectureContained,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -91,8 +91,6 @@ class SearchViewModel @Inject constructor(
 
     private val _querySignal = MutableSharedFlow<Unit>(replay = 0)
 
-    val accessToken get() = userRepository.accessToken
-
     private val _uiEvent = MutableSharedFlow<SearchUiEvent>(replay = 0)
     val uiEvent = _uiEvent.asSharedFlow()
 
@@ -488,45 +486,12 @@ class SearchViewModel @Inject constructor(
             }
     }
 
-    fun openDetailReview() {
-        _uiState.update { current ->
-            val bt = current.bottomSheetType
-            if (bt is SearchUiState.BottomSheetType.LectureDetail) {
-                current.copy(bottomSheetType = bt.copy(reviewVisible = true))
-            } else current
-        }
-        viewModelScope.launch { _uiEvent.emit(SearchUiEvent.OpenDetailReviewSheet) }
-    }
-
-    fun closeDetailReview() {
-        _uiState.update { current ->
-            val bt = current.bottomSheetType
-            if (bt is SearchUiState.BottomSheetType.LectureDetail) {
-                current.copy(bottomSheetType = bt.copy(reviewVisible = false))
-            } else current
-        }
-        viewModelScope.launch { _uiEvent.emit(SearchUiEvent.CloseDetailReviewSheet) }
-    }
-
     fun openSyllabus(lecture: SearchedLecture) {
         viewModelScope.launch {
             val courseBook = tableRepository.currentTable.value?.summary?.courseBook ?: return@launch
             lectureInfoRepository.getSyllabusUrl(courseBook, lecture.courseNumber, lecture.lectureNumber)
                 .onSuccess { url -> _uiEvent.emit(SearchUiEvent.OpenUrl(url)) }
                 .onFailure { handleSearchError(it) }
-        }
-    }
-
-    fun openReviewSheet(lecture: SearchedLecture) {
-        viewModelScope.launch {
-            val state = _uiState.value
-            val referrer = if (state.pageMode == PageMode.Bookmark) {
-                DetailScreenReferrer.Bookmark
-            } else {
-                DetailScreenReferrer.Search(state.searchTitle)
-            }
-            _uiState.update { it.copy(bottomSheetType = SearchUiState.BottomSheetType.Review(lecture, referrer)) }
-            _uiEvent.emit(SearchUiEvent.OpenBottomSheet)
         }
     }
 
@@ -538,17 +503,6 @@ class SearchViewModel @Inject constructor(
 
     fun onSheetDismissed() {
         _uiState.update { it.copy(bottomSheetType = SearchUiState.BottomSheetType.None) }
-    }
-
-    fun onDetailReviewSheetDismissed() {
-        _uiState.update { current ->
-            val bt = current.bottomSheetType
-            if (bt is SearchUiState.BottomSheetType.LectureDetail) {
-                current.copy(bottomSheetType = bt.copy(reviewVisible = false))
-            } else {
-                current
-            }
-        }
     }
 
     fun applyFilterAndClose() {
@@ -696,13 +650,8 @@ data class SearchUiState(
             val lecture: SearchedLecture,
             val referrer: DetailScreenReferrer,
             val buildings: List<LectureBuildingDto> = emptyList(),
-            val reviewVisible: Boolean = false,
         ) : BottomSheetType
 
-        data class Review(
-            val lecture: SearchedLecture,
-            val referrer: DetailScreenReferrer,
-        ) : BottomSheetType
     }
 
     sealed interface DialogState {
@@ -732,8 +681,6 @@ sealed interface SearchUiEvent {
     }
 
     data object ResetScroll : SearchUiEvent
-    data object OpenDetailReviewSheet : SearchUiEvent
-    data object CloseDetailReviewSheet : SearchUiEvent
     data class OpenUrl(val url: String) : SearchUiEvent
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailBottomSheetLayout.kt
@@ -1,22 +1,13 @@
 package com.wafflestudio.snutt2.views.logged_in.lecture_detail.current_table
 
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.wafflestudio.snutt2.components.compose.ModalBottomSheetPlaceholder
 import com.wafflestudio.snutt2.domainmodel.LectureSession
-import com.wafflestudio.snutt2.domainmodel.SyllabusLecture
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
-import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
-import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.DayTimePickerSheetContent
 
 @Composable
@@ -25,12 +16,9 @@ fun CurrentTableLectureDetailBottomSheetLayout(
     sheetState: ModalBottomSheetState,
     onCloseSheet: () -> Unit,
     onEditSessionTime: (Int, LectureSession) -> Unit,
-    reviewWebViewContainer: ReviewWebViewContainer,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val analyticsLogger = LocalAnalyticsLogger.current
-
     ModalBottomSheetLayout(
         sheetContent = {
             when (val sheetType = uiState.sheetType) {
@@ -47,24 +35,6 @@ fun CurrentTableLectureDetailBottomSheetLayout(
                             onCloseSheet()
                         },
                     )
-                }
-
-                CurrentTableLectureDetailUiState.SheetType.Review -> {
-                    LaunchedEffect(Unit) {
-                        analyticsLogger.logScreen(
-                            AnalyticsScreen.ReviewDetail(
-                                ReviewDetailParameter(
-                                    lectureId = when (val lecture = uiState.lecture) {
-                                        is SyllabusLecture -> lecture.originalLectureId
-                                        else -> lecture.id
-                                    },
-                                    referrer = DetailScreenReferrer.LectureDetail,
-                                ),
-                            ),
-                        )
-                    }
-                    ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = reviewWebViewContainer)
-
                 }
             }
         },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailRoute.kt
@@ -27,9 +27,6 @@ import com.wafflestudio.snutt2.components.compose.snackbar.dismiss
 import com.wafflestudio.snutt2.domainmodel.LectureColor
 import com.wafflestudio.snutt2.domainmodel.LectureReminderOffset
 import com.wafflestudio.snutt2.lib.android.toast
-import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
-import com.wafflestudio.snutt2.lib.getReviewUrl
 import com.wafflestudio.snutt2.lib.logging.AddToBookmarkParameter
 import com.wafflestudio.snutt2.lib.logging.AddToVacancyParameter
 import com.wafflestudio.snutt2.lib.logging.AnalyticsEvent
@@ -39,7 +36,6 @@ import com.wafflestudio.snutt2.lib.logging.LectureActionReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.lib.logging.LectureSyllabusParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.ui.isDarkMode
 import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -54,6 +50,7 @@ fun CurrentTableLectureDetailRoute(
     onNavigateColorSelector: (LectureColor) -> Unit,
     onNavigateLectureReminder: () -> Unit,
     onNavigateOnboard: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -166,17 +163,6 @@ fun CurrentTableLectureDetailRoute(
         }
     }
 
-    // TODO: 강의평 웹뷰 컨테이너 (나중에 고민)
-    val isDarkMode = isDarkMode()
-    val reviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, vm.accessToken, isDarkMode).apply {
-            webView.addJavascriptInterface(
-                CloseBridge(onClose = { vm.closeSheet() }),
-                "Snutt",
-            )
-        }
-    }
-
     SnackBarScaffold(
         snackBarHostState = snackBarHostState,
         hazeState = hazeState,
@@ -186,7 +172,6 @@ fun CurrentTableLectureDetailRoute(
             sheetState = sheetState,
             onCloseSheet = vm::closeSheet,
             onEditSessionTime = vm::editSessionTime,
-            reviewWebViewContainer = reviewWebViewContainer,
             modifier = Modifier
                 .padding(contentPadding)
                 .hazeSource(hazeState)
@@ -269,9 +254,9 @@ fun CurrentTableLectureDetailRoute(
                     vm.openSyllabus()
                 },
                 onReview = {
-                    val url = uiState.reviewInfo?.getReviewUrl(context)
-                    scope.launch { reviewWebViewContainer.openPage("$url&on_back=close") }
-                    vm.openReview()
+                    uiState.reviewInfo?.id?.let { reviewId ->
+                        onNavigateToReview(reviewId, vm.getLoggingLectureId())
+                    }
                 },
                 onDelete = { vm.requestDeleteLecture() },
                 onReset = { vm.requestResetLecture() },

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/current_table/CurrentTableLectureDetailViewModel.kt
@@ -80,8 +80,6 @@ class CurrentTableLectureDetailViewModel @Inject constructor(
     private val _uiEvent = MutableSharedFlow<CurrentTableLectureDetailUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
-    val accessToken: StateFlow<String> = userRepository.accessToken
-
     init {
         loadSecondaryData()
         observeThemeAndConfig()
@@ -536,15 +534,7 @@ class CurrentTableLectureDetailViewModel @Inject constructor(
         viewModelScope.launch { _uiEvent.emit(CurrentTableLectureDetailUiEvent.OpenBottomSheet) }
     }
 
-    fun openReview() {
-        _uiState.update { it.copy(sheetType = CurrentTableLectureDetailUiState.SheetType.Review) }
-        viewModelScope.launch { _uiEvent.emit(CurrentTableLectureDetailUiEvent.OpenBottomSheet) }
-    }
-
     fun closeSheet() {
-        if (_uiState.value.sheetType is CurrentTableLectureDetailUiState.SheetType.Review) {
-            refreshReviewInfo()
-        }
         viewModelScope.launch {
             _uiEvent.emit(CurrentTableLectureDetailUiEvent.CloseBottomSheet)
         }
@@ -633,7 +623,6 @@ data class CurrentTableLectureDetailUiState(
     sealed interface SheetType {
         data object None : SheetType
         data class TimePicker(val index: Int, val session: LectureSession) : SheetType
-        data object Review : SheetType
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
@@ -84,7 +84,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
                     lecture = state.lecture,
                     editMode = false,
                     tableTheme = BuiltInTheme.SNUTT,
-                    reviewInfo = state.reviewInfo,
+                    reviewInfo = state.lecture.reviewInfo,
                     buildings = state.buildings,
                     isBookmarked = state.isBookmarked,
                     vacancyRegistered = state.vacancyRegistered,
@@ -115,9 +115,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
                     onAddSession = {},
                     onSyllabus = vm::openSyllabus,
                     onReview = {
-                        state.reviewInfo?.id?.let { reviewId ->
-                            onNavigateToReview(reviewId, state.lecture.id)
-                        }
+                        onNavigateToReview(state.lecture.reviewInfo.id, state.lecture.id)
                     },
                     onDelete = {},
                     onReset = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
@@ -3,20 +3,13 @@ package com.wafflestudio.snutt2.views.logged_in.lecture_detail.deeplink
 import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -26,48 +19,21 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.domainmodel.BuiltInTheme
 import com.wafflestudio.snutt2.domainmodel.LectureWithReminderOption
 import com.wafflestudio.snutt2.lib.android.toast
-import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
-import com.wafflestudio.snutt2.lib.getReviewUrl
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.ui.isDarkMode
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetail
-import kotlinx.coroutines.launch
 
 @Composable
 fun DeeplinkBookmarkLectureDetailRoute(
     vm: DeeplinkBookmarkLectureDetailViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
 ) {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val analyticsLogger = LocalAnalyticsLogger.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
-
-    val isDarkMode = isDarkMode()
-    val sheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true,
-    )
-    val reviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, vm.accessToken, isDarkMode).apply {
-            webView.addJavascriptInterface(
-                CloseBridge(onClose = { vm.closeReview() }),
-                "Snutt",
-            )
-        }
-    }
-
-    BackHandler(enabled = sheetState.isVisible) {
-        vm.closeReview()
-    }
 
     LaunchedEffect(Unit) {
         vm.uiEvent.collect { event ->
@@ -84,14 +50,6 @@ fun DeeplinkBookmarkLectureDetailRoute(
                 is DeeplinkBookmarkLectureDetailUiEvent.OpenUrl -> {
                     val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
                     context.startActivity(intent)
-                }
-
-                is DeeplinkBookmarkLectureDetailUiEvent.OpenReviewSheet -> {
-                    scope.launch { sheetState.show() }
-                }
-
-                is DeeplinkBookmarkLectureDetailUiEvent.CloseReviewSheet -> {
-                    scope.launch { sheetState.hide() }
                 }
             }
         }
@@ -112,7 +70,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
         }
 
         is DeeplinkBookmarkLectureDetailUiState.Success -> {
-            ModalBottomSheetLayout(
+            Box(
                 modifier = Modifier.logImpression(
                     AnalyticsScreen.LectureDetail(
                         LectureDetailParameter(
@@ -121,25 +79,6 @@ fun DeeplinkBookmarkLectureDetailRoute(
                         ),
                     ),
                 ),
-                sheetContent = {
-                    LaunchedEffect(sheetState.isVisible) {
-                        if (sheetState.isVisible) {
-                            analyticsLogger.logScreen(
-                                AnalyticsScreen.ReviewDetail(
-                                    ReviewDetailParameter(
-                                        lectureId = state.lecture.id,
-                                        referrer = DetailScreenReferrer.Bookmark,
-                                    ),
-                                ),
-                            )
-                        }
-                    }
-                    ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = reviewWebViewContainer)
-                },
-                sheetState = sheetState,
-                sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
-                scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
-                sheetGesturesEnabled = false,
             ) {
                 LectureDetail(
                     lecture = state.lecture,
@@ -176,9 +115,9 @@ fun DeeplinkBookmarkLectureDetailRoute(
                     onAddSession = {},
                     onSyllabus = vm::openSyllabus,
                     onReview = {
-                        val url = state.reviewInfo?.getReviewUrl(context)
-                        scope.launch { reviewWebViewContainer.openPage("$url&on_back=close") }
-                        vm.openReview()
+                        state.reviewInfo?.id?.let { reviewId ->
+                            onNavigateToReview(reviewId, state.lecture.id)
+                        }
                     },
                     onDelete = {},
                     onReset = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.data.bookmark.BookmarkRepository
 import com.wafflestudio.snutt2.data.lecture_info.LectureInfoRepository
-import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.data.vacancy_noti.VacancyRepository
 import com.wafflestudio.snutt2.domainmodel.CourseBook
 import com.wafflestudio.snutt2.domainmodel.Lecture
@@ -36,7 +35,6 @@ class DeeplinkBookmarkLectureDetailViewModel @Inject constructor(
     private val bookmarkRepository: BookmarkRepository,
     private val vacancyRepository: VacancyRepository,
     private val lectureInfoRepository: LectureInfoRepository,
-    private val userRepository: UserRepository,
     private val displayMessageResolver: DisplayMessageResolver,
     private val remoteConfig: RemoteConfig,
 ) : ViewModel() {
@@ -54,8 +52,6 @@ class DeeplinkBookmarkLectureDetailViewModel @Inject constructor(
 
     private val _uiEvent = MutableSharedFlow<DeeplinkBookmarkLectureDetailUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
-
-    val accessToken: StateFlow<String?> = userRepository.accessToken
 
     init {
         loadLecture()
@@ -199,18 +195,6 @@ class DeeplinkBookmarkLectureDetailViewModel @Inject constructor(
         }
     }
 
-    fun openReview() {
-        viewModelScope.launch {
-            _uiEvent.emit(DeeplinkBookmarkLectureDetailUiEvent.OpenReviewSheet)
-        }
-    }
-
-    fun closeReview() {
-        viewModelScope.launch {
-            _uiEvent.emit(DeeplinkBookmarkLectureDetailUiEvent.CloseReviewSheet)
-        }
-    }
-
     private fun handleError(error: com.wafflestudio.snutt2.lib.network.DomainError) {
         viewModelScope.launch {
             _uiEvent.emit(
@@ -240,6 +224,4 @@ sealed interface DeeplinkBookmarkLectureDetailUiEvent {
     data class ShowToastAndNavigateBack(val message: String) : DeeplinkBookmarkLectureDetailUiEvent
     data class ShowToast(val message: String) : DeeplinkBookmarkLectureDetailUiEvent
     data class OpenUrl(val url: String) : DeeplinkBookmarkLectureDetailUiEvent
-    data object OpenReviewSheet : DeeplinkBookmarkLectureDetailUiEvent
-    data object CloseReviewSheet : DeeplinkBookmarkLectureDetailUiEvent
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkBookmarkLectureDetailViewModel.kt
@@ -9,7 +9,6 @@ import com.wafflestudio.snutt2.data.lecture_info.LectureInfoRepository
 import com.wafflestudio.snutt2.data.vacancy_noti.VacancyRepository
 import com.wafflestudio.snutt2.domainmodel.CourseBook
 import com.wafflestudio.snutt2.domainmodel.Lecture
-import com.wafflestudio.snutt2.domainmodel.LectureReviewInfo
 import com.wafflestudio.snutt2.domainmodel.LectureSyllabusInfo
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
 import com.wafflestudio.snutt2.lib.network.BookmarkLectureNotFound
@@ -22,7 +21,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -67,7 +65,6 @@ class DeeplinkBookmarkLectureDetailViewModel @Inject constructor(
                         _uiState.update {
                             DeeplinkBookmarkLectureDetailUiState.Success(
                                 lecture = lecture,
-                                reviewInfo = lecture.reviewInfo,
                                 showCategoryPre2025 = (year * 10 + semester) > 20250L,
                             )
                         }
@@ -214,7 +211,6 @@ sealed interface DeeplinkBookmarkLectureDetailUiState {
         val buildings: List<LectureBuildingDto> = emptyList(),
         val isBookmarked: Boolean = false,
         val vacancyRegistered: Boolean = false,
-        val reviewInfo: LectureReviewInfo? = null,
         val showCategoryPre2025: Boolean = true,
         val disableMapFeature: Boolean = false,
     ) : DeeplinkBookmarkLectureDetailUiState

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
@@ -3,20 +3,13 @@ package com.wafflestudio.snutt2.views.logged_in.lecture_detail.deeplink
 import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -27,49 +20,22 @@ import com.wafflestudio.snutt2.domainmodel.BuiltInTheme
 import com.wafflestudio.snutt2.domainmodel.LectureWithReminderOption
 import com.wafflestudio.snutt2.domainmodel.SyllabusLecture
 import com.wafflestudio.snutt2.lib.android.toast
-import com.wafflestudio.snutt2.lib.android.webview.CloseBridge
-import com.wafflestudio.snutt2.lib.android.webview.ReviewWebViewContainer
-import com.wafflestudio.snutt2.lib.getReviewUrl
 import com.wafflestudio.snutt2.lib.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.lib.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.lib.logging.LectureDetailParameter
-import com.wafflestudio.snutt2.lib.logging.ReviewDetailParameter
 import com.wafflestudio.snutt2.lib.logging.logImpression
-import com.wafflestudio.snutt2.views.LocalAnalyticsLogger
 import com.wafflestudio.snutt2.ui.SNUTTColors
-import com.wafflestudio.snutt2.ui.isDarkMode
-import com.wafflestudio.snutt2.views.logged_in.home.reviews.ReviewWebView
 import com.wafflestudio.snutt2.views.logged_in.lecture_detail.LectureDetail
-import kotlinx.coroutines.launch
 
 @Composable
 fun DeeplinkTimetableLectureDetailRoute(
     vm: DeeplinkTimetableLectureDetailViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit,
     onNavigateHome: () -> Unit,
+    onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
 ) {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val analyticsLogger = LocalAnalyticsLogger.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
-
-    val isDarkMode = isDarkMode()
-    val sheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true,
-    )
-    val reviewWebViewContainer = remember {
-        ReviewWebViewContainer(context, vm.accessToken, isDarkMode).apply {
-            webView.addJavascriptInterface(
-                CloseBridge(onClose = { vm.closeReview() }),
-                "Snutt",
-            )
-        }
-    }
-
-    BackHandler(enabled = sheetState.isVisible) {
-        vm.closeReview()
-    }
 
     LaunchedEffect(Unit) {
         vm.uiEvent.collect { event ->
@@ -87,14 +53,6 @@ fun DeeplinkTimetableLectureDetailRoute(
                 is DeeplinkTimetableLectureDetailUiEvent.OpenUrl -> {
                     val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
                     context.startActivity(intent)
-                }
-
-                is DeeplinkTimetableLectureDetailUiEvent.OpenReviewSheet -> {
-                    scope.launch { sheetState.show() }
-                }
-
-                is DeeplinkTimetableLectureDetailUiEvent.CloseReviewSheet -> {
-                    scope.launch { sheetState.hide() }
                 }
             }
         }
@@ -116,7 +74,7 @@ fun DeeplinkTimetableLectureDetailRoute(
 
         is DeeplinkTimetableLectureDetailUiState.Success -> {
             val loggingLectureId = (state.lecture as? SyllabusLecture)?.originalLectureId ?: state.lecture.id
-            ModalBottomSheetLayout(
+            Box(
                 modifier = Modifier.logImpression(
                     AnalyticsScreen.LectureDetail(
                         LectureDetailParameter(
@@ -125,25 +83,6 @@ fun DeeplinkTimetableLectureDetailRoute(
                         ),
                     ),
                 ),
-                sheetContent = {
-                    LaunchedEffect(sheetState.isVisible) {
-                        if (sheetState.isVisible) {
-                            analyticsLogger.logScreen(
-                                AnalyticsScreen.ReviewDetail(
-                                    ReviewDetailParameter(
-                                        lectureId = loggingLectureId,
-                                        referrer = DetailScreenReferrer.Notification,
-                                    ),
-                                ),
-                            )
-                        }
-                    }
-                    ReviewWebView(modifier = Modifier.fillMaxHeight(0.95f), reviewWebViewContainer = reviewWebViewContainer)
-                },
-                sheetState = sheetState,
-                sheetShape = RoundedCornerShape(topStartPercent = 5, topEndPercent = 5),
-                scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
-                sheetGesturesEnabled = false,
             ) {
                 LectureDetail(
                     lecture = state.lecture,
@@ -182,9 +121,9 @@ fun DeeplinkTimetableLectureDetailRoute(
                     onAddSession = {},
                     onSyllabus = vm::openSyllabus,
                     onReview = {
-                        val url = state.reviewInfo?.getReviewUrl(context)
-                        scope.launch { reviewWebViewContainer.openPage("$url&on_back=close") }
-                        vm.openReview()
+                        state.reviewInfo?.id?.let { reviewId ->
+                            onNavigateToReview(reviewId, loggingLectureId)
+                        }
                     },
                     onDelete = {},
                     onReset = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkTimetableLectureDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/deeplink/DeeplinkTimetableLectureDetailViewModel.kt
@@ -7,7 +7,6 @@ import com.wafflestudio.snutt2.RemoteConfig
 import com.wafflestudio.snutt2.data.bookmark.BookmarkRepository
 import com.wafflestudio.snutt2.data.lecture_info.LectureInfoRepository
 import com.wafflestudio.snutt2.data.tables.TableRepository
-import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.data.vacancy_noti.VacancyRepository
 import com.wafflestudio.snutt2.domainmodel.CourseBook
 import com.wafflestudio.snutt2.domainmodel.Lecture
@@ -38,7 +37,6 @@ class DeeplinkTimetableLectureDetailViewModel @Inject constructor(
     private val vacancyRepository: VacancyRepository,
     private val lectureInfoRepository: LectureInfoRepository,
     private val tableRepository: TableRepository,
-    private val userRepository: UserRepository,
     private val displayMessageResolver: DisplayMessageResolver,
     private val remoteConfig: RemoteConfig,
 ) : ViewModel() {
@@ -55,8 +53,6 @@ class DeeplinkTimetableLectureDetailViewModel @Inject constructor(
 
     private val _uiEvent = MutableSharedFlow<DeeplinkTimetableLectureDetailUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
-
-    val accessToken: StateFlow<String?> = userRepository.accessToken
 
     init {
         loadLecture()
@@ -214,18 +210,6 @@ class DeeplinkTimetableLectureDetailViewModel @Inject constructor(
         }
     }
 
-    fun openReview() {
-        viewModelScope.launch {
-            _uiEvent.emit(DeeplinkTimetableLectureDetailUiEvent.OpenReviewSheet)
-        }
-    }
-
-    fun closeReview() {
-        viewModelScope.launch {
-            _uiEvent.emit(DeeplinkTimetableLectureDetailUiEvent.CloseReviewSheet)
-        }
-    }
-
     fun onFloatingButtonClick() {
         viewModelScope.launch {
             runCatching {
@@ -265,6 +249,4 @@ sealed interface DeeplinkTimetableLectureDetailUiEvent {
     data class ShowToastAndNavigateBack(val message: String) : DeeplinkTimetableLectureDetailUiEvent
     data class ShowToast(val message: String) : DeeplinkTimetableLectureDetailUiEvent
     data class OpenUrl(val url: String) : DeeplinkTimetableLectureDetailUiEvent
-    data object OpenReviewSheet : DeeplinkTimetableLectureDetailUiEvent
-    data object CloseReviewSheet : DeeplinkTimetableLectureDetailUiEvent
 }


### PR DESCRIPTION
## 변경사항
ThemeConfig 에서 ThemeDetail 이 바텀시트로 뜨지만, ThemeConfig 안의 ModalBottomSheetLayout 에서 뜨는 게 아니다.
ThemeDetail 은 최상위에서 별도 bottomSheet navigation 으로 뜨게 된다.
이처럼, 본래 페이지와 완전 독립 기능의 페이지가 바텀시트로 뜰 경우 최상위 bottomSheet navigation 으로 분리할 수 있다.

현재 강의평 바텀시트를 가지는 Route 들은, 강의평 관련 상태와 로직으로 인해 uiState 및 뷰모델이 무척 비대하다. 이를 경감하기 위해 강의평 바텀시트를 이 패턴으로 모두 정리한다.

강의 상세 바텀시트도 충분히 가능하지만, 일전부터 논의했던 "navigation arg 문제" 로 인해 일단 고민중..