### PR TITLE
Paging 라이브러리 버전 업

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,7 +146,6 @@ dependencies {
 
     // UI & Misc
     implementation(libs.androidx.core.ktx)
-    implementation(libs.bundles.accompanist)
     implementation(libs.facebook.login)
     implementation(libs.timber)
     implementation(libs.androidx.core.splashscreen)

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchResultList.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
-import androidx.paging.compose.items
 import com.wafflestudio.snutt2.components.compose.AnimatedLazyRow
 import com.wafflestudio.snutt2.domainmodel.SearchTag
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
@@ -96,8 +95,10 @@ fun SearchResultList(
                         state = lazyListState,
                         modifier = listModifier,
                     ) {
-                        items(searchResultPagingItems) { lectureDataWithState ->
-                            lectureDataWithState?.let { (lecture, lectureState) ->
+                        items(
+                            count = searchResultPagingItems.itemCount,
+                        ) { index ->
+                            searchResultPagingItems[index]?.let { (lecture, lectureState) ->
                                 SearchLectureListItem(
                                     modifier = Modifier.animateItem(
                                         placementSpec = spring(

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/notifications/NotificationScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.components.compose.AlarmOnIcon
 import com.wafflestudio.snutt2.components.compose.CalendarIcon
@@ -110,10 +109,12 @@ fun NotificationScreen(
             NotificationUiState.Error -> NotificationError()
             NotificationUiState.Loading -> {}
             is NotificationUiState.Success -> LazyColumn {
-                items(uiState.notificationList) { notification ->
-                    notification?.let {
+                items(
+                    count = uiState.notificationList.itemCount,
+                ) { index ->
+                    uiState.notificationList[index]?.let { notification ->
                         NotificationItem(notification) {
-                            onNotificationClick(it)
+                            onNotificationClick(notification)
                         }
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ lifecycle = "2.10.0"
 hiltNavigationCompose = "1.3.0"
 
 # Paging
-pagingCompose = "1.0.0-alpha14"
+pagingCompose = "3.4.2"
 
 # Firebase
 firebaseBom = "34.9.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,6 @@ firebaseCrashlytics = "3.0.6"
 
 # UI & Graphics
 coil = "2.7.0"
-accompanist = "0.36.0"
 splashscreen = "1.2.0"
 
 # Authentication
@@ -111,10 +110,6 @@ firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 # Image Loading
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
-# UI Components
-accompanist-pager = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }
-accompanist-pager-indicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
-
 # Authentication
 facebook-login = { module = "com.facebook.android:facebook-login", version.ref = "facebookLogin" }
 google-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "googleAuth" }
@@ -181,11 +176,6 @@ firebase = [
     "firebase-messaging",
     "firebase-analytics",
     "firebase-crashlytics"
-]
-
-accompanist = [
-    "accompanist-pager",
-    "accompanist-pager-indicators"
 ]
 
 kakao = [


### PR DESCRIPTION
- Paging Library 버전을 3.4.2로 올림
- // Paging 라이브러리의 한계로 인한 workaround는 일단 그대로 둠 
- 브랜치 이름을 잘못 판 김에 안 쓰고 있던 Accompanist Pager 의존성을 지움