### PR TITLE
fix: 강의평 rating 이 null 일때 n 이라고 표시되는 문제 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureReviewRatingField.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/lecture_detail/LectureReviewRatingField.kt
@@ -55,7 +55,7 @@ internal fun LectureReviewRatingField(
                 Text(
                     text = buildAnnotatedString {
                         withStyle(SpanStyle(color = SNUTTColors.Black900)) {
-                            append(reviewInfo?.let { "%.1f".format(it.rating) } ?: "--")
+                            append(reviewInfo?.rating?.let { "%.1f".format(it) } ?: "--")
                             append(" ")
                         }
                         withStyle(SpanStyle(color = SNUTTColors.Gray2)) {
@@ -87,5 +87,17 @@ private fun WithReviewInfoPreview() {
 private fun WithoutReviewInfoPreview() {
     LectureReviewRatingField(
         reviewInfo = null,
+    )
+}
+
+@Preview(showBackground = true, widthDp = 360, name = "강의퍙 없음")
+@Composable
+private fun WithZeroReviewInfoPreview() {
+    LectureReviewRatingField(
+        reviewInfo = LectureReviewInfo(
+            id = "",
+            rating = null,
+            reviewCount = 0,
+        ),
     )
 }


### PR DESCRIPTION
## 변경사항
```
❯ 왜 n이라고 나왔었을까?                                                                                                                                                    

⏺ "%.1f".format(null) 이 실행되면서 생긴 현상입니다.

  Java의 Formatter는 %f에 null이 들어오면 숫자 변환 대신 문자열 "null"로 폴백합니다. 이때 정밀도 지정자 .1이 문자열에도 적용되어 첫 1글자만 잘리게 됩니다.

  - "%.1f".format(3.75) → "3.8" (소수점 1자리)
  - "%.1f".format(null) → "null"을 .1로 자름 → "n"

  그래서 "n"이 표시된 것입니다.
```