### PR TITLE
chore: deprecated API 마이그레이션 및 컴파일러 워닝 정리

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/components/compose/embed_map/EmbedMap.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/components/compose/embed_map/EmbedMap.kt
@@ -22,7 +22,7 @@ import com.naver.maps.map.compose.MarkerDefaults
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.PolygonOverlay
 import com.naver.maps.map.compose.rememberCameraPositionState
-import com.naver.maps.map.compose.rememberMarkerState
+import com.naver.maps.map.compose.rememberUpdatedMarkerState
 import com.naver.maps.map.overlay.OverlayImage
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.databinding.MapPinBinding
@@ -83,7 +83,7 @@ fun EmbedMap(
                     building.buildingNumber,
                 ),
                 captionOffset = (-26).dp,
-                state = rememberMarkerState(
+                state = rememberUpdatedMarkerState(
                     position = CameraPosition(
                         LatLng(building.coordinate.latitude, building.coordinate.longitude),
                         6.0,

--- a/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
@@ -18,10 +18,12 @@ import com.wafflestudio.snutt2.lib.network.dto.core.toDomainModel
 import com.wafflestudio.snutt2.lib.network.toDomainError
 import com.wafflestudio.snutt2.lib.toOptional
 import com.wafflestudio.snutt2.domainmodel.toOffsetString
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
 @Singleton
 class TableRepositoryImpl @Inject constructor(
     private val api: SNUTTRestApi,

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/FacebookLogin.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/FacebookLogin.kt
@@ -9,10 +9,8 @@ import com.facebook.login.LoginManager
 import com.facebook.login.LoginResult
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.android.toast
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-@OptIn(ExperimentalCoroutinesApi::class)
 suspend fun facebookLogin(
     context: Context,
 ): LoginResult {
@@ -21,10 +19,9 @@ suspend fun facebookLogin(
     return suspendCancellableCoroutine { continuation ->
         val callback = object : FacebookCallback<LoginResult> {
             override fun onSuccess(result: LoginResult) {
-                continuation.resume(
-                    result,
-                    onCancellation = { loginManager.unregisterCallback(callbackManager) },
-                )
+                continuation.resume(result) { _, _, _ ->
+                    loginManager.unregisterCallback(callbackManager)
+                }
             }
 
             override fun onCancel() {

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/network/NetworkLogger.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/network/NetworkLogger.kt
@@ -48,7 +48,7 @@ fun Interceptor.Chain.createNewNetworkLog(
                 )
             } ?: ""
 
-            responseBody = response.body?.run {
+            responseBody = response.body.run {
                 GsonBuilder().setPrettyPrinting().create().toJson(
                     JsonParser.parseString(
                         source().buffer.clone().readString(

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/preferences/context/PrefValue.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/preferences/context/PrefValue.kt
@@ -13,6 +13,7 @@ class PrefValue<T : Any> constructor(
 
     init {
         val listener: (Any?) -> Unit = { value ->
+            @Suppress("UNCHECKED_CAST")
             asdf.value = ((value as? T) ?: metaData.defaultValue)
         }
         prefContext.addValueChangeListener(metaData.domain, metaData.key, listener)

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/Theme.kt
@@ -42,7 +42,7 @@ private val DarkThemeColors @Composable get() = darkColors(
 val Colors.onSurfaceVariant: Color
     get() = if (isLight) SNUTTColors.DarkerGray else SNUTTColors.Gray30
 
-enum class ThemeMode(@StringRes val labelResId: Int) {
+enum class ThemeMode(@param:StringRes val labelResId: Int) {
     DARK(R.string.theme_mode_dark),
     LIGHT(R.string.theme_mode_light),
     AUTO(R.string.theme_mode_auto),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePageViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/HomePageViewModel.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomePageViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val notificationRepository: NotificationRepository,
     private val tableRepository: TableRepository,
     private val tableDisplayRepository: TableDisplayRepository,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerTableSummaryItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerTableSummaryItem.kt
@@ -65,7 +65,7 @@ fun CourseBookDrawerItem(
             )
             Text(
                 text = stringResource(
-                    R.string.home_drawer_table_credit, tableSummary.totalCredit ?: 0L,
+                    R.string.home_drawer_table_credit, tableSummary.totalCredit,
                 ),
                 style = SNUTTTypography.body2.copy(color = SNUTTColors.Black300),
                 maxLines = 1,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/friend/FriendsPage2.kt
@@ -86,7 +86,7 @@ fun FriendsRoute(
             viewModel.acceptFriendByKakaoLink(requestToken)
             viewModel.openDrawer()
             // intent data를 null로 설정해서 다시 처리되지 않도록 함
-            activity?.intent?.data = null
+            activity.intent?.data = null
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/LectureListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/search/LectureListItem.kt
@@ -134,7 +134,7 @@ fun ExpandableLectureListItem(
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(
-                        text = lectureDataWithState.item.reviewInfo.displayText ?: "-- (0)",
+                        text = lectureDataWithState.item.reviewInfo.displayText,
                         color = SNUTTColors.White,
                         fontWeight = FontWeight.Light,
                         fontSize = 12.sp,

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/SocialLinkPage.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.views.logged_in.home.settings
 import android.annotation.SuppressLint
 import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -23,9 +24,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.auth.api.identity.AuthorizationRequest
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.common.api.Scope
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.AuthError
 import com.kakao.sdk.common.model.AuthErrorCause
@@ -57,26 +58,24 @@ fun SocialLinkPage(
     val clientId = context.getString(R.string.web_client_id)
     val clientSecret = context.getString(R.string.web_client_secret)
 
-    val googleLoginActivityResultLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult(),
+    val googleAuthLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
     ) { result ->
-        when (result.resultCode) {
-            Activity.RESULT_OK -> {
-                try {
-                    val authCode = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-                        .getResult(ApiException::class.java)?.serverAuthCode
-                    if (authCode != null) {
-                        viewModel.onGoogleAuthCodeReceived(authCode, clientId, clientSecret)
-                    } else {
-                        context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
-                    }
-                } catch (_: ApiException) {
+        if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+            try {
+                val authorizationResult = Identity.getAuthorizationClient(activityContext)
+                    .getAuthorizationResultFromIntent(result.data!!)
+                val authCode = authorizationResult.serverAuthCode
+                if (authCode != null) {
+                    viewModel.onGoogleAuthCodeReceived(authCode, clientId, clientSecret)
+                } else {
                     context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
                 }
+            } catch (e: Exception) {
+                context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
             }
-
-            Activity.RESULT_CANCELED -> context.toast(context.getString(R.string.sign_in_sign_in_google_cancelled))
-            else -> context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+        } else {
+            context.toast(context.getString(R.string.sign_in_sign_in_google_cancelled))
         }
     }
 
@@ -88,13 +87,29 @@ fun SocialLinkPage(
                 is SocialLinkUiEvent.ShowToast -> context.toast(event.message)
 
                 is SocialLinkUiEvent.LaunchGoogleSignIn -> {
-                    val client = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                        .requestEmail()
-                        .requestServerAuthCode(clientId)
-                        .build().let { GoogleSignIn.getClient(activityContext, it) }
-                    client.signOut().addOnCompleteListener {
-                        googleLoginActivityResultLauncher.launch(client.signInIntent)
-                    }
+                    val authorizationRequest = AuthorizationRequest.builder()
+                        .setRequestedScopes(listOf(Scope("email")))
+                        .requestOfflineAccess(clientId)
+                        .build()
+                    Identity.getAuthorizationClient(activityContext)
+                        .authorize(authorizationRequest)
+                        .addOnSuccessListener { authorizationResult ->
+                            if (authorizationResult.hasResolution()) {
+                                googleAuthLauncher.launch(
+                                    IntentSenderRequest.Builder(authorizationResult.pendingIntent!!.intentSender).build(),
+                                )
+                            } else {
+                                val authCode = authorizationResult.serverAuthCode
+                                if (authCode != null) {
+                                    viewModel.onGoogleAuthCodeReceived(authCode, clientId, clientSecret)
+                                } else {
+                                    context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                                }
+                            }
+                        }
+                        .addOnFailureListener {
+                            context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                        }
                 }
 
                 is SocialLinkUiEvent.LaunchFacebookLogin -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/UserConfigPage.kt
@@ -182,7 +182,7 @@ fun UserConfigScreen(
                         hasNextPage = false,
                     ) {
                         Text(
-                            text = uiState.localId.toString(),
+                            text = uiState.localId,
                             style = SNUTTTypography.body1.copy(
                                 color = SNUTTColors.Black500,
                             ),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/diary/diary_write/DiaryWriteViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_in/home/settings/diary/diary_write/DiaryWriteViewModel.kt
@@ -55,7 +55,7 @@ class DiaryWriteViewModel @Inject constructor(
                 .onSuccess { dailyClassTypes ->
                     _uiState.update {
                         DiaryWriteUiState.Write(
-                            lectureName = courseTitle ?: "",
+                            lectureName = courseTitle,
                             dailyClassTypes = dailyClassTypes.map { Selectable(it, false) },
                             activitySelectingState = ActivitySelectionState.InitialSelecting,
                             questions = emptyList(),

--- a/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/TutorialPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/views/logged_out/TutorialPage.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.views.logged_out
 import android.annotation.SuppressLint
 import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -23,9 +24,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.auth.api.identity.AuthorizationRequest
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.common.api.Scope
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.AuthError
 import com.kakao.sdk.common.model.AuthErrorCause
@@ -62,26 +63,24 @@ fun TutorialPage(
     val clientId = context.getString(R.string.web_client_id)
     val clientSecret = context.getString(R.string.web_client_secret)
 
-    val googleLoginActivityResultLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult(),
+    val googleAuthLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
     ) { result ->
-        when (result.resultCode) {
-            Activity.RESULT_OK -> {
-                try {
-                    val authCode = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-                        .getResult(ApiException::class.java)?.serverAuthCode
-                    if (authCode != null) {
-                        viewModel.onGoogleAuthCodeReceived(authCode, clientId, clientSecret)
-                    } else {
-                        context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
-                    }
-                } catch (e: ApiException) {
+        if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+            try {
+                val authorizationResult = Identity.getAuthorizationClient(activityContext)
+                    .getAuthorizationResultFromIntent(result.data!!)
+                val authCode = authorizationResult.serverAuthCode
+                if (authCode != null) {
+                    viewModel.onGoogleAuthCodeReceived(authCode, clientId, clientSecret)
+                } else {
                     context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
                 }
+            } catch (e: Exception) {
+                context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
             }
-
-            Activity.RESULT_CANCELED -> context.toast(context.getString(R.string.sign_in_sign_in_google_cancelled))
-            else -> context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+        } else {
+            context.toast(context.getString(R.string.sign_in_sign_in_google_cancelled))
         }
     }
 
@@ -92,13 +91,29 @@ fun TutorialPage(
                 is TutorialUiEvent.NavigateHome -> onNavigateHome()
 
                 is TutorialUiEvent.LaunchGoogleSignIn -> {
-                    val client = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                        .requestEmail()
-                        .requestServerAuthCode(clientId)
-                        .build().let { GoogleSignIn.getClient(activityContext, it) }
-                    client.signOut().addOnCompleteListener {
-                        googleLoginActivityResultLauncher.launch(client.signInIntent)
-                    }
+                    val authorizationRequest = AuthorizationRequest.builder()
+                        .setRequestedScopes(listOf(Scope("email")))
+                        .requestOfflineAccess(clientId)
+                        .build()
+                    Identity.getAuthorizationClient(activityContext)
+                        .authorize(authorizationRequest)
+                        .addOnSuccessListener { authorizationResult ->
+                            if (authorizationResult.hasResolution()) {
+                                googleAuthLauncher.launch(
+                                    IntentSenderRequest.Builder(authorizationResult.pendingIntent!!.intentSender).build(),
+                                )
+                            } else {
+                                val authCode = authorizationResult.serverAuthCode
+                                if (authCode != null) {
+                                    viewModel.onGoogleAuthCodeReceived(authCode, clientId, clientSecret)
+                                } else {
+                                    context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                                }
+                            }
+                        }
+                        .addOnFailureListener {
+                            context.toast(context.getString(R.string.sign_in_sign_in_google_failed_unknown))
+                        }
                 }
 
                 is TutorialUiEvent.LaunchFacebookLogin -> {

--- a/app/src/main/res/values/secrets_defaults.xml
+++ b/app/src/main/res/values/secrets_defaults.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- flavor(live/staging)의 strings.xml에서 실제 값으로 override됩니다. -->
+<!-- 이 파일은 IDE에서 R.string.* 참조를 인식시키기 위한 더미 기본값입니다. -->
+<resources>
+    <string name="app_name" translatable="false">SNUTT</string>
+    <string name="api_key" translatable="false">PLACEHOLDER</string>
+    <string name="api_server" translatable="false">PLACEHOLDER</string>
+    <string name="web_client_id" translatable="false">PLACEHOLDER</string>
+    <string name="web_client_secret" translatable="false">PLACEHOLDER</string>
+    <string name="facebook_app_id" translatable="false">PLACEHOLDER</string>
+    <string name="facebook_client_token" translatable="false">PLACEHOLDER</string>
+    <string name="fb_login_protocol_scheme" translatable="false">PLACEHOLDER</string>
+    <string name="review_base_url" translatable="false">PLACEHOLDER</string>
+    <string name="file_provider_authorities" translatable="false">PLACEHOLDER</string>
+    <string name="scheme" translatable="false">PLACEHOLDER</string>
+    <string name="naver_map_client_id" translatable="false">PLACEHOLDER</string>
+    <string name="kakao_native_app_key" translatable="false">PLACEHOLDER</string>
+    <string name="kakao_native_app_key_kakao" translatable="false">PLACEHOLDER</string>
+    <string name="theme_market_base_url" translatable="false">PLACEHOLDER</string>
+</resources>


### PR DESCRIPTION
## Summary

- **Google Sign-In → AuthorizationClient 마이그레이션**: deprecated된 `GoogleSignIn`/`GoogleSignInOptions` 클래스를 `AuthorizationClient` + `AuthorizationRequest`로 교체. 기존 `play-services-auth` 라이브러리 내의 신규 API를 사용하므로 의존성 변경 없음. ViewModel/백엔드 변경 없이 UI 레이어(`TutorialPage`, `SocialLinkPage`)만 수정.
- **기타 deprecated API 교체**: `rememberMarkerState` → `rememberUpdatedMarkerState`, `CancellableContinuation.resume` 시그니처 변경
- **컴파일러 워닝 정리**: unnecessary safe call/elvis 제거, annotation target 명시(`@param:`), opt-in 추가, unchecked cast suppress, redundant conversion 제거

## Google Sign-In 변경 상세

기존 흐름:
```
GoogleSignInOptions.requestServerAuthCode() → signInIntent 실행 → GoogleSignIn.getSignedInAccountFromIntent() → serverAuthCode
```

신규 흐름:
```
AuthorizationRequest.requestOfflineAccess() → authorize() → resolution 필요 시 IntentSender 실행 → getAuthorizationResultFromIntent() → serverAuthCode
```

- `serverAuthCode → accessToken 교환 → 백엔드 전송` 흐름은 그대로 유지
- `ActivityResultContracts.StartActivityForResult` → `StartIntentSenderForResult`로 변경

## 미해결

- `NaverMapSdk.NaverCloudPlatformClient` deprecated: NCP 콘솔에서 새 NCP Key ID 발급이 선행되어야 하므로 보류

## Test plan

- [ ] 구글 로그인 (TutorialPage)
- [ ] 구글 계정 연동/해제 (SocialLinkPage)
- [ ] 네이버 지도 표시 (EmbedMap)
- [ ] 페이스북 로그인

🤖 Generated with [Claude Code](https://claude.com/claude-code)