### PR TITLE
test: HomeDrawerViewModel 테스트 추가

### DIFF
--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeCourseBookRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeCourseBookRepository.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.snutt2.fake
+
+import com.wafflestudio.snutt2.data.course_books.CourseBookRepository
+import com.wafflestudio.snutt2.domainmodel.CourseBook
+import com.wafflestudio.snutt2.lib.network.Result
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeCourseBookRepository : CourseBookRepository {
+
+    override val courseBooks = MutableStateFlow<List<CourseBook>>(emptyList())
+
+    var fetchCourseBooksResult: Result<Unit> = Result.Success(Unit)
+    var fetchCourseBooksCalled = false
+        private set
+
+    override suspend fun fetchCourseBooks(): Result<Unit> {
+        fetchCourseBooksCalled = true
+        return fetchCourseBooksResult
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeTableRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeTableRepository.kt
@@ -1,0 +1,121 @@
+package com.wafflestudio.snutt2.fake
+
+import com.wafflestudio.snutt2.data.tables.TableRepository
+import com.wafflestudio.snutt2.domainmodel.CourseBook
+import com.wafflestudio.snutt2.domainmodel.LectureReminderOffset
+import com.wafflestudio.snutt2.domainmodel.LectureWithReminderOption
+import com.wafflestudio.snutt2.domainmodel.Table
+import com.wafflestudio.snutt2.domainmodel.TableSummary
+import com.wafflestudio.snutt2.domainmodel.TimetableLectureReminders
+import com.wafflestudio.snutt2.lib.network.Result
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeTableRepository : TableRepository {
+
+    // --- StateFlow ---
+    override val currentTable = MutableStateFlow<Table?>(null)
+    override val tableSummaryList = MutableStateFlow<List<TableSummary>>(emptyList())
+
+    // --- 테스트 제어용 필드 ---
+    var fetchAndSelectTableResult: Result<Unit> = Result.Success(Unit)
+    var fetchAndSelectTableCalledWith: String? = null
+        private set
+
+    var createAndSelectTableResult: Result<Unit> = Result.Success(Unit)
+    var createAndSelectTableCalledWith: Pair<CourseBook, String>? = null
+        private set
+
+    var updateTableNameResult: Result<Unit> = Result.Success(Unit)
+    var updateTableNameCalledWith: Pair<TableSummary, String>? = null
+        private set
+
+    var deleteTableResult: Result<Unit> = Result.Success(Unit)
+    var deleteTableCalledWith: TableSummary? = null
+        private set
+
+    var copyTableResult: Result<Unit> = Result.Success(Unit)
+    var copyTableCalledWith: TableSummary? = null
+        private set
+
+    var getTableByIdResult: Result<Table> = Result.Fail(
+        com.wafflestudio.snutt2.lib.network.Unknown(displayTitle = "", displayMessage = ""),
+    )
+    var getTableByIdCalledWith: String? = null
+        private set
+
+    var setPrimaryTableResult: Result<Unit> = Result.Success(Unit)
+    var setPrimaryTableCalledWith: TableSummary? = null
+        private set
+
+    var unsetPrimaryTableResult: Result<Unit> = Result.Success(Unit)
+    var unsetPrimaryTableCalledWith: TableSummary? = null
+        private set
+
+    var fetchTableListResult: Result<Unit> = Result.Success(Unit)
+    var fetchTableListCalled = false
+        private set
+
+    var updateTableThemeBuiltInResult: Result<Unit> = Result.Success(Unit)
+    var updateTableThemeCustomResult: Result<Unit> = Result.Success(Unit)
+
+    // --- 인터페이스 구현 ---
+    override suspend fun fetchAndSelectTable(id: String): Result<Unit> {
+        fetchAndSelectTableCalledWith = id
+        return fetchAndSelectTableResult
+    }
+
+    override suspend fun createAndSelectTable(courseBook: CourseBook, title: String): Result<Unit> {
+        createAndSelectTableCalledWith = courseBook to title
+        return createAndSelectTableResult
+    }
+
+    override suspend fun updateTableName(table: TableSummary, newTitle: String): Result<Unit> {
+        updateTableNameCalledWith = table to newTitle
+        return updateTableNameResult
+    }
+
+    override suspend fun deleteTable(table: TableSummary): Result<Unit> {
+        deleteTableCalledWith = table
+        return deleteTableResult
+    }
+
+    override suspend fun copyTable(table: TableSummary): Result<Unit> {
+        copyTableCalledWith = table
+        return copyTableResult
+    }
+
+    override suspend fun getTableById(id: String): Result<Table> {
+        getTableByIdCalledWith = id
+        return getTableByIdResult
+    }
+
+    override suspend fun setPrimaryTable(table: TableSummary): Result<Unit> {
+        setPrimaryTableCalledWith = table
+        return setPrimaryTableResult
+    }
+
+    override suspend fun unsetPrimaryTable(table: TableSummary): Result<Unit> {
+        unsetPrimaryTableCalledWith = table
+        return unsetPrimaryTableResult
+    }
+
+    override suspend fun fetchTableList(): Result<Unit> {
+        fetchTableListCalled = true
+        return fetchTableListResult
+    }
+
+    override suspend fun updateTableTheme(tableId: String, code: Int): Result<Unit> {
+        return updateTableThemeBuiltInResult
+    }
+
+    override suspend fun updateTableTheme(tableId: String, themeId: String): Result<Unit> {
+        return updateTableThemeCustomResult
+    }
+
+    // --- 미사용 메서드 ---
+    override suspend fun updateCurrentTable() = TODO("Not used in this test")
+    override suspend fun fetchAndSelectDefaultTable(): Result<Unit> = TODO("Not used in this test")
+    override suspend fun getTimetableReminders(timetableId: String): Result<TimetableLectureReminders> = TODO("Not used in this test")
+    override suspend fun getTimetableLectureReminder(timetableId: String, lectureId: String): Result<LectureWithReminderOption> = TODO("Not used in this test")
+    override suspend fun updateTimetableLectureReminder(timetableId: String, lectureId: String, offset: LectureReminderOffset): Result<LectureWithReminderOption> = TODO("Not used in this test")
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeThemeRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeThemeRepository.kt
@@ -1,0 +1,30 @@
+package com.wafflestudio.snutt2.fake
+
+import com.wafflestudio.snutt2.data.themes.ThemeRepository
+import com.wafflestudio.snutt2.domainmodel.BuiltInTheme
+import com.wafflestudio.snutt2.domainmodel.CustomTheme
+import com.wafflestudio.snutt2.domainmodel.ThemeColor
+import com.wafflestudio.snutt2.lib.network.Result
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeThemeRepository : ThemeRepository {
+
+    // --- StateFlow ---
+    override val customThemes = MutableStateFlow<List<CustomTheme>>(emptyList())
+    override val builtInThemes = MutableStateFlow<List<BuiltInTheme>>(emptyList())
+
+    // --- 테스트 제어용 필드 ---
+    var getThemeResult: CustomTheme? = null
+
+    // --- 인터페이스 구현 ---
+    override fun getTheme(themeId: String): CustomTheme {
+        return getThemeResult ?: error("getThemeResult not set for themeId=$themeId")
+    }
+
+    // --- 미사용 메서드 ---
+    override suspend fun fetchThemes(): Result<Unit> = TODO("Not used in this test")
+    override suspend fun createTheme(name: String, colors: List<ThemeColor>): Result<CustomTheme> = TODO("Not used in this test")
+    override suspend fun updateTheme(themeId: String, name: String, colors: List<ThemeColor>): Result<CustomTheme> = TODO("Not used in this test")
+    override suspend fun copyTheme(themeId: String): Result<Unit> = TODO("Not used in this test")
+    override suspend fun deleteTheme(themeId: String): Result<Unit> = TODO("Not used in this test")
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/fixture/TestFixtures.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fixture/TestFixtures.kt
@@ -1,9 +1,47 @@
 package com.wafflestudio.snutt2.fixture
 
+import com.wafflestudio.snutt2.domainmodel.CourseBook
 import com.wafflestudio.snutt2.domainmodel.LectureReviewInfo
 import com.wafflestudio.snutt2.domainmodel.SearchedLecture
+import com.wafflestudio.snutt2.domainmodel.Table
+import com.wafflestudio.snutt2.domainmodel.TableSummary
+import com.wafflestudio.snutt2.domainmodel.ThemeReference
 
 object TestFixtures {
+
+    // --- CourseBook ---
+
+    val courseBook2025_1 = CourseBook(semester = 1, year = 2025)
+    val courseBook2024_2 = CourseBook(semester = 2, year = 2024)
+
+    // --- TableSummary ---
+
+    fun tableSummary(
+        id: String = "table-1",
+        courseBook: CourseBook = courseBook2025_1,
+        title: String = "��의 시간표",
+        totalCredit: Long = 18,
+        isPrimary: Boolean = false,
+    ) = TableSummary(
+        id = id,
+        courseBook = courseBook,
+        title = title,
+        totalCredit = totalCredit,
+        isPrimary = isPrimary,
+    )
+
+    // --- Table ---
+
+    fun table(
+        summary: TableSummary = tableSummary(),
+        themeRef: ThemeReference = ThemeReference.BuiltIn(0),
+    ) = Table(
+        summary = summary,
+        lectures = emptyList(),
+        themeRef = themeRef,
+    )
+
+    // --- SearchedLecture ---
 
     fun searchedLecture(
         id: String = "lec-1",

--- a/app/src/test/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/views/logged_in/home/drawer/HomeDrawerViewModelTest.kt
@@ -1,0 +1,792 @@
+package com.wafflestudio.snutt2.views.logged_in.home.drawer
+
+import app.cash.turbine.test
+import com.wafflestudio.snutt2.domain.GetCurrentTableThemeUseCase
+import com.wafflestudio.snutt2.domainmodel.BuiltInTheme
+import com.wafflestudio.snutt2.domainmodel.CustomTheme
+import com.wafflestudio.snutt2.domainmodel.ThemeColor
+import com.wafflestudio.snutt2.fake.FakeCourseBookRepository
+import com.wafflestudio.snutt2.fake.FakeDisplayMessageResolver
+import com.wafflestudio.snutt2.fake.FakeTableRepository
+import com.wafflestudio.snutt2.fake.FakeThemeRepository
+import com.wafflestudio.snutt2.fixture.TestFixtures.courseBook2024_2
+import com.wafflestudio.snutt2.fixture.TestFixtures.courseBook2025_1
+import com.wafflestudio.snutt2.fixture.TestFixtures.table
+import com.wafflestudio.snutt2.fixture.TestFixtures.tableSummary
+import com.wafflestudio.snutt2.lib.network.Result
+import com.wafflestudio.snutt2.lib.network.Unknown
+import com.wafflestudio.snutt2.lib.toDataWithState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeDrawerViewModelTest {
+
+    private lateinit var fakeCourseBookRepository: FakeCourseBookRepository
+    private lateinit var fakeTableRepository: FakeTableRepository
+    private lateinit var fakeThemeRepository: FakeThemeRepository
+    private lateinit var fakeDisplayMessageResolver: FakeDisplayMessageResolver
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        fakeCourseBookRepository = FakeCourseBookRepository()
+        fakeTableRepository = FakeTableRepository()
+        fakeThemeRepository = FakeThemeRepository()
+        fakeDisplayMessageResolver = FakeDisplayMessageResolver()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = HomeDrawerViewModel(
+        courseBookRepository = fakeCourseBookRepository,
+        tableRepository = fakeTableRepository,
+        themeRepository = fakeThemeRepository,
+        getCurrentTableThemeUseCase = GetCurrentTableThemeUseCase(
+            themeRepository = fakeThemeRepository,
+            tableRepository = fakeTableRepository,
+        ),
+        displayMessageResolver = fakeDisplayMessageResolver,
+    )
+
+    // region init — combine으로 courseBookDrawerItemList 구성
+
+    @Test
+    fun `init 시 courseBooks와 tableSummaryList로 서랍 목록이 구성된다`() = runTest {
+        val summary1 = tableSummary(id = "t1", courseBook = courseBook2025_1, title = "시간표1")
+        val summary2 = tableSummary(id = "t2", courseBook = courseBook2024_2, title = "시간표2")
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1, courseBook2024_2)
+        fakeTableRepository.tableSummaryList.value = listOf(summary1, summary2)
+        fakeTableRepository.currentTable.value = table(summary = summary1)
+
+        val viewModel = createViewModel()
+
+        assertEquals(
+            HomeDrawerUiState(
+                courseBookDrawerItemList = listOf(
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2025_1,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary1),
+                    ).toDataWithState(true), // current semester → expanded
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2024_2,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary2),
+                    ).toDataWithState(false),
+                ),
+                selectedTable = summary1,
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `최신 학기에 시간표가 없어도 서랍에 표시되고 newCoursebookDot이 true이다`() = runTest {
+        val summary = tableSummary(id = "t1", courseBook = courseBook2024_2)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1, courseBook2024_2)
+        fakeTableRepository.tableSummaryList.value = listOf(summary)
+        fakeTableRepository.currentTable.value = table(summary = summary)
+
+        val viewModel = createViewModel()
+
+        assertEquals(
+            HomeDrawerUiState(
+                courseBookDrawerItemList = listOf(
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2025_1,
+                        showNewCoursebookDot = true,
+                        tableList = emptyList(),
+                    ).toDataWithState(false),
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2024_2,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary),
+                    ).toDataWithState(true), // current semester → expanded
+                ),
+                selectedTable = summary,
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `courseBooks가 비어있으면 서랍 목록이 갱신되지 않는다`() = runTest {
+        fakeCourseBookRepository.courseBooks.value = emptyList()
+        fakeTableRepository.tableSummaryList.value = listOf(tableSummary())
+        fakeTableRepository.currentTable.value = table()
+
+        val viewModel = createViewModel()
+
+        assertEquals(HomeDrawerUiState(), viewModel.uiState.value)
+    }
+
+    // endregion
+
+    // region Source 반응 — currentTable 변경 시 expanded 이동
+
+    @Test
+    fun `currentTable이 다른 학기로 변경되면 해당 학기가 expanded 되고 이전 학기도 유지된다`() = runTest {
+        val summary2025 = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        val summary2024 = tableSummary(id = "t2", courseBook = courseBook2024_2)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1, courseBook2024_2)
+        fakeTableRepository.tableSummaryList.value = listOf(summary2025, summary2024)
+        fakeTableRepository.currentTable.value = table(summary = summary2025)
+        val viewModel = createViewModel()
+
+        fakeTableRepository.currentTable.value = table(summary = summary2024)
+
+        // NOTE: isCurrentSemester || wasExpanded 로직으로 인해,
+        // 한번 expanded된 학기는 current가 아니게 되어도 접히지 않는다.
+        // 수동 toggle만이 접을 수 있다.
+        assertEquals(
+            HomeDrawerUiState(
+                courseBookDrawerItemList = listOf(
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2025_1,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary2025),
+                    ).toDataWithState(true), // 이전에 current로 expanded → wasExpanded로 유지
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2024_2,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary2024),
+                    ).toDataWithState(true), // 새로 current → expanded
+                ),
+                selectedTable = summary2024,
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    // endregion
+
+    // region Source 반응 — tableSummaryList 변경 시 그룹핑 반영
+
+    @Test
+    fun `tableSummaryList에 시간표가 추가되면 해당 학기의 tableList에 반영된다`() = runTest {
+        val summary1 = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary1)
+        fakeTableRepository.currentTable.value = table(summary = summary1)
+        val viewModel = createViewModel()
+
+        val summary2 = tableSummary(id = "t2", courseBook = courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary1, summary2)
+
+        assertEquals(
+            HomeDrawerUiState(
+                courseBookDrawerItemList = listOf(
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2025_1,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary1, summary2),
+                    ).toDataWithState(true),
+                ),
+                selectedTable = summary1,
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    // endregion
+
+    // region Source 반응 — expanded 보존
+
+    @Test
+    fun `수동으로 펼친 학기는 source 변화 후에도 expanded가 유지된다`() = runTest {
+        val summary2025 = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        val summary2024 = tableSummary(id = "t2", courseBook = courseBook2024_2)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1, courseBook2024_2)
+        fakeTableRepository.tableSummaryList.value = listOf(summary2025, summary2024)
+        fakeTableRepository.currentTable.value = table(summary = summary2025)
+        val viewModel = createViewModel()
+        // 2024-2를 수동으로 펼침 (index 1)
+        viewModel.toggleCourseBookDrawerItem(1)
+
+        // tableSummaryList 변경 → combine 재실행
+        val summary2025_2 = tableSummary(id = "t3", courseBook = courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary2025, summary2024, summary2025_2)
+
+        assertEquals(
+            HomeDrawerUiState(
+                courseBookDrawerItemList = listOf(
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2025_1,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary2025, summary2025_2),
+                    ).toDataWithState(true), // current → expanded
+                    CoursebookDrawerItem(
+                        courseBook = courseBook2024_2,
+                        showNewCoursebookDot = false,
+                        tableList = listOf(summary2024),
+                    ).toDataWithState(true), // 수동으로 펼쳤으므로 유지
+                ),
+                selectedTable = summary2025,
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    // endregion
+
+    // region onClickDrawerIcon
+
+    @Test
+    fun `onClickDrawerIcon 호출 시 OpenDrawer 이벤트가 발생한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.onClickDrawerIcon()
+            assertEquals(HomeDrawerUiEvent.OpenDrawer, awaitItem())
+        }
+    }
+
+    // endregion
+
+    // region toggleCourseBookDrawerItem
+
+    @Test
+    fun `toggleCourseBookDrawerItem 호출 시 해당 항목의 expanded가 토글된다`() = runTest {
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1, courseBook2024_2)
+        fakeTableRepository.tableSummaryList.value = listOf(
+            tableSummary(id = "t1", courseBook = courseBook2024_2),
+        )
+        fakeTableRepository.currentTable.value = table(
+            summary = tableSummary(id = "t1", courseBook = courseBook2024_2),
+        )
+        val viewModel = createViewModel()
+        val before = viewModel.uiState.value
+
+        // index 0 = courseBook2025_1 (최신 순 정렬)
+        viewModel.toggleCourseBookDrawerItem(0)
+
+        assertEquals(
+            before.copy(
+                courseBookDrawerItemList = before.courseBookDrawerItemList.mapIndexed { i, item ->
+                    if (i == 0) item.copy(state = !item.state) else item
+                },
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    // endregion
+
+    // region selectTable
+
+    @Test
+    fun `selectTable 호출 시 repository의 fetchAndSelectTable을 호출한다`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.selectTable("table-id")
+        assertEquals("table-id", fakeTableRepository.fetchAndSelectTableCalledWith)
+    }
+
+    @Test
+    fun `selectTable 성공 시 CloseDrawer 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.fetchAndSelectTableResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.selectTable("table-id")
+            assertEquals(HomeDrawerUiEvent.CloseDrawer, awaitItem())
+        }
+    }
+
+    @Test
+    fun `selectTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.fetchAndSelectTableResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.selectTable("table-id")
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region openCreateNewTableSheet / createNewTable
+
+    @Test
+    fun `openCreateNewTableSheet 호출 시 바텀시트 상태가 SelectCourseBook이 된다`() = runTest {
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1, courseBook2024_2)
+        fakeTableRepository.tableSummaryList.value = listOf(tableSummary(id = "t1"))
+        fakeTableRepository.currentTable.value = table(summary = tableSummary(id = "t1"))
+        val viewModel = createViewModel()
+        val before = viewModel.uiState.value
+
+        viewModel.openCreateNewTableSheet()
+
+        assertEquals(
+            before.copy(
+                homeDrawerBottomSheetType = HomeDrawerBottomSheetType.CreateNewTable.SelectCourseBook(
+                    initialCourseBook = courseBook2025_1,
+                    allCourseBook = listOf(courseBook2025_1, courseBook2024_2),
+                ),
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `openCreateNewTableSheet 호출 시 OpenBottomSheet 이벤트가 발생한다`() = runTest {
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.openCreateNewTableSheet()
+            assertEquals(HomeDrawerUiEvent.OpenBottomSheet, awaitItem())
+        }
+    }
+
+    @Test
+    fun `openCreateNewTableOfSpecificCourseBookSheet 호출 시 바텀시트 상태가 SpecificCourseBook이 된다`() = runTest {
+        val viewModel = createViewModel()
+        val before = viewModel.uiState.value
+
+        viewModel.openCreateNewTableOfSpecificCourseBookSheet(courseBook2025_1)
+
+        assertEquals(
+            before.copy(
+                homeDrawerBottomSheetType = HomeDrawerBottomSheetType.CreateNewTable.SpecificCourseBook(
+                    courseBook = courseBook2025_1,
+                ),
+            ),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `openCreateNewTableOfSpecificCourseBookSheet 호출 시 OpenBottomSheet 이벤트가 발생한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.openCreateNewTableOfSpecificCourseBookSheet(courseBook2025_1)
+            assertEquals(HomeDrawerUiEvent.OpenBottomSheet, awaitItem())
+        }
+    }
+
+    @Test
+    fun `createNewTable 호출 시 repository의 createAndSelectTable을 호출한다`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.createNewTable(courseBook2025_1, "새 시간표")
+        assertEquals(courseBook2025_1 to "새 시간표", fakeTableRepository.createAndSelectTableCalledWith)
+    }
+
+    @Test
+    fun `createNewTable 성공 시 CloseBottomSheet와 CloseDrawer 이벤트가 순서대로 발생한다`() = runTest {
+        fakeTableRepository.createAndSelectTableResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.createNewTable(courseBook2025_1, "새 시간표")
+            assertEquals(HomeDrawerUiEvent.CloseBottomSheet, awaitItem())
+            assertEquals(HomeDrawerUiEvent.CloseDrawer, awaitItem())
+        }
+    }
+
+    @Test
+    fun `createNewTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.createAndSelectTableResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.createNewTable(courseBook2025_1, "새 시간표")
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region openMoreActionBottomSheet
+
+    @Test
+    fun `openMoreActionBottomSheet 호출 시 바텀시트 상태가 MoreAction이 된다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        val viewModel = createViewModel()
+        val before = viewModel.uiState.value
+
+        viewModel.openMoreActionBottomSheet(summary)
+
+        assertEquals(
+            before.copy(homeDrawerBottomSheetType = HomeDrawerBottomSheetType.MoreAction(summary)),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `openMoreActionBottomSheet 호출 시 OpenBottomSheet 이벤트가 발생한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.openMoreActionBottomSheet(tableSummary(id = "t1"))
+            assertEquals(HomeDrawerUiEvent.OpenBottomSheet, awaitItem())
+        }
+    }
+
+    // endregion
+
+    // region openChangeTableNameDialog / changeTableTitle
+
+    @Test
+    fun `openChangeTableNameDialog 호출 시 ChangeTableName 다이얼로그가 열린다`() = runTest {
+        val viewModel = createViewModel()
+        val before = viewModel.uiState.value
+        val summary = tableSummary(id = "t1")
+
+        viewModel.openChangeTableNameDialog(summary)
+
+        assertEquals(
+            before.copy(dialogState = HomeDrawerUiState.DialogState.ChangeTableName(summary)),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `changeTableTitle 호출 시 repository의 updateTableName을 호출한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        val viewModel = createViewModel()
+
+        viewModel.changeTableTitle(summary, "변경된 이름")
+
+        assertEquals(summary to "변경된 이름", fakeTableRepository.updateTableNameCalledWith)
+    }
+
+    @Test
+    fun `changeTableTitle 성공 시 다이얼로그가 닫히고 CloseBottomSheet 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.updateTableNameResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+        val summary = tableSummary(id = "t1")
+        viewModel.openChangeTableNameDialog(summary)
+
+        viewModel.uiEvent.test {
+            viewModel.changeTableTitle(summary, "변경된 이름")
+            assertEquals(HomeDrawerUiEvent.CloseBottomSheet, awaitItem())
+        }
+        assertEquals(HomeDrawerUiState.DialogState.None, viewModel.uiState.value.dialogState)
+    }
+
+    @Test
+    fun `changeTableTitle 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.updateTableNameResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.changeTableTitle(tableSummary(id = "t1"), "변경된 이름")
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region openDeleteTableDialog / deleteTable
+
+    @Test
+    fun `openDeleteTableDialog 호출 시 DeleteTable 다이얼로그가 열린다`() = runTest {
+        val viewModel = createViewModel()
+        val before = viewModel.uiState.value
+        val summary = tableSummary(id = "t1")
+
+        viewModel.openDeleteTableDialog(summary)
+
+        assertEquals(
+            before.copy(dialogState = HomeDrawerUiState.DialogState.DeleteTable(summary)),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `deleteTable 호출 시 repository의 deleteTable을 호출한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary)
+        fakeTableRepository.currentTable.value = table(summary = tableSummary(id = "t2"))
+        val viewModel = createViewModel()
+
+        viewModel.deleteTable(summary)
+
+        assertEquals(summary, fakeTableRepository.deleteTableCalledWith)
+    }
+
+    @Test
+    fun `deleteTable 성공 시 다이얼로그가 닫히고 CloseBottomSheet 이벤트가 발생한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary)
+        fakeTableRepository.currentTable.value = table(summary = tableSummary(id = "t2"))
+        fakeTableRepository.deleteTableResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+        viewModel.openDeleteTableDialog(summary)
+
+        viewModel.uiEvent.test {
+            viewModel.deleteTable(summary)
+            assertEquals(HomeDrawerUiEvent.CloseBottomSheet, awaitItem())
+        }
+        assertEquals(HomeDrawerUiState.DialogState.None, viewModel.uiState.value.dialogState)
+    }
+
+    @Test
+    fun `deleteTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary)
+        fakeTableRepository.currentTable.value = table(summary = tableSummary(id = "t2"))
+        fakeTableRepository.deleteTableResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.deleteTable(summary)
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region shareTable
+
+    @Test
+    fun `shareTable 호출 시 repository의 getTableById를 호출한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        val viewModel = createViewModel()
+
+        viewModel.shareTable(summary)
+
+        assertEquals("t1", fakeTableRepository.getTableByIdCalledWith)
+    }
+
+    @Test
+    fun `shareTable 성공 시 ShareTable 이벤트가 발생한다`() = runTest {
+        val tableObj = table(summary = tableSummary(id = "t1"))
+        fakeTableRepository.getTableByIdResult = Result.Success(tableObj)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.shareTable(tableSummary(id = "t1"))
+            val event = assertIs<HomeDrawerUiEvent.ShareTable>(awaitItem())
+            assertEquals(tableObj, event.table)
+        }
+    }
+
+    @Test
+    fun `shareTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.getTableByIdResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.shareTable(tableSummary(id = "t1"))
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region dismissDialog
+
+    @Test
+    fun `dismissDialog 호출 시 다이얼로그가 닫힌다`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.openChangeTableNameDialog(tableSummary())
+        val before = viewModel.uiState.value
+
+        viewModel.dismissDialog()
+
+        assertEquals(
+            before.copy(dialogState = HomeDrawerUiState.DialogState.None),
+            viewModel.uiState.value,
+        )
+    }
+
+    // endregion
+
+    // region onDrawerOpened
+
+    @Test
+    fun `onDrawerOpened 호출 시 fetchTableList와 fetchCourseBooks가 호출된다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.onDrawerOpened()
+
+        assertEquals(true, fakeTableRepository.fetchTableListCalled)
+        assertEquals(true, fakeCourseBookRepository.fetchCourseBooksCalled)
+    }
+
+    // endregion
+
+    // region copyTable
+
+    @Test
+    fun `copyTable 호출 시 repository의 copyTable을 호출한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        val viewModel = createViewModel()
+
+        viewModel.copyTable(summary)
+
+        assertEquals(summary, fakeTableRepository.copyTableCalledWith)
+    }
+
+    @Test
+    fun `copyTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.copyTableResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.copyTable(tableSummary(id = "t1"))
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region navigateToThemeDetail
+
+    @Test
+    fun `navigateToThemeDetail 호출 시 NavigateToThemeDetail 이벤트가 발생한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.navigateToThemeDetail()
+            assertEquals(HomeDrawerUiEvent.NavigateToThemeDetail, awaitItem())
+        }
+    }
+
+    // endregion
+
+    // region closeSheet
+
+    @Test
+    fun `closeSheet 호출 시 CloseBottomSheet 이벤트가 발생한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.closeSheet()
+            assertEquals(HomeDrawerUiEvent.CloseBottomSheet, awaitItem())
+        }
+    }
+
+    // endregion
+
+    // region onSheetDismissed
+
+    @Test
+    fun `onSheetDismissed 호출 시 바텀시트가 Empty가 된다`() = runTest {
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        val viewModel = createViewModel()
+        viewModel.openCreateNewTableSheet()
+        val before = viewModel.uiState.value
+
+        viewModel.onSheetDismissed()
+
+        assertEquals(
+            before.copy(homeDrawerBottomSheetType = HomeDrawerBottomSheetType.Empty),
+            viewModel.uiState.value,
+        )
+    }
+
+    // NOTE: sheetTransitionTarget을 통한 시트 전환 테스트는 onClickSetThemeSheet → changeToSelectThemeSheet 흐름에서
+    // getCurrentTableThemeUseCase().first()가 Flow의 첫 emission을 기다리는데,
+    // UnconfinedTestDispatcher에서 combine의 initial emission 타이밍이 미묘하여
+    // 별도의 세팅이 필요하다. 우선 기본 동작만 검증하고, 시트 전환 패턴은 추후 다룬다.
+
+    // endregion
+
+    // region setPrimaryTable
+
+    @Test
+    fun `setPrimaryTable 호출 시 repository의 setPrimaryTable을 호출한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        val viewModel = createViewModel()
+
+        viewModel.setPrimaryTable(summary)
+
+        assertEquals(summary, fakeTableRepository.setPrimaryTableCalledWith)
+    }
+
+    @Test
+    fun `setPrimaryTable 성공 시 CloseBottomSheet 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.setPrimaryTableResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.setPrimaryTable(tableSummary(id = "t1"))
+            assertEquals(HomeDrawerUiEvent.CloseBottomSheet, awaitItem())
+        }
+    }
+
+    @Test
+    fun `setPrimaryTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.setPrimaryTableResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.setPrimaryTable(tableSummary(id = "t1"))
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+
+    // region unsetPrimaryTable
+
+    @Test
+    fun `unsetPrimaryTable 호출 시 repository의 unsetPrimaryTable을 호출한다`() = runTest {
+        val summary = tableSummary(id = "t1")
+        val viewModel = createViewModel()
+
+        viewModel.unsetPrimaryTable(summary)
+
+        assertEquals(summary, fakeTableRepository.unsetPrimaryTableCalledWith)
+    }
+
+    @Test
+    fun `unsetPrimaryTable 성공 시 CloseBottomSheet 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.unsetPrimaryTableResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.unsetPrimaryTable(tableSummary(id = "t1"))
+            assertEquals(HomeDrawerUiEvent.CloseBottomSheet, awaitItem())
+        }
+    }
+
+    @Test
+    fun `unsetPrimaryTable 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeTableRepository.unsetPrimaryTableResult =
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.unsetPrimaryTable(tableSummary(id = "t1"))
+            val event = assertIs<HomeDrawerUiEvent.ShowToast>(awaitItem())
+            assertEquals("에러", event.displayMessage)
+        }
+    }
+
+    // endregion
+}

--- a/docs/viewmodel-test-strategy.md
+++ b/docs/viewmodel-test-strategy.md
@@ -225,6 +225,31 @@ source 테스트에서는 Fake의 `MutableStateFlow`에 `.value = ...`로 변화
 
 하나의 테스트에서 여러 범주를 동시에 검증하지 않는다.
 
+#### 테스트 작성 절차
+
+**나가는 방향**: 각 public 함수에 대해, 아래 범주를 **빠짐없이 열거**하고 해당되는 것마다 테스트를 작성한다:
+
+1. **Repository 호출**: 올바른 인자로 호출되었는가?
+2. **UiEvent (성공)**: 성공 시 올바른 이벤트가 발행되는가?
+3. **UiEvent (실패)**: 실패 시 올바른 에러 이벤트가 발행되는가?
+4. **UiState 전이**: 상태가 올바르게 변경되는가?
+
+해당되지 않는 범주는 건너뛴다 (예: Repository를 호출하지 않는 함수는 1번 생략). 하지만 **해당되는데 빠뜨리지 않도록** 매 함수마다 위 목록을 체크한다.
+
+**들어오는 방향**: 테스트 작성 전에 init의 combine/collect 로직을 읽고, **각 source가 UiState의 어떤 필드에 어떤 변환으로 기여하는지** 파악한다. 그 이해를 바탕으로 시나리오를 도출한다.
+
+1. init 블록의 combine/collect 대상 source를 열거한다.
+2. 각 source가 combine 내에서 **어떤 로직에 사용되는지** 파악한다 (그룹핑, 정렬, 조건부 플래그, 상태 보존 등).
+3. 그 로직에서 의미 있는 시나리오를 도출하여 테스트를 작성한다.
+
+예: `combine(courseBooks, tableSummaryList, currentTable)`에서
+- `courseBooks.first()`가 최신 학기를 결정 → 최신 학기에 시간표가 없으면 빈 항목 + dot 표시
+- `tableSummaryList`가 courseBook별로 그룹핑 → 시간표 추가 시 해당 학기 tableList에 반영
+- `currentTable`의 courseBook이 expanded 결정 → 학기 전환 시 expanded 이동
+- `previousExpandedState`가 이전 expanded를 보존 → source 변화 후에도 수동 펼침 유지
+
+"source가 변하면 UiState가 갱신된다" 같은 피상적 검증이 아니라, **combine 로직의 구체적인 동작**을 검증해야 한다.
+
 나가는 방향 테스트는 **public 함수 단위로**, 들어오는 방향 테스트는 **source 단위로** region을 묶어 구조화한다:
 
 ```kotlin
@@ -335,6 +360,39 @@ fun `init 시 fetch 성공하고 강의가 있으면 Loaded 상태가 된다`() 
 ```
 
 **어떤 경우든 개별 필드를 하나씩 assertEquals 하지 않는다.** 반드시 전체 객체 단위로 비교한다.
+
+#### 주의: init combine 결과도 예외 없이 전체 객체 비교
+
+init의 combine이 복잡한 파생 로직(그룹핑, 정렬, 조건부 플래그 등)으로 상태를 구성하더라도 기대 객체를 직접 만들어 비교한다. "기대 객체가 복잡해질 것 같다"는 이유로 개별 필드 검증으로 후퇴하지 않는다.
+
+실제로 기대 객체를 구성해 보면 대부분 가능하고, 이를 통해 combine 로직의 모든 출력 필드가 한눈에 검증된다:
+
+```kotlin
+@Test
+fun `init 시 courseBooks와 tableSummaryList로 서랍 목록이 구성된다`() = runTest {
+    // ... Fake 세팅 ...
+    val viewModel = createViewModel()
+
+    assertEquals(
+        HomeDrawerUiState(
+            courseBookDrawerItemList = listOf(
+                CoursebookDrawerItem(
+                    courseBook = courseBook2025_1,
+                    showNewCoursebookDot = false,
+                    tableList = listOf(summary1),
+                ).toDataWithState(true),
+                CoursebookDrawerItem(
+                    courseBook = courseBook2024_2,
+                    showNewCoursebookDot = false,
+                    tableList = listOf(summary2),
+                ).toDataWithState(false),
+            ),
+            selectedTable = summary1,
+        ),
+        viewModel.uiState.value,
+    )
+}
+```
 
 ---
 


### PR DESCRIPTION
## 변경사항
뷰모델 테스트 작성 규칙을 보완해 가면서 테스트 하나씩 짜기

```

**나가는 방향**: 각 public 함수에 대해, 아래 범주를 **빠짐없이 열거**하고 해당되는 것마다 테스트를 작성한다:

1. **Repository 호출**: 올바른 인자로 호출되었는가?
2. **UiEvent (성공)**: 성공 시 올바른 이벤트가 발행되는가?
3. **UiEvent (실패)**: 실패 시 올바른 에러 이벤트가 발행되는가?
4. **UiState 전이**: 상태가 올바르게 변경되는가?

해당되지 않는 범주는 건너뛴다 (예: Repository를 호출하지 않는 함수는 1번 생략). 하지만 **해당되는데 빠뜨리지 않도록** 매 함수마다 위 목록을 체크한다.

**들어오는 방향**: 테스트 작성 전에 init의 combine/collect 로직을 읽고, **각 source가 UiState의 어떤 필드에 어떤 변환으로 기여하는지** 파악한다. 그 이해를 바탕으로 시나리오를 도출한다.

1. init 블록의 combine/collect 대상 source를 열거한다.
2. 각 source가 combine 내에서 **어떤 로직에 사용되는지** 파악한다 (그룹핑, 정렬, 조건부 플래그, 상태 보존 등).
3. 그 로직에서 의미 있는 시나리오를 도출하여 테스트를 작성한다.
```