### PR TITLE
ViewModel 단위 테스트 인프라 구축 및 첫 테스트 작성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           EOF
       - name: Run ktlint and build debug APK
         run: ./gradlew ktlintCheck assembleStagingDebug --stacktrace
+      - name: Run unit tests
+        run: ./gradlew testStagingDebugUnitTest --stacktrace
       - name: Upload ktlint report
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -29,6 +29,7 @@
     <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="NonAsciiCharacters" enabled="true" level="INFORMATION" enabled_by_default="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,9 @@ android {
 dependencies {
     // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 
     // Android Core
     implementation(libs.material)

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeDisplayMessageResolver.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeDisplayMessageResolver.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.snutt2.fake
+
+import com.wafflestudio.snutt2.lib.network.DisplayMessageResolver
+import com.wafflestudio.snutt2.lib.network.DomainError
+
+class FakeDisplayMessageResolver : DisplayMessageResolver {
+    override fun getDisplayTitle(error: DomainError): String = error.displayTitle
+    override fun getDisplayMessage(error: DomainError): String = error.displayMessage
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeUserRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeUserRepository.kt
@@ -7,24 +7,25 @@ import com.wafflestudio.snutt2.lib.network.Result
 import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
 import com.wafflestudio.snutt2.ui.ThemeMode
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 class FakeUserRepository : UserRepository {
 
-    private val _user = MutableStateFlow<User?>(null)
-    override val user: StateFlow<User?> = _user.asStateFlow()
-
-    private val _accessToken = MutableStateFlow("")
-    override val accessToken: StateFlow<String> = _accessToken.asStateFlow()
-
-    private val _themeMode = MutableStateFlow(ThemeMode.AUTO)
-    override val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
+    override val user = MutableStateFlow<User?>(null)
+    override val accessToken = MutableStateFlow("")
+    override val themeMode = MutableStateFlow(ThemeMode.AUTO)
 
     // region 테스트 제어용 필드
 
     var findIdByEmailResult: Result<Unit> = Result.Success(Unit)
     var findIdByEmailCalledWith: String? = null
+        private set
+
+    var setThemeModeResult: Result<Unit> = Result.Success(Unit)
+    var setThemeModeCalledWith: ThemeMode? = null
+        private set
+
+    var postFeedbackResult: Result<Unit> = Result.Success(Unit)
+    var postFeedbackCalledWith: Pair<String, String>? = null
         private set
 
     // endregion
@@ -43,12 +44,18 @@ class FakeUserRepository : UserRepository {
     override suspend fun deleteUserAccount(): Result<Unit> = TODO()
     override suspend fun putUserPassword(oldPassword: String, newPassword: String): Result<Unit> = TODO()
     override suspend fun postUserPassword(id: String, password: String): Result<Unit> = TODO()
-    override suspend fun postFeedback(email: String, detail: String): Result<Unit> = TODO()
+    override suspend fun postFeedback(email: String, detail: String): Result<Unit> {
+        postFeedbackCalledWith = email to detail
+        return postFeedbackResult
+    }
     override suspend fun postForceLogout(): Result<Unit> = TODO()
     override suspend fun getAccessToken(): Result<String> = TODO()
     override suspend fun performLogout(): Result<Unit> = TODO()
     override suspend fun registerToken(): Result<Unit> = TODO()
-    override suspend fun setThemeMode(mode: ThemeMode): Result<Unit> = TODO()
+    override suspend fun setThemeMode(mode: ThemeMode): Result<Unit> {
+        setThemeModeCalledWith = mode
+        return setThemeModeResult
+    }
     override suspend fun checkEmailById(id: String): Result<String> = TODO()
     override suspend fun sendPwResetCodeToEmail(email: String): Result<Unit> = TODO()
     override suspend fun verifyPwResetCode(id: String, code: String): Result<Unit> = TODO()

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeUserRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeUserRepository.kt
@@ -1,0 +1,73 @@
+package com.wafflestudio.snutt2.fake
+
+import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.domainmodel.PushPreferences
+import com.wafflestudio.snutt2.domainmodel.User
+import com.wafflestudio.snutt2.lib.network.Result
+import com.wafflestudio.snutt2.lib.network.dto.GetSocialProvidersResults
+import com.wafflestudio.snutt2.ui.ThemeMode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeUserRepository : UserRepository {
+
+    private val _user = MutableStateFlow<User?>(null)
+    override val user: StateFlow<User?> = _user.asStateFlow()
+
+    private val _accessToken = MutableStateFlow("")
+    override val accessToken: StateFlow<String> = _accessToken.asStateFlow()
+
+    private val _themeMode = MutableStateFlow(ThemeMode.AUTO)
+    override val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
+
+    // region 테스트 제어용 필드
+
+    var findIdByEmailResult: Result<Unit> = Result.Success(Unit)
+    var findIdByEmailCalledWith: String? = null
+        private set
+
+    // endregion
+
+    override suspend fun findIdByEmail(email: String): Result<Unit> {
+        findIdByEmailCalledWith = email
+        return findIdByEmailResult
+    }
+
+    // region 미사용 메서드
+
+    override suspend fun postSignIn(id: String, password: String): Result<Unit> = TODO()
+    override suspend fun postSignUp(id: String, password: String, email: String): Result<Unit> = TODO()
+    override suspend fun fetchUserInfo(): Result<Unit> = TODO()
+    override suspend fun patchUserInfo(nickname: String): Result<Unit> = TODO()
+    override suspend fun deleteUserAccount(): Result<Unit> = TODO()
+    override suspend fun putUserPassword(oldPassword: String, newPassword: String): Result<Unit> = TODO()
+    override suspend fun postUserPassword(id: String, password: String): Result<Unit> = TODO()
+    override suspend fun postFeedback(email: String, detail: String): Result<Unit> = TODO()
+    override suspend fun postForceLogout(): Result<Unit> = TODO()
+    override suspend fun getAccessToken(): Result<String> = TODO()
+    override suspend fun performLogout(): Result<Unit> = TODO()
+    override suspend fun registerToken(): Result<Unit> = TODO()
+    override suspend fun setThemeMode(mode: ThemeMode): Result<Unit> = TODO()
+    override suspend fun checkEmailById(id: String): Result<String> = TODO()
+    override suspend fun sendPwResetCodeToEmail(email: String): Result<Unit> = TODO()
+    override suspend fun verifyPwResetCode(id: String, code: String): Result<Unit> = TODO()
+    override suspend fun resetPassword(id: String, password: String, code: String): Result<Unit> = TODO()
+    override suspend fun sendCodeToEmail(email: String): Result<Unit> = TODO()
+    override suspend fun verifyEmailCode(code: String): Result<Unit> = TODO()
+    override suspend fun getAccessTokenByAuthCode(authCode: String, clientId: String, clientSecret: String): Result<String> = TODO()
+    override suspend fun getPushPreferences(): Result<PushPreferences> = TODO()
+    override suspend fun postPushPreferences(pushPreferences: PushPreferences): Result<Unit> = TODO()
+    override suspend fun getSocialProviders(): Result<GetSocialProvidersResults> = TODO()
+    override suspend fun postLoginFacebook(facebookToken: String): Result<Unit> = TODO()
+    override suspend fun postLoginGoogle(googleAccessToken: String): Result<Unit> = TODO()
+    override suspend fun postLoginKakao(kakaoAccessToken: String): Result<Unit> = TODO()
+    override suspend fun postUserFacebook(facebookToken: String): Result<Unit> = TODO()
+    override suspend fun postUserGoogle(googleAccessToken: String): Result<Unit> = TODO()
+    override suspend fun postUserKakao(kakaoAccessToken: String): Result<Unit> = TODO()
+    override suspend fun deleteUserFacebook(): Result<Unit> = TODO()
+    override suspend fun deleteUserGoogle(): Result<Unit> = TODO()
+    override suspend fun deleteUserKakao(): Result<Unit> = TODO()
+
+    // endregion
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/views/logged_in/home/settings/AppReportViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/views/logged_in/home/settings/AppReportViewModelTest.kt
@@ -1,0 +1,96 @@
+package com.wafflestudio.snutt2.views.logged_in.home.settings
+
+import app.cash.turbine.test
+import com.wafflestudio.snutt2.domainmodel.User
+import com.wafflestudio.snutt2.fake.FakeDisplayMessageResolver
+import com.wafflestudio.snutt2.fake.FakeUserRepository
+import com.wafflestudio.snutt2.lib.network.Result
+import com.wafflestudio.snutt2.lib.network.Unknown
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppReportViewModelTest {
+
+    private lateinit var fakeUserRepository: FakeUserRepository
+    private lateinit var fakeDisplayMessageResolver: FakeDisplayMessageResolver
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        fakeUserRepository = FakeUserRepository()
+        fakeDisplayMessageResolver = FakeDisplayMessageResolver()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = AppReportViewModel(
+        userRepository = fakeUserRepository,
+        displayMessageResolver = fakeDisplayMessageResolver,
+    )
+
+    // region initialEmail
+
+    @Test
+    fun `user가 있으면 initialEmail이 user의 email이다`() {
+        fakeUserRepository.user.value = User(email = "user@snu.ac.kr", localId = null, nickname = null)
+        val viewModel = createViewModel()
+        assertEquals("user@snu.ac.kr", viewModel.initialEmail)
+    }
+
+    @Test
+    fun `user가 없으면 initialEmail이 빈 문자열이다`() {
+        fakeUserRepository.user.value = null
+        val viewModel = createViewModel()
+        assertEquals("", viewModel.initialEmail)
+    }
+
+    // endregion
+
+    // region sendFeedback
+
+    @Test
+    fun `sendFeedback 호출 시 repository의 postFeedback을 호출한다`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.sendFeedback("test@snu.ac.kr", "버그 발견")
+        assertEquals("test@snu.ac.kr" to "버그 발견", fakeUserRepository.postFeedbackCalledWith)
+    }
+
+    @Test
+    fun `sendFeedback 성공 시 Success 이벤트가 발생한다`() = runTest {
+        fakeUserRepository.postFeedbackResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.sendFeedback("test@snu.ac.kr", "버그 발견")
+            assertEquals(AppReportUiEvent.Success, awaitItem())
+        }
+    }
+
+    @Test
+    fun `sendFeedback 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        val error = Unknown(displayTitle = "", displayMessage = "전송 실패")
+        fakeUserRepository.postFeedbackResult = Result.Fail(error)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.sendFeedback("test@snu.ac.kr", "버그 발견")
+            val event = assertIs<AppReportUiEvent.ShowToast>(awaitItem())
+            assertEquals("전송 실패", event.message)
+        }
+    }
+
+    // endregion
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/views/logged_in/home/settings/ColorModeSelectViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/views/logged_in/home/settings/ColorModeSelectViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.wafflestudio.snutt2.views.logged_in.home.settings
+
+import com.wafflestudio.snutt2.fake.FakeUserRepository
+import com.wafflestudio.snutt2.ui.ThemeMode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ColorModeSelectViewModelTest {
+
+    private lateinit var fakeUserRepository: FakeUserRepository
+    private lateinit var viewModel: ColorModeSelectViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        fakeUserRepository = FakeUserRepository()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = ColorModeSelectViewModel(
+        userRepository = fakeUserRepository,
+    )
+
+    // region source: themeMode
+
+    @Test
+    fun `init 시 repository의 themeMode가 UiState에 반영된다`() = runTest {
+        fakeUserRepository.themeMode.value = ThemeMode.DARK
+        viewModel = createViewModel()
+
+        assertEquals(
+            ColorModeSelectUiState(themeMode = ThemeMode.DARK),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `repository의 themeMode가 변경되면 UiState에 반영된다`() = runTest {
+        viewModel = createViewModel()
+        val before = viewModel.uiState.value
+
+        fakeUserRepository.themeMode.value = ThemeMode.LIGHT
+
+        assertEquals(before.copy(themeMode = ThemeMode.LIGHT), viewModel.uiState.value)
+    }
+
+    // endregion
+
+    // region setThemeMode
+
+    @Test
+    fun `setThemeMode 호출 시 repository의 setThemeMode를 호출한다`() = runTest {
+        viewModel = createViewModel()
+        viewModel.setThemeMode(ThemeMode.DARK)
+        assertEquals(ThemeMode.DARK, fakeUserRepository.setThemeModeCalledWith)
+    }
+
+    // endregion
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/views/logged_out/FindIdViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/views/logged_out/FindIdViewModelTest.kt
@@ -1,0 +1,74 @@
+package com.wafflestudio.snutt2.views.logged_out
+
+import app.cash.turbine.test
+import com.wafflestudio.snutt2.fake.FakeDisplayMessageResolver
+import com.wafflestudio.snutt2.fake.FakeUserRepository
+import com.wafflestudio.snutt2.lib.network.Result
+import com.wafflestudio.snutt2.lib.network.Unknown
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FindIdViewModelTest {
+
+    private lateinit var fakeUserRepository: FakeUserRepository
+    private lateinit var fakeDisplayMessageResolver: FakeDisplayMessageResolver
+    private lateinit var viewModel: FindIdViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        fakeUserRepository = FakeUserRepository()
+        fakeDisplayMessageResolver = FakeDisplayMessageResolver()
+        viewModel = FindIdViewModel(
+            userRepository = fakeUserRepository,
+            displayMessageResolver = fakeDisplayMessageResolver,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // region findIdByEmail
+
+    @Test
+    fun `findIdByEmail 호출 시 입력된 이메일로 repository를 호출한다`() = runTest {
+        viewModel.findIdByEmail("test@snu.ac.kr")
+        assertEquals("test@snu.ac.kr", fakeUserRepository.findIdByEmailCalledWith)
+    }
+
+    @Test
+    fun `findIdByEmail 성공 시 Success 이벤트가 발생한다`() = runTest {
+        fakeUserRepository.findIdByEmailResult = Result.Success(Unit)
+
+        viewModel.uiEvent.test {
+            viewModel.findIdByEmail("test@snu.ac.kr")
+            assertEquals(FindIdUiEvent.Success("test@snu.ac.kr"), awaitItem())
+        }
+    }
+
+    @Test
+    fun `findIdByEmail 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        val error = Unknown(displayTitle = "", displayMessage = "존재하지 않는 이메일입니다")
+        fakeUserRepository.findIdByEmailResult = Result.Fail(error)
+
+        viewModel.uiEvent.test {
+            viewModel.findIdByEmail("wrong@snu.ac.kr")
+            val event = assertIs<FindIdUiEvent.ShowToast>(awaitItem())
+            assertEquals("존재하지 않는 이메일입니다", event.message)
+        }
+    }
+
+    // endregion
+}

--- a/docs/viewmodel-test-strategy.md
+++ b/docs/viewmodel-test-strategy.md
@@ -1,0 +1,287 @@
+# ViewModel 테스트 전략
+
+## 목표
+
+ViewModel의 비즈니스 로직을 검증한다. 구체적으로:
+- 특정 상태에서 public 함수가 호출되었을 때 UiState가 올바르게 전이되는지
+- 올바른 UiEvent가 발생하는지
+- Repository에 올바른 요청이 전달되는지
+
+## 테스트 대상이 아닌 것
+
+- Repository 내부 로직 (별도 Repository 테스트에서 다룸)
+- Compose UI 렌더링
+- Navigation 동작
+- Hilt DI 바인딩
+
+---
+
+## 의존성 전략: Fake
+
+Mock 대신 Fake를 사용한다. Repository 인터페이스에 대한 간소화된 인메모리 구현체를 직접 작성한다.
+
+### Fake의 역할 범위
+
+Fake는 서버 로직을 모사하지 않는다. 역할은 다음으로 한정한다:
+- 성공 시 `Result.Success(미리 정의된 데이터)` 반환
+- 실패 시 `Result.Fail(지정된 에러)` 반환
+- `StateFlow` 프로퍼티에 대해 값을 세팅하고 노출
+
+### Fake의 구조
+
+```kotlin
+class FakeUserRepository : UserRepository {
+    // --- StateFlow: MutableStateFlow로 override하여 테스트에서 .value = 로 직접 세팅 ---
+    override val user = MutableStateFlow<User?>(null)
+    override val themeMode = MutableStateFlow(ThemeMode.AUTO)
+
+    // --- 테스트 제어용 필드 ---
+    var findIdByEmailResult: Result<Unit> = Result.Success(Unit)
+    var findIdByEmailCalledWith: String? = null
+        private set
+
+    // --- 인터페이스 구현 ---
+    override suspend fun findIdByEmail(email: String): Result<Unit> {
+        findIdByEmailCalledWith = email
+        return findIdByEmailResult
+    }
+
+    // ... 나머지 메서드도 같은 패턴
+}
+```
+
+핵심 원칙:
+- StateFlow 프로퍼티는 `MutableStateFlow`로 직접 override한다. 테스트에서 `.value = ...`로 source 변화를 시뮬레이션한다. `private val _xxx` + `asStateFlow()` 패턴이나 별도 setter 메서드를 쓰지 않는다.
+- 각 suspend 함수마다 `var xxxResult` 필드를 두어 반환값을 테스트에서 제어한다.
+- 인자 검증이 필요하면 `var xxxCalledWith` 필드를 두어 마지막 호출의 인자를 기록한다.
+- suspend 함수 구현에서는 `calledWith` 기록과 `xxxResult` 반환만 한다. StateFlow 갱신 등 부수 동작을 넣지 않는다.
+- 사용하지 않는 메서드는 `TODO("Not used in this test")`로 둔다.
+
+### DisplayMessageResolver
+
+`DisplayMessageResolver`도 인터페이스이므로 Fake를 만든다. 단, 역할이 단순하여 에러의 `displayMessage`를 그대로 반환하는 것으로 충분하다:
+
+```kotlin
+class FakeDisplayMessageResolver : DisplayMessageResolver {
+    override fun getDisplayTitle(error: DomainError) = error.displayTitle
+    override fun getDisplayMessage(error: DomainError) = error.displayMessage
+}
+```
+
+### Fake 파일 위치
+
+```
+app/src/test/java/com/wafflestudio/snutt2/
+├── fake/                          # Fake 구현체
+│   ├── FakeUserRepository.kt
+│   ├── FakeBookmarkRepository.kt
+│   ├── FakeDisplayMessageResolver.kt
+│   └── ...
+└── views/                         # 실제 ViewModel 경로를 미러링
+    └── logged_out/
+        └── FindIdViewModelTest.kt
+```
+
+- Fake는 `fake/` 패키지에 모아 둔다. 여러 ViewModel 테스트에서 공유된다.
+- 테스트 파일은 대상 ViewModel과 동일한 패키지 경로에 둔다.
+
+---
+
+## 테스트 코드 구조
+
+### 기본 골격
+
+```kotlin
+class FindIdViewModelTest {
+
+    private lateinit var fakeUserRepository: FakeUserRepository
+    private lateinit var fakeDisplayMessageResolver: FakeDisplayMessageResolver
+    private lateinit var viewModel: FindIdViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        fakeUserRepository = FakeUserRepository()
+        fakeDisplayMessageResolver = FakeDisplayMessageResolver()
+        viewModel = FindIdViewModel(
+            userRepository = fakeUserRepository,
+            displayMessageResolver = fakeDisplayMessageResolver,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}
+```
+
+Fake를 포함한 모든 의존성은 `@Before`에서 매번 새로 생성한다. `val`로 필드 선언 시점에 초기화하지 않는다. JUnit 4는 테스트마다 클래스를 재생성하므로 동작은 동일하지만, `lateinit` + `@Before` 패턴이 "매 테스트마다 초기화됨"을 명시적으로 드러낸다.
+
+### 검증 범주
+
+ViewModel 테스트는 **나가는 방향**과 **들어오는 방향** 두 축으로 나뉜다.
+
+**나가는 방향**: public 함수 호출 시 발생하는 효과
+
+| 범주 | 검증 내용 | 해당되지 않는 경우 |
+|------|-----------|-------------------|
+| **Repository 호출** | 올바른 인자로 호출되었는지 | - |
+| **UiEvent 발행** | 성공/실패 시 올바른 이벤트가 발행되는지 | UiEvent가 없는 함수 |
+| **UiState 전이** | public 함수 호출 후 상태가 올바르게 변경되는지 | UiState가 없는 ViewModel |
+
+**들어오는 방향**: ViewModel이 collect하는 source의 변화에 대한 반응
+
+| 범주 | 검증 내용 |
+|------|-----------|
+| **Source 반응** | collect 대상 StateFlow 변화 시 UiState가 올바르게 반영되는지 |
+
+source 테스트에서는 Fake의 `MutableStateFlow`에 `.value = ...`로 변화를 주고, UiState를 검증한다.
+
+하나의 테스트에서 여러 범주를 동시에 검증하지 않는다.
+
+나가는 방향 테스트는 **public 함수 단위로**, 들어오는 방향 테스트는 **source 단위로** region을 묶어 구조화한다:
+
+```kotlin
+// region findIdByEmail
+
+@Test
+fun `findIdByEmail 호출 시 입력된 이메일로 repository를 호출한다`() = runTest {
+    viewModel.findIdByEmail("test@snu.ac.kr")
+    assertEquals("test@snu.ac.kr", fakeUserRepository.findIdByEmailCalledWith)
+}
+
+@Test
+fun `findIdByEmail 성공 시 Success 이벤트가 발생한다`() = runTest {
+    fakeUserRepository.findIdByEmailResult = Result.Success(Unit)
+
+    viewModel.uiEvent.test {
+        viewModel.findIdByEmail("test@snu.ac.kr")
+        assertEquals(FindIdUiEvent.Success("test@snu.ac.kr"), awaitItem())
+    }
+}
+
+@Test
+fun `findIdByEmail 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+    val error = Unknown(displayTitle = "", displayMessage = "에러 발생")
+    fakeUserRepository.findIdByEmailResult = Result.Fail(error)
+
+    viewModel.uiEvent.test {
+        viewModel.findIdByEmail("test@snu.ac.kr")
+        val event = assertIs<FindIdUiEvent.ShowToast>(awaitItem())
+        assertEquals("에러 발생", event.message)
+    }
+}
+
+// endregion
+```
+
+### UiState 검증
+
+UiState는 **전체 객체를 비교**한다. 특정 필드만 검증하면 의도치 않은 다른 필드의 변경을 놓칠 수 있다.
+
+동작 직전의 상태를 캡처해두고, `copy`로 기대값을 만든다:
+
+```kotlin
+@Test
+fun `setThemeMode 호출 시 themeMode가 변경된다`() = runTest {
+    // Given
+    val before = viewModel.uiState.value
+
+    // When
+    viewModel.setThemeMode(ThemeMode.LIGHT)
+
+    // Then
+    assertEquals(before.copy(themeMode = ThemeMode.LIGHT), viewModel.uiState.value)
+}
+```
+
+이 패턴의 장점:
+- `copy`에 명시된 필드만 바뀌고, 나머지는 동일해야 테스트가 통과한다.
+- 테스트가 "이 동작이 정확히 무엇을 바꾸는가"를 명확히 드러낸다.
+- Fake 세팅이나 init 로직이 변경되어도, 실제 상태를 기준으로 하므로 테스트가 불필요하게 깨지지 않는다.
+
+상태 전이가 여러 단계인 경우에도 동일하게 적용한다:
+
+```kotlin
+@Test
+fun `북마크된 강의를 onClickBookmark하면 DeleteBookmark 다이얼로그가 열린다`() = runTest {
+    // Given
+    val before = viewModel.uiState.value as BookmarkUiState.Success
+
+    // When
+    viewModel.onClickBookmark(lecture1)
+
+    // Then
+    assertEquals(
+        before.copy(dialogState = BookmarkUiState.DialogState.DeleteBookmark(lecture1)),
+        viewModel.uiState.value,
+    )
+}
+
+@Test
+fun `onDismissDialog 호출 시 다이얼로그만 닫힌다`() = runTest {
+    // Given: 다이얼로그가 열린 상태
+    viewModel.onClickBookmark(lecture1)
+    val before = viewModel.uiState.value as BookmarkUiState.Success
+
+    // When
+    viewModel.onDismissDialog()
+
+    // Then
+    assertEquals(
+        before.copy(dialogState = BookmarkUiState.DialogState.None),
+        viewModel.uiState.value,
+    )
+}
+```
+
+---
+
+## 필요한 라이브러리
+
+```toml
+# gradle/libs.versions.toml
+[versions]
+turbine = "1.2.0"
+coroutines-test = "1.9.0"  # 프로젝트의 코루틴 버전과 맞출 것
+
+[libraries]
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test" }
+```
+
+```kotlin
+// app/build.gradle.kts
+testImplementation(libs.junit)
+testImplementation(libs.kotlin.test)
+testImplementation(libs.kotlinx.coroutines.test)
+testImplementation(libs.turbine)
+```
+
+Mock 라이브러리(MockK, Mockito 등)는 사용하지 않는다.
+
+---
+
+## 테스트 작성 순서
+
+복잡도 순으로 단계적으로 확장한다:
+
+| 단계 | 대상 | 새로 다루는 패턴 | 상태 |
+|------|------|-----------------|------|
+| 1 | FindIdViewModel | UiEvent, 성공/실패 분기 | 완료 |
+| 2 | ColorModeSelectViewModel | UiState, init Flow collect | 완료 |
+| 3 | AppReportViewModel | 초기값 + UiEvent (복합) | 완료 |
+| 4 | 중간 복잡도 ViewModel | 다이얼로그 상태 전이, combine | |
+| 5 | BookmarkViewModel 등 | 복합 상태, 바텀시트, 다중 Repository | |
+
+---
+
+## 작성 기준
+
+- **테스트 이름**: 백틱(`` ` ``)으로 감싸서 한국어로 시나리오를 서술한다.
+  - 예: `` `findIdByEmail 성공 시 Success 이벤트가 발생한다` ``
+- **Given-When-Then**: 복잡한 테스트는 주석으로 단계를 구분한다. 단순한 테스트는 생략 가능.
+- **하나의 테스트에 하나의 검증**: 한 테스트에서 여러 시나리오를 검증하지 않는다.
+- **Fake 상태 설정은 테스트 안에서**: `@Before`에는 최소한의 공통 설정만 두고, 시나리오별 Fake 상태는 각 테스트에서 설정한다.
+- **Fake의 초기값에 의존하지 않는다**: 테스트에 필요한 상태는 Fake의 기본값과 같더라도 명시적으로 세팅한다. 테스트의 의도가 Fake 구현을 읽지 않아도 드러나야 한다.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,9 @@ gson = "2.13.2"
 kotlinxSerialization = "1.10.0"
 desugarJdkLibs = "2.1.5"
 junit = "4.13.2"
+coroutinesTest = "1.9.0"
+turbine = "1.2.0"
+kotlinTest = "2.3.10"
 
 # Haze
 haze = "1.7.2"
@@ -130,6 +133,9 @@ desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref 
 
 # Testing
 junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlinTest" }
 
 # Haze
 haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }


### PR DESCRIPTION
## Summary

ViewModel 단위 테스트의 기반을 마련하고, 3개의 간단한 ViewModel에 대해 첫 테스트를 작성합니다.

### ViewModel 테스트에서 검증하는 것

각 ViewModel의 public 함수마다 아래 범주를 **각각 독립된 테스트**로 작성합니다:

**나가는 방향** (public 함수 호출 시)
- **Repository 호출**: 올바른 인자로 호출되었는지 (`calledWith` 검증)
- **UiEvent 발행**: 성공/실패 시 올바른 이벤트가 발행되는지 (Turbine으로 검증)
- **UiState 전이**: 상태 객체가 올바르게 변경되는지 (전체 객체 비교, `before.copy()` 패턴)

**들어오는 방향** (ViewModel이 collect하는 source 변화 시)
- **Source 반응**: Repository의 StateFlow 변화 → UiState가 올바르게 반영되는지

### 의존성 전략: Fake (Mock 라이브러리 미사용)

- Repository 인터페이스에 대해 간소화된 인메모리 구현체(Fake)를 직접 작성
- StateFlow는 `MutableStateFlow`로 직접 override → 테스트에서 `.value =`로 source 변화 시뮬레이션
- suspend 함수는 `xxxResult`로 반환값 제어, `xxxCalledWith`로 호출 인자 기록
- Fake는 서버 로직을 모사하지 않음. 반환값 제어 + 호출 기록만 담당

### 작성된 테스트

| ViewModel | 테스트 수 | 다루는 패턴 |
|-----------|----------|------------|
| FindIdViewModel | 3 | UiEvent, 성공/실패 분기, Repository 호출 검증 |
| ColorModeSelectViewModel | 3 | UiState, init Flow collect, source 반응 |
| AppReportViewModel | 5 | 초기값 검증, UiEvent + Repository 호출 |

### 기타

- 테스트 라이브러리 추가: `kotlinx-coroutines-test`, `turbine`, `kotlin-test`
- CI에 `testStagingDebugUnitTest` 스텝 추가
- 전략 문서: `docs/viewmodel-test-strategy.md`

## Test plan

- [x] `./gradlew testStagingDebugUnitTest` 전체 통과 확인
- [ ] CI에서 테스트 스텝 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)