### PR TITLE
fix: 필터 칩 row에서 "시간대 직접 선택" x 눌러도 검색 시 시간대필터 여전히 적용되는 문제 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/SearchViewModel.kt
@@ -135,7 +135,11 @@ class SearchViewModel @Inject constructor(
                     semester = table.summary.courseBook.semester,
                     title = state.searchTitle,
                     tags = state.selectedTags,
-                    times = state.draggedTimeBlock.clusterToTimeBlocks().ifEmpty { null },
+                    times = if (state.selectedTags.contains(SearchTag.TimeSelect)) {
+                        state.draggedTimeBlock.clusterToTimeBlocks().ifEmpty { null }
+                    } else {
+                        null
+                    },
                     timesToExclude = if (state.selectedTags.contains(SearchTag.TimeEmpty)) {
                         table.lectures.flatMapToSearchTime()
                     } else {


### PR DESCRIPTION
## 변경사항
 필터 칩 row에서 "시간대 직접 선택" x 눌러서 지우면, 상태에서 selectedTags 만 바뀐다.
하지만 draggedTimeBlock 상태는 남아있음 (이건 의도적)

query 날릴 때 selectedTags에 "시간대 직접 선택" 이 있는지 없는지 안 보고 무조건 draggedTimeBlock 상태를 요청에 포함하고 있는게 문제였다