### PR TITLE
[CI정비] ci/docs: Phase 1 기반 정비 + Phase 2 Lint 통합 + Phase 4 계획 확정

### DIFF
--- a/.github/actions/setup-secrets/action.yml
+++ b/.github/actions/setup-secrets/action.yml
@@ -1,0 +1,60 @@
+name: Setup Secrets
+description: 'Write build-time secrets (google-services.json, secrets.xml, gcp-service-account.json, keystore) for a given product flavor.'
+
+inputs:
+  variant:
+    description: 'Product flavor: staging or live'
+    required: true
+  google_services_json:
+    description: 'Contents of google-services.json for the variant'
+    required: true
+  secrets_xml_app:
+    description: 'Contents of app/src/<variant>/res/values/secrets.xml'
+    required: true
+  gcp_service_account:
+    description: 'Contents of gcp-service-account-<variant>.json (optional)'
+    required: false
+    default: ''
+  keystore_base64:
+    description: 'Base64-encoded release keystore (optional, required for release builds)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Write google-services.json
+      shell: bash
+      env:
+        CONTENT: ${{ inputs.google_services_json }}
+        VARIANT: ${{ inputs.variant }}
+      run: |
+        mkdir -p "./app/src/${VARIANT}"
+        printf '%s' "$CONTENT" > "./app/src/${VARIANT}/google-services.json"
+
+    - name: Write app secrets.xml
+      shell: bash
+      env:
+        CONTENT: ${{ inputs.secrets_xml_app }}
+        VARIANT: ${{ inputs.variant }}
+      run: |
+        mkdir -p "./app/src/${VARIANT}/res/values"
+        printf '%s' "$CONTENT" > "./app/src/${VARIANT}/res/values/secrets.xml"
+
+    - name: Write gcp-service-account.json
+      if: inputs.gcp_service_account != ''
+      shell: bash
+      env:
+        CONTENT: ${{ inputs.gcp_service_account }}
+        VARIANT: ${{ inputs.variant }}
+      run: |
+        printf '%s' "$CONTENT" > "./gcp-service-account-${VARIANT}.json"
+
+    - name: Decode keystore
+      if: inputs.keystore_base64 != ''
+      shell: bash
+      env:
+        ENCODED: ${{ inputs.keystore_base64 }}
+      run: |
+        mkdir -p ./app/keystore
+        printf '%s' "$ENCODED" | base64 -d > ./app/keystore/android.jks

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Setup secrets
         uses: ./.github/actions/setup-secrets
         with:
@@ -63,7 +64,8 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Setup secrets
         uses: ./.github/actions/setup-secrets
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,35 +19,14 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
-      - name: Setup google-services.json (Live)
-        run: |
-          mkdir -p ./app/src/live
-          cat << EOF > ./app/src/live/google-services.json
-          ${{ secrets.google_services_json_live }}
-          EOF
-      - name: Setup gcp-service-account.json (Live)
-        run: |
-          cat << EOF > ./gcp-service-account-live.json
-          ${{ secrets.app_distribution_service_account_live }}
-          EOF
-      - name: Setup secrets.xml for app module (Live)
-        run: |
-          mkdir -p ./app/src/live/res/values
-          cat << EOF > ./app/src/live/res/values/secrets.xml
-          ${{ secrets.secrets_xml_live }}
-          EOF
-      - name: Setup secrets.xml for core:network module (Live)
-        run: |
-          mkdir -p ./core/network/src/live/res/values
-          cat << EOF > ./core/network/src/live/res/values/secrets.xml
-          ${{ secrets.secrets_xml_live_core_network }}
-          EOF
-      - name: Decode Keystore
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE }}
-        run: |
-          mkdir -p ./app/keystore
-          echo $ENCODED_STRING | base64 -di > ./app/keystore/android.jks
+      - name: Setup secrets
+        uses: ./.github/actions/setup-secrets
+        with:
+          variant: live
+          google_services_json: ${{ secrets.google_services_json_live }}
+          secrets_xml_app: ${{ secrets.secrets_xml_live }}
+          gcp_service_account: ${{ secrets.app_distribution_service_account_live }}
+          keystore_base64: ${{ secrets.KEYSTORE }}
       - name: Build production apk
         run: ./gradlew bundleLiveRelease
         env:
@@ -85,35 +64,14 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
-      - name: Setup google-services.json (Staging)
-        run: |
-          mkdir -p ./app/src/staging
-          cat << EOF > ./app/src/staging/google-services.json
-          ${{ secrets.google_services_json_staging }}
-          EOF
-      - name: Setup gcp-service-account.json (Staging)
-        run: |
-          cat << EOF > ./gcp-service-account-staging.json
-          ${{ secrets.app_distribution_service_account_staging }}
-          EOF
-      - name: Setup secrets.xml for app module (Staging)
-        run: |
-          mkdir -p ./app/src/staging/res/values
-          cat << EOF > ./app/src/staging/res/values/secrets.xml
-          ${{ secrets.secrets_xml_staging }}
-          EOF
-      - name: Setup secrets.xml for core:network module (Staging)
-        run: |
-          mkdir -p ./core/network/src/staging/res/values
-          cat << EOF > ./core/network/src/staging/res/values/secrets.xml
-          ${{ secrets.secrets_xml_staging_core_network }}
-          EOF
-      - name: Decode Keystore
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE }}
-        run: |
-          mkdir -p ./app/keystore
-          echo $ENCODED_STRING | base64 -di > ./app/keystore/android.jks
+      - name: Setup secrets
+        uses: ./.github/actions/setup-secrets
+        with:
+          variant: staging
+          google_services_json: ${{ secrets.google_services_json_staging }}
+          secrets_xml_app: ${{ secrets.secrets_xml_staging }}
+          gcp_service_account: ${{ secrets.app_distribution_service_account_staging }}
+          keystore_base64: ${{ secrets.KEYSTORE }}
       - name: Build production apk
         run: ./gradlew assembleStagingRelease
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,24 +24,12 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
-      - name: Setup google-services.json (Staging)
-        run: |
-          mkdir -p ./app/src/staging
-          cat << EOF > ./app/src/staging/google-services.json
-          ${{ secrets.google_services_json_staging }}
-          EOF
-      - name: Setup secrets.xml for app module (Staging)
-        run: |
-          mkdir -p ./app/src/staging/res/values
-          cat << EOF > ./app/src/staging/res/values/secrets.xml
-          ${{ secrets.secrets_xml_staging }}
-          EOF
-      - name: Setup secrets.xml for core:network module (Staging)
-        run: |
-          mkdir -p ./core/network/src/staging/res/values
-          cat << EOF > ./core/network/src/staging/res/values/secrets.xml
-          ${{ secrets.secrets_xml_staging_core_network }}
-          EOF
+      - name: Setup secrets
+        uses: ./.github/actions/setup-secrets
+        with:
+          variant: staging
+          google_services_json: ${{ secrets.google_services_json_staging }}
+          secrets_xml_app: ${{ secrets.secrets_xml_staging }}
       - name: Run ktlint and build debug APK
         run: ./gradlew ktlintCheck assembleStagingDebug --stacktrace
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
       - name: Setup google-services.json (Staging)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Setup secrets
         uses: ./.github/actions/setup-secrets
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  ktlint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,13 +33,40 @@ jobs:
           variant: staging
           google_services_json: ${{ secrets.google_services_json_staging }}
           secrets_xml_app: ${{ secrets.secrets_xml_staging }}
-      - name: Run ktlint and build debug APK
-        run: ./gradlew ktlintCheck assembleStagingDebug --stacktrace
-      - name: Run unit tests
-        run: ./gradlew testStagingDebugUnitTest --stacktrace
+      - name: Run ktlint
+        run: ./gradlew ktlintCheck --stacktrace
       - name: Upload ktlint report
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ktlint-result
           path: ./**/build/reports/ktlint/**/*.html
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+      - name: Setup secrets
+        uses: ./.github/actions/setup-secrets
+        with:
+          variant: staging
+          google_services_json: ${{ secrets.google_services_json_staging }}
+          secrets_xml_app: ${{ secrets.secrets_xml_staging }}
+      - name: Build debug APK and run unit tests
+        run: ./gradlew assembleStagingDebug testStagingDebugUnitTest --stacktrace
+      - name: Upload unit test report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: unit-test-report
+          path: ./**/build/reports/tests/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,17 @@ jobs:
           variant: staging
           google_services_json: ${{ secrets.google_services_json_staging }}
           secrets_xml_app: ${{ secrets.secrets_xml_staging }}
-      - name: Build debug APK and run unit tests
-        run: ./gradlew assembleStagingDebug testStagingDebugUnitTest --stacktrace
+      - name: Build debug APK, run unit tests, run lint
+        run: ./gradlew assembleStagingDebug testStagingDebugUnitTest lintStagingDebug --stacktrace
       - name: Upload unit test report
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: unit-test-report
           path: ./**/build/reports/tests/**
+      - name: Upload lint report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: lint-report
+          path: ./**/build/reports/lint-results-*.html

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Setup secrets (Live)
         if: github.event.inputs.variant == 'live'
         uses: ./.github/actions/setup-secrets

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -33,85 +33,43 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
-      - name: Setup google-services.json (Live)
-        if: startsWith(github.event.inputs.variant, 'live')
-        run: |
-          mkdir -p ./app/src/live
-          cat << EOF > ./app/src/live/google-services.json
-          ${{ secrets.google_services_json_live }}
-          EOF
-      - name: Setup google-services.json (Staging)
-        if: startsWith(github.event.inputs.variant, 'staging')
-        run: |
-          mkdir -p ./app/src/staging
-          cat << EOF > ./app/src/staging/google-services.json
-          ${{ secrets.google_services_json_staging }}
-          EOF
-      - name: Setup gcp-service-account.json (Live)
-        if: startsWith(github.event.inputs.variant, 'live')
-        run: |
-          cat << EOF > ./gcp-service-account-live.json
-          ${{ secrets.app_distribution_service_account_live }}
-          EOF
-      - name: Setup gcp-service-account.json (Staging)
-        if: startsWith(github.event.inputs.variant, 'staging')
-        run: |
-          cat << EOF > ./gcp-service-account-staging.json
-          ${{ secrets.app_distribution_service_account_staging }}
-          EOF
-      - name: Setup secrets.xml for app module (Live)
-        if: startsWith(github.event.inputs.variant, 'live')
-        run: |
-          mkdir -p ./app/src/live/res/values
-          cat << EOF > ./app/src/live/res/values/secrets.xml
-          ${{ secrets.secrets_xml_live }}
-          EOF
-      - name: Setup secrets.xml for core:network module (Live)
-        if: startsWith(github.event.inputs.variant, 'live')
-        run: |
-          mkdir -p ./core/network/src/live/res/values
-          cat << EOF > ./core/network/src/live/res/values/secrets.xml
-          ${{ secrets.secrets_xml_live_core_network }}
-          EOF
-      - name: Setup secrets.xml for app module (Staging)
-        if: startsWith(github.event.inputs.variant, 'staging')
-        run: |
-          mkdir -p ./app/src/staging/res/values
-          cat << EOF > ./app/src/staging/res/values/secrets.xml
-          ${{ secrets.secrets_xml_staging }}
-          EOF
-      - name: Setup secrets.xml for core:network module (Staging)
-        if: startsWith(github.event.inputs.variant, 'staging')
-        run: |
-          mkdir -p ./core/network/src/staging/res/values
-          cat << EOF > ./core/network/src/staging/res/values/secrets.xml
-          ${{ secrets.secrets_xml_staging_core_network }}
-          EOF
-      - name: Decode Keystore
-        env:
-          ENCODED_STRING: ${{ secrets.KEYSTORE }}
-        run: |
-          mkdir -p ./app/keystore
-          echo $ENCODED_STRING | base64 -di > ./app/keystore/android.jks
+      - name: Setup secrets (Live)
+        if: github.event.inputs.variant == 'live'
+        uses: ./.github/actions/setup-secrets
+        with:
+          variant: live
+          google_services_json: ${{ secrets.google_services_json_live }}
+          secrets_xml_app: ${{ secrets.secrets_xml_live }}
+          gcp_service_account: ${{ secrets.app_distribution_service_account_live }}
+          keystore_base64: ${{ secrets.KEYSTORE }}
+      - name: Setup secrets (Staging)
+        if: github.event.inputs.variant == 'staging'
+        uses: ./.github/actions/setup-secrets
+        with:
+          variant: staging
+          google_services_json: ${{ secrets.google_services_json_staging }}
+          secrets_xml_app: ${{ secrets.secrets_xml_staging }}
+          gcp_service_account: ${{ secrets.app_distribution_service_account_staging }}
+          keystore_base64: ${{ secrets.KEYSTORE }}
       - name: Build production apk (Live)
-        if: startsWith(github.event.inputs.variant, 'live')
+        if: github.event.inputs.variant == 'live'
         run: ./gradlew bundleLiveRelease
         env:
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Build production apk (Staging)
-        if: startsWith(github.event.inputs.variant, 'staging')
+        if: github.event.inputs.variant == 'staging'
         run: ./gradlew assembleStagingRelease
         env:
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Upload artifact to Firebase App Distribution (Live)
-        if: ${{ github.event.inputs.firebase == 'true' && startsWith(github.event.inputs.variant, 'live') }}
+        if: ${{ github.event.inputs.firebase == 'true' && github.event.inputs.variant == 'live' }}
         run: ./gradlew appDistributionUploadLiveRelease
       - name: Upload artifact to Firebase App Distribution (Staging)
-        if: ${{ github.event.inputs.firebase == 'true' && startsWith(github.event.inputs.variant, 'staging') }}
+        if: ${{ github.event.inputs.firebase == 'true' && github.event.inputs.variant == 'staging' }}
         run: ./gradlew appDistributionUploadStagingRelease
       - name: Slack Notification
         if: ${{ github.event.inputs.slack == 'true' }}
@@ -122,7 +80,7 @@ jobs:
           SLACK_MESSAGE: ${{ github.event.inputs.slack_message }}
           SLACK_USERNAME: BuildNoti
       - name: Slack Upload APK (Live)
-        if: ${{ github.event.inputs.slack == 'true' && startsWith(github.event.inputs.variant, 'live') }}
+        if: ${{ github.event.inputs.slack == 'true' && github.event.inputs.variant == 'live' }}
         uses: MeilCli/slack-upload-file@v3
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}
@@ -132,7 +90,7 @@ jobs:
           file_type: 'apk'
           initial_comment: 'live-release APK'
       - name: Slack Upload APK (Staging)
-        if: ${{ github.event.inputs.slack == 'true' && startsWith(github.event.inputs.variant, 'staging') }}
+        if: ${{ github.event.inputs.slack == 'true' && github.event.inputs.variant == 'staging' }}
         uses: MeilCli/slack-upload-file@v3
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Setup google-services.json (Live)
         if: startsWith(github.event.inputs.variant, 'live')

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,10 @@ android {
         viewBinding = true
         buildConfig = true
     }
+
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dependencies {

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,3714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.0.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.1)" variant="all" version="9.0.1">
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="    return &quot;$startHour:${String.format(&quot;%02d&quot;, startMinute)}-$endHour:${"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/SearchOptionUtils.kt"
+            line="109"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        String.format("
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/SearchOptionUtils.kt"
+            line="110"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="InlinedApi"
+        message="Field requires API level 31 (current min is 24): `android.appwidget.AppWidgetManager#OPTION_APPWIDGET_SIZES`"
+        errorLine1="            options.getParcelableArrayList&lt;SizeF>(AppWidgetManager.OPTION_APPWIDGET_SIZES)"
+        errorLine2="                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/TimetableWidgetProvider.kt"
+            line="69"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `enableOnBackInvokedCallback` is only used in API level 33 and higher (current min is 24)"
+        errorLine1="        android:enableOnBackInvokedCallback=&quot;false&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="12"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="AppLinkUrlError"
+        message="Scheme matching is case sensitive and should only use lower-case characters"
+        errorLine1="                    android:scheme=&quot;@string/kakao_native_app_key_kakao&quot; />"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="53"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="AppLinkUrlError"
+        message="Scheme matching is case sensitive and should only use lower-case characters"
+        errorLine1="                    android:scheme=&quot;@string/kakao_native_app_key_kakao&quot; />"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="70"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="CredentialDependency"
+        message="This app supports Android 13 and depends on `androidx.credentials:credentials`, and so should also depend on `androidx.credentials:credentials-play-services-auth`"
+        errorLine1="    &lt;application"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="9"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="UnspecifiedRegisterReceiverFlag"
+        message="`receiver` is missing `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED` flag for unprotected broadcasts registered for an IntentFilter that cannot be inspected by lint"
+        errorLine1="            super.registerReceiver(receiver, filter)"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/SNUTTApplication.kt"
+            line="33"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="VectorRaster"
+        message="Limit vector icons sizes to 200×200 to keep icon drawing fast; see https://developer.android.com/studio/write/vector-asset-studio#when for more"
+        errorLine1="    android:width=&quot;288dp&quot;"
+        errorLine2="                   ~~~~~">
+        <location
+            file="src/main/res/drawable/snutt_splash_icon.xml"
+            line="2"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of Gradle than 9.1.0 is available: 9.4.1"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/wrapper/gradle-wrapper.properties"
+            line="5"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AndroidGradlePluginVersion"
+        message="A newer version of com.android.application than 9.0.1 is available: 9.1.1"
+        errorLine1="androidGradle = &quot;9.0.1&quot;"
+        errorLine2="                ~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="4"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2026.02.00 is available: 2026.03.01"
+        errorLine1="composeBom = &quot;2026.02.00&quot;"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="17"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose.material:material-navigation than 1.10.3 is available: 1.10.6"
+        errorLine1="composeMaterialNavigation = &quot;1.10.3&quot;"
+        errorLine2="                            ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="18"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-bom than 34.9.0 is available: 34.12.0"
+        errorLine1="firebaseBom = &quot;34.9.0&quot;"
+        errorLine2="              ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="27"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase.crashlytics than 3.0.6 is available: 3.0.7"
+        errorLine1="firebaseCrashlytics = &quot;3.0.6&quot;"
+        errorLine2="                      ~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="30"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.gms:play-services-auth than 21.4.0 is available: 21.5.1"
+        errorLine1="googleAuth = &quot;21.4.0&quot;"
+        errorLine2="             ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="38"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.libraries.identity.googleid:googleid than 1.1.1 is available: 1.2.0"
+        errorLine1="googleId = &quot;1.1.1&quot;"
+        errorLine2="           ~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="39"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.kakao.sdk:v2-user than 2.21.5 is available: 2.23.2"
+        errorLine1="kakaoSDK = &quot;2.21.5&quot;"
+        errorLine2="           ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="40"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.17.0 is available: 1.18.0"
+        errorLine1="androidxCore = &quot;1.17.0&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="47"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="LockedOrientationActivity"
+        message="Expecting `android:screenOrientation=&quot;unspecified&quot;` or `&quot;fullSensor&quot;` for this activity so the user can use the application in any orientation and provide a great experience on Chrome OS devices"
+        errorLine1="            android:screenOrientation=&quot;portrait&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.compose than 2.3.10 is available: 2.3.20"
+        errorLine1="kotlin = &quot;2.3.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.serialization than 2.3.10 is available: 2.3.20"
+        errorLine1="kotlin = &quot;2.3.10&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="3"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jlleitschuh.gradle.ktlint than 14.0.1 is available: 14.2.0"
+        errorLine1="ktlintGradle = &quot;14.0.1&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="7"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.dagger.hilt.android than 2.59.1 is available: 2.59.2"
+        errorLine1="hilt = &quot;2.59.1&quot;"
+        errorLine2="       ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="8"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.dagger:hilt-android than 2.59.1 is available: 2.59.2"
+        errorLine1="hilt = &quot;2.59.1&quot;"
+        errorLine2="       ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="8"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.google.dagger:hilt-android-compiler than 2.59.1 is available: 2.59.2"
+        errorLine1="hilt = &quot;2.59.1&quot;"
+        errorLine2="       ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="8"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.facebook.android:facebook-login than 15.0.1 is available: 18.2.3"
+        errorLine1="facebookLogin = &quot;15.0.1&quot;"
+        errorLine2="                ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="37"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-serialization-json than 1.10.0 is available: 1.11.0"
+        errorLine1="kotlinxSerialization = &quot;1.10.0&quot;"
+        errorLine2="                       ~~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="51"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-test than 1.9.0 is available: 1.10.2"
+        errorLine1="coroutinesTest = &quot;1.9.0&quot;"
+        errorLine2="                 ~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="54"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of app.cash.turbine:turbine than 1.2.0 is available: 1.2.1"
+        errorLine1="turbine = &quot;1.2.0&quot;"
+        errorLine2="          ~~~~~~~">
+        <location
+            file="$HOME/Documents/snutt/snutt-android/gradle/libs.versions.toml"
+            line="55"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="ComposableNaming"
+        message="Composable functions that return Unit should start with an uppercase letter"
+        errorLine1="    fun setUpUI(startDestination: NavigationDestination) {"
+        errorLine2="        ~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/RootActivity.kt"
+            line="121"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenWidthDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="    val imageWidth = min((LocalConfiguration.current.screenWidthDp * 0.8).dp, 400.dp)"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/popups/PopupComposable.kt"
+            line="40"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenWidthDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="                                    (LocalConfiguration.current.screenWidthDp * 0.8).dp,"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/theme_config/ThemeDetailScreen.kt"
+            line="225"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="                                    (LocalConfiguration.current.screenHeightDp * 0.6).dp,"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/theme_config/ThemeDetailScreen.kt"
+            line="226"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="            .height(LocalConfiguration.current.screenHeightDp.dp * SearchOptionSheetConstants.MaxHeightRatio),"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TimeSelectSheet.kt"
+            line="104"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenWidthDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="                        (LocalConfiguration.current.screenWidthDp * 0.8).dp,"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/TimetableConfigPage.kt"
+            line="237"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="                        (LocalConfiguration.current.screenHeightDp * 0.6).dp,"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/TimetableConfigPage.kt"
+            line="238"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                    context.toast(context.getString(R.string.feedback_send_success_message))"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt"
+            line="63"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.feedback_empty_detail_warning))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt"
+            line="92"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.feedback_invalid_email_warning))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt"
+            line="94"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.find_password_enter_id_hint))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/reset_password/CheckIdStep.kt"
+            line="61"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                    context.toast(context.getString(R.string.find_password_enter_verification_code_success_alert))"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationPage.kt"
+            line="80"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.find_password_enter_verification_code_empty_alert))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationPage.kt"
+            line="121"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.find_password_enter_verification_code_expire_message))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationPage.kt"
+            line="123"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                            context.getString("
+        errorLine2="                            ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/embed_map/EmbedMap.kt"
+            line="71"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                            context.getString("
+        errorLine2="                            ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/embed_map/EmbedMap.kt"
+            line="71"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                captionText = context.getString("
+        errorLine2="                              ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/embed_map/EmbedMap.kt"
+            line="81"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                context.toast(context.getString(R.string.find_password_enter_id_hint))"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/reset_password/EnterFullEmailStep.kt"
+            line="66"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                    context.toast(context.getString(R.string.find_id_send_email_success_message).format(event.email))"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/FindIdPage.kt"
+            line="51"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.settings_user_config_enter_email))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/FindIdPage.kt"
+            line="78"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.find_id_wrong_email_format))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/FindIdPage.kt"
+            line="80"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        context.getString("
+        errorLine2="                        ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt"
+            line="143"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                title = context.getString(R.string.home_drawer_change_name_dialog_title),"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerDialogs.kt"
+            line="42"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                positiveButtonText = context.getString(R.string.common_ok),"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerDialogs.kt"
+            line="43"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                negativeButtonText = context.getString(R.string.common_cancel),"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerDialogs.kt"
+            line="44"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                title = context.getString(R.string.home_drawer_table_delete),"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerDialogs.kt"
+            line="56"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                positiveButtonText = context.getString(R.string.common_ok),"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerDialogs.kt"
+            line="57"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                negativeButtonText = context.getString(R.string.common_cancel),"
+        errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerDialogs.kt"
+            line="58"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                            -> context.getString(R.string.settings_lecture_reminder_update_success_ten_minutes_before)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/LectureReminderScreen.kt"
+            line="85"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                            -> context.getString(R.string.settings_lecture_reminder_update_success_at_start_time)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/LectureReminderScreen.kt"
+            line="88"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                            -> context.getString(R.string.settings_lecture_reminder_update_success_ten_minutes_after)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/LectureReminderScreen.kt"
+            line="91"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            errorDialogTitle = context.getString(R.string.find_password_enter_password_confirm_expired_alert)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/reset_password/NewPasswordStep.kt"
+            line="75"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                errorDialogTitle = context.getString(R.string.find_password_enter_password_confirm_fail_alert)"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/reset_password/NewPasswordStep.kt"
+            line="88"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                errorDialogTitle = context.getString(R.string.error_invalid_password)"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/reset_password/NewPasswordStep.kt"
+            line="91"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                onNavigateLicenseDetail(context.getString(R.string.license_colorpicker_route))"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/OpenSourceLicensePage.kt"
+            line="39"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                onNavigateLicenseDetail(context.getString(R.string.license_guava_route))"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/OpenSourceLicensePage.kt"
+            line="46"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                onNavigateLicenseDetail(context.getString(R.string.license_retrofit_route))"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/OpenSourceLicensePage.kt"
+            line="53"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                onNavigateLicenseDetail(context.getString(R.string.license_okhttp_route))"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/OpenSourceLicensePage.kt"
+            line="60"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                onNavigateLicenseDetail(context.getString(R.string.license_pretendard_route))"
+        errorLine2="                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/OpenSourceLicensePage.kt"
+            line="67"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="    val url = context.getString(R.string.review_base_url) + &quot;/detail?id=${viewModel.reviewId}&amp;on_back=close&quot;"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/reviews/ReviewBottomSheetRoute.kt"
+            line="35"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        SearchSnackBarEvent.FIRST_VACANCY_ADD -> context.getString(R.string.vacancy_first_add_snackbar_message)"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt"
+            line="94"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        SearchSnackBarEvent.FIRST_BOOKMARK_ADD -> context.getString(R.string.bookmark_first_alert_message)"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt"
+            line="95"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                            actionLabel = context.getString(R.string.vacancy_first_add_snackbar_action_label),"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt"
+            line="107"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.error_invalid_id))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="104"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.error_invalid_password))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="106"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.toast(context.getString(R.string.sign_up_password_confirm_invalid_toast))"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="108"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            onSignUp(idField, emailField.plus(context.getString(R.string.sign_up_email_form)), passwordField)"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="110"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                                val termsPageUrl = context.getString(R.string.api_server) + context.getString(R.string.terms)"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="220"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                                val termsPageUrl = context.getString(R.string.api_server) + context.getString(R.string.terms)"
+        errorLine2="                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="220"
+            column="93"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_sort_criteria) to TagType.SORT_CRITERIA,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_classification) to TagType.CLASSIFICATION,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="36"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_department) to TagType.DEPARTMENT,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_academic_year) to TagType.ACADEMIC_YEAR,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="38"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_credit) to TagType.CREDIT,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_time) to TagType.TIME,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="40"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_general_category) to TagType.CATEGORY,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_general_category_pre2025) to TagType.CATEGORY_PRE2025,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="            context.getString(R.string.search_option_tag_type_etc) to TagType.ETC,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/TagTypeColumn.kt"
+            line="43"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        UserConfigEvent.InvalidIdError -> context.getString(R.string.error_invalid_id)"
+        errorLine2="                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt"
+            line="58"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        UserConfigEvent.InvalidPasswordError -> context.getString(R.string.error_invalid_password)"
+        errorLine2="                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt"
+            line="59"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        UserConfigEvent.PasswordMismatchError -> context.getString(R.string.settings_user_config_password_confirm_fail)"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt"
+            line="60"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        UserConfigEvent.ChangePasswordSuccess -> context.getString(R.string.settings_user_config_change_password_success)"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt"
+            line="61"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                        UserConfigEvent.AddIdPasswordSuccess -> context.getString(R.string.settings_user_config_add_local_id_success)"
+        errorLine2="                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt"
+            line="62"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="LocalContextGetResourceValueCall"
+        message="Querying resource values using LocalContext.current"
+        errorLine1="                toastMessage = context.getString(R.string.settings_user_nickname_copied_toast),"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt"
+            line="89"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Optional Modifier parameter should have a default value of `Modifier`"
+        errorLine1="    modifier: Modifier = Modifier"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/AnimatedLazyRow.kt"
+            line="16"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Optional Modifier parameter should have a default value of `Modifier`"
+        errorLine1="    modifier: Modifier = Modifier.size(30.dp),"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt"
+            line="61"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Optional Modifier parameter should have a default value of `Modifier`"
+        errorLine1="    modifier: Modifier = Modifier.size(30.dp),"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt"
+            line="679"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Optional Modifier parameter should have a default value of `Modifier`"
+        errorLine1="    modifier: Modifier = Modifier.fillMaxWidth().height(40.dp),"
+        errorLine2="    ~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/lecture_detail/LectureDetailItem.kt"
+            line="32"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="SpUsage"
+        message="Should use &quot;`sp`&quot; instead of &quot;`dp`&quot; for text sizes"
+        errorLine1="        android:textSize=&quot;15dp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/widget_timetable.xml"
+            line="18"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DiscouragedApi"
+        message="Fixed screen orientations will be ignored in most cases, starting from Android 16. Android is moving toward a model where apps are expected to adapt to various orientations, display sizes, and aspect ratios."
+        errorLine1="            android:screenOrientation=&quot;portrait&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;api_google_server&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;api_google_server&quot;>https://oauth2.googleapis.com&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="8"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;sign_up_email_form&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;sign_up_email_form&quot;>\@snu.ac.kr&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="35"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;sign_in_logo_title&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;sign_in_logo_title&quot;>SNUTT&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="41"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_colorpicker_route&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_colorpicker_route&quot;>colorpicker&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="63"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_colorpicker_title&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_colorpicker_title&quot;>Color Picker&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_colorpicker_name&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_colorpicker_name&quot;>Apache License&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_colorpicker_content&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_colorpicker_content&quot;>Copyright 2014-2017 QuadFlask"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_guava_route&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_guava_route&quot;>guava&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="79"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_guava_title&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_guava_title&quot;>Guava&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="80"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_guava_name&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_guava_name&quot;>Apache License&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="81"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_guava_content&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_guava_content&quot;>Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="82"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_retrofit_route&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_retrofit_route&quot;>retrofit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="93"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_retrofit_title&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_retrofit_title&quot;>Retrofit&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="94"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_retrofit_name&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_retrofit_name&quot;>Apache License&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="95"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_retrofit_content&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_retrofit_content&quot;>Copyright 2013 Square, Inc."
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="96"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_okhttp_route&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_okhttp_route&quot;>okhttp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="109"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_okhttp_title&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_okhttp_title&quot;>Okhttp&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="110"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_okhttp_name&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_okhttp_name&quot;>Apache License&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="111"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_okhttp_content&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_okhttp_content&quot;>Copyright 2019 Square, Inc."
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="112"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_pretendard_route&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_pretendard_route&quot;>pretendard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="125"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_pretendard_title&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_pretendard_title&quot;>Pretendard&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="126"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_pretendard_name&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_pretendard_name&quot;>SIL OPEN FONT LICENSE&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="127"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;license_pretendard_content&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;license_pretendard_content&quot;>Copyright © 2021, Kil Hyung-jin (https://github.com/orioncactus/pretendard),"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="128"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;home_select_theme_snutt&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;home_select_theme_snutt&quot;>SNUTT&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="361"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;settings_app_report_detail_hint&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;settings_app_report_detail_hint&quot;> &lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="396"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;settings_push_preferences_lecture_diary&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;settings_push_preferences_lecture_diary&quot;>강의 일기장&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="402"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;example_email&quot; is not translated in &quot;en&quot; (English)"
+        errorLine1="    &lt;string name=&quot;example_email&quot;>example@gmail.com&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="523"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;credits&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;home_drawer_table_credit&quot;>(%d credits)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-en/strings.xml"
+            line="135"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;credits&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;timetable_credit&quot;>(%d credits)&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-en/strings.xml"
+            line="191"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="SetJavaScriptEnabled"
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully"
+        errorLine1="        this.settings.javaScriptEnabled = true"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/reviews/ReviewWebViewContainer.kt"
+            line="64"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="SetJavaScriptEnabled"
+        message="Using `setJavaScriptEnabled` can introduce XSS vulnerabilities into your application, review carefully"
+        errorLine1="        this.settings.javaScriptEnabled = true"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/thememarket/ThemeMarketWebViewContainer.kt"
+            line="63"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="VectorPath"
+        message="Very long vector path (3339 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
+        errorLine1="      android:pathData=&quot;M47.316,49V48H45.877L46.378,49.348L47.316,49ZM48.738,52.828L49.676,52.479L48.738,52.828ZM47.19,53.967L46.578,54.759L47.19,53.967ZM40.761,49L41.373,48.209L41.103,48H40.761V49ZM14.387,44L15.324,44.348L15.825,43H14.387V44ZM12.218,49.833L11.281,49.485L12.218,49.833ZM13.767,50.973L14.379,51.764H14.379L13.767,50.973ZM22.791,44V43H22.449L22.179,43.209L22.791,44ZM27.896,14.5L28.603,13.793C28.411,13.601 28.149,13.495 27.876,13.5C27.604,13.506 27.346,13.622 27.162,13.821L27.896,14.5ZM20.329,22.69L21.031,23.402L21.048,23.386L21.063,23.369L20.329,22.69ZM19.633,24.556H20.633V24.507L20.628,24.458L19.633,24.556ZM33,36.5L33.962,36.772L33.981,36.704L33.991,36.635L33,36.5ZM34.5,25.5L35.491,25.635L35.5,25.568V25.5H34.5ZM27.896,23.181L27.091,22.588C26.867,22.892 26.834,23.296 27.004,23.632C27.174,23.969 27.519,24.181 27.896,24.181V23.181ZM29.5,21L30.306,21.593L30.352,21.53L30.387,21.461L29.5,21ZM57.196,26C57.196,24.895 56.301,24 55.196,24V26H57.196ZM57.196,48V26H55.196V48H57.196ZM55.196,50C56.301,50 57.196,49.105 57.196,48H55.196V50ZM47.316,50H55.196V48H47.316V50ZM49.676,52.479L48.253,48.652L46.378,49.348L47.801,53.176L49.676,52.479ZM46.578,54.759C48.17,55.988 50.376,54.364 49.676,52.479L47.801,53.176L46.578,54.759ZM40.15,49.791L46.578,54.759L47.801,53.176L41.373,48.209L40.15,49.791ZM26,50H40.761V48H26V50ZM24,48C24,49.105 24.895,50 26,50V48H24ZM55.196,24H43V26H55.196V24ZM4,11V11V9C2.895,9 2,9.895 2,11H4ZM4,43V11H2V43H4ZM4,43H4H2C2,44.105 2.895,45 4,45V43ZM14.387,43H4V45H14.387V43ZM13.156,50.181L15.324,44.348L13.449,43.652L11.281,49.485L13.156,50.181ZM13.156,50.181H13.156L11.281,49.485C10.58,51.37 12.787,52.994 14.379,51.764L13.156,50.181ZM22.179,43.209L13.156,50.181L14.379,51.764L23.402,44.791L22.179,43.209ZM42,43H22.791V45H42V43ZM42,43V45C43.105,45 44,44.105 44,43H42ZM42,11V43H44V11H42ZM42,11H44C44,9.895 43.105,9 42,9V11ZM4,11H42V9H4V11ZM21.063,23.369L28.631,15.179L27.162,13.821L19.594,22.011L21.063,23.369ZM20.628,24.458C20.593,24.098 20.717,23.712 21.031,23.402L19.627,21.978C18.888,22.706 18.543,23.686 18.638,24.654L20.628,24.458ZM20.633,37.222V24.556H18.633V37.222H20.633ZM20.633,37.222H18.633C18.633,38.327 19.529,39.222 20.633,39.222V37.222ZM30.799,37.222H20.633V39.222H30.799V37.222ZM32.038,36.228C31.938,36.579 31.781,36.82 31.602,36.97C31.433,37.111 31.187,37.222 30.799,37.222V39.222C31.612,39.222 32.325,38.973 32.886,38.503C33.437,38.042 33.779,37.421 33.962,36.772L32.038,36.228ZM33.509,25.365L32.009,36.365L33.991,36.635L35.491,25.635L33.509,25.365ZM32.717,24.181C32.838,24.181 33.5,24.436 33.5,25.5H35.5C35.5,23.564 34.162,22.181 32.717,22.181V24.181ZM27.896,24.181H32.717V22.181H27.896V24.181ZM28.694,20.407L27.091,22.588L28.702,23.773L30.306,21.593L28.694,20.407ZM27.189,15.207C28.415,16.433 28.972,17.271 29.153,17.993C29.319,18.657 29.207,19.394 28.613,20.539L30.387,21.461C31.091,20.106 31.428,18.843 31.093,17.507C30.772,16.229 29.877,15.067 28.603,13.793L27.189,15.207ZM12,23.625H18.633V21.625H12V23.625ZM18.633,23.625V37.933H20.633V23.625H18.633ZM18.633,37.933H12V39.933H18.633V37.933ZM12,37.933V23.625H10V37.933H12ZM12,37.933H10C10,39.037 10.895,39.933 12,39.933V37.933ZM18.633,37.933V37.933V39.933C19.738,39.933 20.633,39.037 20.633,37.933H18.633ZM18.633,23.625H20.633C20.633,22.521 19.738,21.625 18.633,21.625V23.625ZM12,21.625C10.895,21.625 10,22.521 10,23.625H12V23.625V21.625ZM24,44V48H26V44H24Z&quot;"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/drawable/ic_review_unselected.xml"
+            line="7"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
+        errorLine1="        mutableStateOf("
+        errorLine2="        ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/CircularPicker.kt"
+            line="55"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableFloatStateOf` instead of `mutableStateOf`"
+        errorLine1="    return remember { mutableStateOf(1F) }"
+        errorLine2="                      ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/snackbar/CustomSnackBar.kt"
+            line="454"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `@color/black_translucent_50` with a theme that also paints a background (inferred theme is `@style/Theme.Snutt.Splash`)"
+        errorLine1="    android:background=&quot;@color/black_translucent_50&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_popup.xml"
+            line="6"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="Overdraw"
+        message="Possible overdraw: Root element paints background `@color/white` with a theme that also paints a background (inferred theme is `@style/Theme.Snutt.Splash`)"
+        errorLine1="    android:background=&quot;@color/white&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/widget_timetable.xml"
+            line="6"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.actionbar_background` appears to be unused"
+        errorLine1="&lt;layer-list xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/actionbar_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.array.time_string` appears to be unused"
+        errorLine1="    &lt;string-array name=&quot;time_string&quot;>"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/arrays.xml"
+            line="12"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.background_search_option` appears to be unused"
+        errorLine1="&lt;shape xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/background_search_option.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.transparent` appears to be unused"
+        errorLine1="    &lt;color name=&quot;transparent&quot;>#00000000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="18"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_1&quot;>#F58D3D&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="21"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_2&quot;>#FAC42D&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="22"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_3&quot;>#A6D930&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="23"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_4&quot;>#2BC267&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="24"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_6&quot;>#1D99E8&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="26"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_7&quot;>#4F48C4&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="27"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_8&quot;>#AF56B3&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="28"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_0&quot;>#D95F71&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="30"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_1&quot;>#DF6E3C&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="31"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_2&quot;>#E68937&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="32"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_3&quot;>#95B03E&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="33"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_4&quot;>#419343&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="34"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_5&quot;>#5BA0D7&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="35"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_6&quot;>#58C1B7&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="36"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_7&quot;>#3E35A7&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="37"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_snutt_dark_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_snutt_dark_8&quot;>#783891&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="38"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_0&quot;>#B82E31&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="40"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_1&quot;>#DB701C&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="41"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_2&quot;>#EAA32A&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="42"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_3&quot;>#C6C013&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="43"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_4&quot;>#3A856E&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="44"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_5&quot;>#19B2AC&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="45"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_6&quot;>#3994CE&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="46"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_7&quot;>#3F3A9C&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="47"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_8&quot;>#924396&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="48"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_0&quot;>#A93A36&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="50"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_1&quot;>#D56738&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="51"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_2&quot;>#CC973F&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="52"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_3&quot;>#A0942F&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="53"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_4&quot;>#4E8370&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="54"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_5&quot;>#29625A&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="55"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_6&quot;>#4171A2&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="56"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_7&quot;>#4F48C4&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="57"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_autumn_dark_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_autumn_dark_8&quot;>#783891&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="58"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_0&quot;>#F0652A&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="60"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_1&quot;>#F5AD3E&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="61"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_2&quot;>#998F36&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="62"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_3&quot;>#89C291&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="63"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_4&quot;>#266F55&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="64"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_5&quot;>#13808F&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="65"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_6&quot;>#366689&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="66"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_7&quot;>#432920&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="67"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_8&quot;>#D82F3D&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="68"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_0&quot;>#BB592F&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="70"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_1&quot;>#E08B45&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="71"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_2&quot;>#B4B194&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="72"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_3&quot;>#5B967C&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="73"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_4&quot;>#266F55&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="74"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_5&quot;>#13808F&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="75"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_6&quot;>#426586&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="76"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_7&quot;>#5C4335&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="77"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_modern_dark_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_modern_dark_8&quot;>#AD2F31&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="78"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_0&quot;>#FD79A8&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="80"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_1&quot;>#FEC9DD&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="81"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_2&quot;>#FEB0CC&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="82"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_3&quot;>#FE93BF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="83"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_4&quot;>#E9B1D0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="84"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_5&quot;>#C67D97&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="85"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_6&quot;>#BB8EA7&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="86"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_7&quot;>#BDB4BF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="87"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_8&quot;>#E16597&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="88"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_0&quot;>#A43C58&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="90"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_1&quot;>#7C164F&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="91"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_2&quot;>#99446E&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="92"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_3&quot;>#A77085&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="93"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_4&quot;>#B290B8&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="94"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_5&quot;>#BDB4BF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="95"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_6&quot;>#BB8EA7&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="96"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_7&quot;>#736C75&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="97"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_cherry_dark_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_cherry_dark_8&quot;>#C76F92&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="98"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_0&quot;>#AABDCF&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="100"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_1&quot;>#C0E9E8&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="101"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_2&quot;>#66B6CA&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="102"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_3&quot;>#015F95&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="103"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_4&quot;>#A8D0DB&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="104"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_5&quot;>#458ED0&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="105"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_6&quot;>#62A9D1&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="106"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_7&quot;>#20363D&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="107"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_8&quot;>#6D8A96&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="108"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_0&quot;>#014D79&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="110"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_1&quot;>#788DA4&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="111"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_2&quot;>#AEC1C9&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="112"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_3&quot;>#48595B&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="113"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_4&quot;>#1C6C8E&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="114"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_5&quot;>#64909C&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="115"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_6&quot;>#88B1C6&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="116"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_7&quot;>#44576B&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="117"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_ice_dark_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_ice_dark_8&quot;>#757C80&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="118"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_0&quot;>#4FBEAA&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="120"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_1&quot;>#9FC1A4&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="121"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_2&quot;>#5A8173&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="122"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_3&quot;>#84AEB1&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="123"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_4&quot;>#266F55&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="124"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_5&quot;>#D0E0C4&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="125"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_6&quot;>#59886D&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="126"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_7&quot;>#476060&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="127"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_8&quot;>#3D7068&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="128"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_0` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_0&quot;>#2D5A45&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="130"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_1` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_1&quot;>#429587&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="131"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_2` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_2&quot;>#86A99A&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="132"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_3` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_3&quot;>#597B6A&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="133"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_4` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_4&quot;>#42635B&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="134"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_5` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_5&quot;>#586C5D&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="135"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_6` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_6&quot;>#324845&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="136"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_7` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_7&quot;>#AAB6B1&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="137"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.theme_grass_dark_8` appears to be unused"
+        errorLine1="    &lt;color name=&quot;theme_grass_dark_8&quot;>#747877&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="138"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.black_translucent_50` appears to be unused"
+        errorLine1="    &lt;color name=&quot;black_translucent_50&quot;>#80000000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/colors.xml"
+            line="139"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.dialog_item_picker` appears to be unused"
+        errorLine1="&lt;androidx.constraintlayout.widget.ConstraintLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/dialog_item_picker.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.dialog_popup` appears to be unused"
+        errorLine1="&lt;androidx.constraintlayout.widget.ConstraintLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/dialog_popup.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.layout.dialog_text_input` appears to be unused"
+        errorLine1="&lt;FrameLayout xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/layout/dialog_text_input.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.fade_in` appears to be unused"
+        errorLine1="&lt;alpha xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/fade_in.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.fade_out` appears to be unused"
+        errorLine1="&lt;alpha xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/fade_out.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_close_white` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/ic_close_white.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_people_test` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_people_test.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_question_new` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_question_new.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_refresh` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_refresh.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.iconfacebook` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/iconfacebook.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.imgintro1` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/imgintro1.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.imgintro2` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/imgintro2.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.imgintro3` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/imgintro3.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.imgintrotitle1` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/imgintrotitle1.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.imgintrotitle2` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/imgintrotitle2.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.imgintrotitle3` appears to be unused">
+        <location
+            file="src/main/res/drawable-hdpi/imgintrotitle3.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.fb_login_protocol_scheme` appears to be unused"
+        errorLine1="    &lt;string name=&quot;fb_login_protocol_scheme&quot; translatable=&quot;false&quot;>PLACEHOLDER&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/secrets_defaults.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.slide_in` appears to be unused"
+        errorLine1="&lt;translate xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/slide_in.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.anim.slide_out` appears to be unused"
+        errorLine1="&lt;translate xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/anim/slide_out.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_no_timetable_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_no_timetable_title&quot;>시간표 이름이 주어지지 않았습니다&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="20"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.error_logout_fail` appears to be unused"
+        errorLine1="    &lt;string name=&quot;error_logout_fail&quot;>로그아웃에 실패하였습니다&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="21"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.sign_up_sign_up_facebook_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;sign_up_sign_up_facebook_button&quot;>페이스북으로 시작하기&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="39"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.sign_in_sign_in_facebook_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;sign_in_sign_in_facebook_button&quot;>페이스북으로 시작하기&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.sign_in_sign_in_google_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;sign_in_sign_in_google_button&quot;>구글 계정으로 시작하기&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="45"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.social_link_account_already_using` appears to be unused"
+        errorLine1="    &lt;string name=&quot;social_link_account_already_using&quot;>이미 사용 중인 이메일입니다.\n%s 계정으로 시도해 보세요.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="49"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.sign_up_facebook_login_failed_toast` appears to be unused"
+        errorLine1="    &lt;string name=&quot;sign_up_facebook_login_failed_toast&quot;>페이스북 연동중 오류가 발생하였습니다&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="240"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.find_password_enter_password_empty_alert` appears to be unused"
+        errorLine1="    &lt;string name=&quot;find_password_enter_password_empty_alert&quot;>새 비밀번호를 입력해주세요.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="268"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.verify_email_input_code` appears to be unused"
+        errorLine1="    &lt;string name=&quot;verify_email_input_code&quot;>%s으로 전송된 인증번호를\n입력해주세요.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="279"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.verify_email_code_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;verify_email_code_title&quot;>인증번호&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="280"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.verify_email_code_hint` appears to be unused"
+        errorLine1="    &lt;string name=&quot;verify_email_code_hint&quot;>인증번호 6자리를 입력하세요&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="281"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.lecture_list_add_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;lecture_list_add_button&quot;>직접 강좌 추가하기&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="290"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.notifications_noti_announce` appears to be unused"
+        errorLine1="    &lt;string name=&quot;notifications_noti_announce&quot;>공지&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="291"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.notifications_noti_update` appears to be unused"
+        errorLine1="    &lt;string name=&quot;notifications_noti_update&quot;>업데이트&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="293"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.notifications_noti_disconnect` appears to be unused"
+        errorLine1="    &lt;string name=&quot;notifications_noti_disconnect&quot;>변경&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="296"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_drawer_create_success_message` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_drawer_create_success_message&quot;>%s \&quot;%s\&quot; 시간표가 생성되었습니다.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="315"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_drawer_copy_success_message` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_drawer_copy_success_message&quot;>\&quot;%s\&quot; 시간표가 복사되었습니다.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="316"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_drawer_delete_table_unable_alert_message` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_drawer_delete_table_unable_alert_message&quot;>하나 남은 시간표는 삭제할 수 없습니다&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="317"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_drawer_delete_table_success_alert_message` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_drawer_delete_table_success_alert_message&quot;>시간표가 삭제되었습니다.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="318"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_menu_add_lecture_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_menu_add_lecture_button&quot;>직접 추가&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="322"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.home_menu_lecture_list_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;home_menu_lecture_list_button&quot;>현재 시간표 목록&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="323"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_app_report_loading_indicator_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_app_report_loading_indicator_title&quot;>피드백 전송&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="395"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_user_config_facebook_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_user_config_facebook_name&quot;>페이스북 이름&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="446"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_user_config_connect_facebook` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_user_config_connect_facebook&quot;>페이스북 연동&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="447"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_user_config_change_email` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_user_config_change_email&quot;>이메일 변경&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="448"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.settings_user_config_change_email_success` appears to be unused"
+        errorLine1="    &lt;string name=&quot;settings_user_config_change_email_success&quot;>이메일을 변경하였습니다.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="456"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.lecture_detail_add_bookmark_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;lecture_detail_add_bookmark_button&quot;>관심강좌 지정&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="503"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.lecture_detail_remove_bookmark_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;lecture_detail_remove_bookmark_button&quot;>관심강좌 제외&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="504"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.lecture_detail_quota_info_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;lecture_detail_quota_info_title&quot;>정원(재학생)이란?&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="513"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.lecture_detail_quota_info_content` appears to be unused"
+        errorLine1="    &lt;string name=&quot;lecture_detail_quota_info_content&quot;>정원은 재학생 정원과 신입생 정원으로 구분되어 있습니다.\n정원(재학생)이 25(5)인 경우 강의의 총 정원 25석 중 재학생은 5석만 신청할 수 있고, 나머지 20석은 신입생만 신청할 수 있습니다. &lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="514"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.bookmark_remove_toast` appears to be unused"
+        errorLine1="    &lt;string name=&quot;bookmark_remove_toast&quot;>관심강좌 목록에서 제거하였습니다.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="532"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.loading_indicator_message` appears to be unused"
+        errorLine1="    &lt;string name=&quot;loading_indicator_message&quot;>잠시만 기다려 주세요…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="539"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.vacancy_item_detail_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;vacancy_item_detail_button&quot;>자세히&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="545"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.vacancy_item_goto_button` appears to be unused"
+        errorLine1="    &lt;string name=&quot;vacancy_item_goto_button&quot;>수강신청으로 이동&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="546"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.diary_day_bad` appears to be unused"
+        errorLine1="    &lt;string name=&quot;diary_day_bad&quot;>별로에요&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="560"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.diary_day_neutral` appears to be unused"
+        errorLine1="    &lt;string name=&quot;diary_day_neutral&quot;>그럭저럭&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="561"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.diary_day_good` appears to be unused"
+        errorLine1="    &lt;string name=&quot;diary_day_good&quot;>좋아요&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="562"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.diary_wrote_text` appears to be unused"
+        errorLine1="    &lt;string name=&quot;diary_wrote_text&quot;>에 대한 강의일기를 남겼어요.&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="563"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.diary_list_edit_text` appears to be unused"
+        errorLine1="    &lt;string name=&quot;diary_list_edit_text&quot;>수정하기&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="564"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.custom_theme_action_set_default` appears to be unused"
+        errorLine1="    &lt;string name=&quot;custom_theme_action_set_default&quot;>기본 테마로 지정&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="579"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.custom_theme_action_unset_default` appears to be unused"
+        errorLine1="    &lt;string name=&quot;custom_theme_action_unset_default&quot;>기본 테마 해제&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="580"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.deeplink_page_timetable_lecture_page_loading_text` appears to be unused"
+        errorLine1="    &lt;string name=&quot;deeplink_page_timetable_lecture_page_loading_text&quot;>강의 불러오는 중…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="605"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.deeplink_page_timetable_lecture_page_not_existing_table` appears to be unused"
+        errorLine1="    &lt;string name=&quot;deeplink_page_timetable_lecture_page_not_existing_table&quot;>삭제된 시간표입니다&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="607"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.friend_page_loading_title` appears to be unused"
+        errorLine1="    &lt;string name=&quot;friend_page_loading_title&quot;>친구 시간표 불러 오는 중&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="609"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.friend_page_loading_subtitle` appears to be unused"
+        errorLine1="    &lt;string name=&quot;friend_page_loading_subtitle&quot;>잠시만 기다려 주세요…&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="610"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.search_option_recent_departments` appears to be unused"
+        errorLine1="    &lt;string name=&quot;search_option_recent_departments&quot;>최근 찾아본 학과&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="677"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.theme_new_default_name` appears to be unused"
+        errorLine1="    &lt;string name=&quot;theme_new_default_name&quot;>새 테마&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="701"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.AppBottomSheetDialogTheme` appears to be unused"
+        errorLine1="    &lt;style name=&quot;AppBottomSheetDialogTheme&quot; parent=&quot;Theme.Design.Light.BottomSheetDialog&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="36"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.AppModalStyle` appears to be unused"
+        errorLine1="    &lt;style name=&quot;AppModalStyle&quot; parent=&quot;Widget.Design.BottomSheet.Modal&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="40"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.popup_dialog` appears to be unused"
+        errorLine1="    &lt;style name=&quot;popup_dialog&quot; parent=&quot;Theme.AppCompat.Light.NoActionBar&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="67"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UseOfNonLambdaOffsetOverload"
+        message="State backed values should use the lambda overload of Modifier.offset"
+        errorLine1="                .offset(x = 5.dp + yOffsetTop),"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/timetable/HomeSessionlessLectureHint.kt"
+            line="131"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseOfNonLambdaOffsetOverload"
+        message="State backed values should use the lambda overload of Modifier.offset"
+        errorLine1="                .offset(x = 40.dp + yOffsetBottom),"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/timetable/HomeSessionlessLectureHint.kt"
+            line="137"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseOfNonLambdaOffsetOverload"
+        message="State backed values should use the lambda overload of Modifier.offset"
+        errorLine1="            .offset(y = offsetYAnimatedDp)"
+        errorLine2="             ~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/search/search_option/SearchOptionConfirmButton.kt"
+            line="43"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UseOfNonLambdaOffsetOverload"
+        message="State backed values should use the lambda overload of Modifier.offset"
+        errorLine1="                    .offset(x = indicatorOffset)"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/SegmentedPicker.kt"
+            line="101"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;search_result_placeholder_7&quot;>e.g. Bldg 26 / 302-208&lt;/string>"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-en/strings.xml"
+            line="159"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="TypographyDashes"
+        message="Replace &quot;-&quot; with an &quot;en dash&quot; character (–, &amp;#8211;) ?"
+        errorLine1="    &lt;string name=&quot;search_result_placeholder_7&quot;>ex) 26동 / 302-208 / 대글2 43-1동&lt;/string>"
+        errorLine2="                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="338"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/facebook_login.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/facebook_login.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/google_login.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/google_login.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/ic_map_pin.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/ic_map_pin.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/kakao_login.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/kakao_login.png"/>
+    </issue>
+
+    <issue
+        id="IconDensities"
+        message="Missing the following drawables in `drawable-hdpi`: ic_alarm_default.png, ic_setting_selected.png, ic_setting_unselected.png, img_reviews_coming_soon.png, theme_preview_autumn.png... (5 more)">
+        <location
+            file="src/main/res/drawable-hdpi"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toColorInt` instead?"
+        errorLine1="            hsv = colorToHsv(Color(AndroidColor.parseColor(hexCode)))"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/ColorPicker.kt"
+            line="84"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="            Bitmap.createBitmap("
+        errorLine2="            ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/ColorPicker.kt"
+            line="233"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="            Bitmap.createBitmap("
+        errorLine2="            ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/ColorPicker.kt"
+            line="325"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                Uri.parse("
+        errorLine2="                ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/embed_map/EmbedMapUtils.kt"
+            line="58"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                Uri.parse(&quot;kakaomap://look?p=${building.coordinate.latitude},${building.coordinate.longitude}&quot;),"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/ui/components/compose/embed_map/EmbedMapUtils.kt"
+            line="74"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            intent.data = Uri.parse(it)"
+        errorLine2="                          ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/RootActivity.kt"
+            line="203"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            intent.data = Uri.parse(it)"
+        errorLine2="                          ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/RootActivity.kt"
+            line="203"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="        Bitmap.createBitmap("
+        errorLine2="        ^">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/home/drawer/ScreenshotUtil.kt"
+            line="37"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(termsPageUrl)))"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt"
+            line="221"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX function `createBitmap` instead?"
+        errorLine1="            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)"
+        errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/TimetableWidgetProvider.kt"
+            line="127"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `Bitmap.scale` instead?"
+        errorLine1="            val resizedBitmap = Bitmap.createScaledBitmap(bitmap, (width / scale).toInt(), (height / scale).toInt(), false)"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/wafflestudio/snutt2/TimetableWidgetProvider.kt"
+            line="134"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_popup.xml"
+            line="11"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/map_pin.xml"
+            line="17"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/widget_timetable.xml"
+            line="21"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="HardcodedText"
+        message="Hardcoded string &quot;로그인을 해주세요&quot;, should use `@string` resource"
+        errorLine1="        android:text=&quot;로그인을 해주세요&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/widget_timetable.xml"
+            line="16"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -35,11 +35,18 @@
     - 조치: `ci.yml` java-version 21 → 17. `manual_deploy.yml` distribution `adopt`(legacy) → `temurin` 도 함께 정렬.
     - 별도 발견: `core/network` 모듈은 실제 존재하지 않음. 3개 워크플로우의 `./core/network/...` secrets 셋업 스텝은 쓸모없는 디렉토리만 생성. **1-2 에서 정리**.
 
-### [ ] 1-2. Secrets 셋업 composite action 추출
+### [x] 1-2. Secrets 셋업 composite action 추출
 
 - 현재: google-services.json / secrets.xml(app, core:network) / gcp-service-account.json / keystore 가 3개 워크플로우에 거의 동일하게 중복.
 - 할 일: `.github/actions/setup-secrets/action.yml` composite action 으로 뽑아 공통화. `variant` (staging/live) 를 입력으로 받아 분기.
 - 효과: 한 곳만 수정하면 됨. 휴먼 에러 감소.
+- 결정/결과:
+    - `.github/actions/setup-secrets/action.yml` composite action 신설. inputs: `variant`, `google_services_json`, `secrets_xml_app`, `gcp_service_account`(optional), `keystore_base64`(optional).
+    - `ci.yml` / `cd.yml` / `manual_deploy.yml` 의 중복 secrets 셋업 블록 전부 composite action 호출 한 스텝으로 치환.
+    - 내부 구현은 `env:` 로 시크릿을 스텝에 주입하고 `printf '%s' "$VAR" > ...` 로 파일에 기록. heredoc 미사용(1-5 목표가 여기서 해소 — 별도 PR 불필요).
+    - 실제 존재하지 않는 `core/network` 모듈용 secrets.xml 셋업 스텝 모두 제거. 관련 GitHub Secret (`secrets_xml_staging_core_network`, `secrets_xml_live_core_network`) 은 현재 참조되지 않음. (UI 에서 수동 제거 가능)
+    - `manual_deploy.yml` 의 `startsWith(inputs.variant, 'live')` 조건은 값이 고정 enum 이라 `== 'live'` 로 단순화.
+    - 별도 발견: `app/src/staging/res/value/strings.xml` 디렉토리 오타(`value` 단수형). Android 가 리소스로 인식 안 함. CI/CD 범위 밖이라 플래그만.
 
 ### [ ] 1-3. Gradle 셋업 개선
 

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -111,40 +111,179 @@
 
 ---
 
-## Phase 3. PR 자동화
+## Phase 3. ~~PR 자동화~~ (삭제)
 
-### [ ] 3-1. PR labeler 도입
-
-- 할 일: `actions/labeler` 로 변경된 파일 경로 기반 영역 라벨 (`feature/bookmark`, `core/network`, `ci`, `docs` 등) 자동 부여.
-- 효과: PR 리뷰어/필터링 편의.
-
-### [ ] 3-2. PR size label
-
-- 할 일: `CodelyTV/pr-size-labeler` 또는 유사 액션으로 S/M/L/XL 라벨링.
-
-### [ ] 3-3. Danger-Kotlin 검토
-
-- 현재: 없음.
-- 할 일: 먼저 **검토**. "체크리스트 미작성 / 큰 PR 경고 / CHANGELOG 업데이트 확인" 등 어떤 규칙을 강제할지 먼저 정의 → 규칙 없으면 도입 보류.
+사용자 판단으로 제거. PR labeler / size label / Danger-Kotlin 모두 현 팀 규모와 프로세스 특성상 ROI 불명확하여 도입하지 않음. 필요해지면 Phase 번호와 무관하게 별도 도입 검토.
 
 ---
 
 ## Phase 4. 릴리스 자동화
 
-### [ ] 4-1. `cd.yml` ↔ `manual_deploy.yml` 정리
+### 배경: 현재 릴리스 흐름 (수동)
 
-- 현재: 두 워크플로우가 거의 같은 job 을 중복으로 들고 있음. (Phase 1-2 composite action 이 적용되면 부담이 크게 줄어듦)
-- 할 일: reusable workflow (`workflow_call`) 로 공통화 검토.
+1. 담당자가 `develop` 에서 `release-X.Y.Z` 브랜치 분기.
+2. `version.properties` 를 `X.Y.Z-rc.1` 로 수정 → push.
+3. `cd.yml` 트리거 → live AAB(Firebase) + staging APK(Firebase + Slack) 빌드/배포.
+4. **(수동)** 담당자가 Play Console 에서 AAB 를 internal track 에 업로드 → 내부자 테스트 배포.
+5. QA 에서 이슈 발견 시 release 브랜치에 수정 커밋 → **담당자가 직접** `version.properties` 를 `X.Y.Z-rc.2` 로 수정 push → 3–4 반복.
+6. QA 완료 시 `version.properties` 를 `X.Y.Z` (rc 제거) 로 수정 push → live AAB 재빌드.
+7. **(수동)** Play Console 에서 production 업로드 & 릴리스.
+8. **(수동)** GitHub 에서 tag + release note 작성.
+9. `release-X.Y.Z` 를 `develop` 으로 merge back.
 
-### [ ] 4-2. `version.properties` 자동 bump
+### 자동화 목표 (Phase 4 완료 후)
 
-- 할 일: 릴리스 브랜치 생성 시 버전 자동 증분 워크플로우. semver 규칙 선정 필요.
-- 고려: 현재 릴리스 플로우(누가, 언제 `version.properties` 를 바꾸는지)를 먼저 파악해야 안전.
+1. 담당자가 `release-X.Y.Z` 브랜치 분기. (유지, 시작 시그널)
+2. 담당자가 `version.properties` 를 `X.Y.Z-rc.1` 로 최초 설정 push. (유지, 릴리스 시작 시그널)
+3. **이후 release 브랜치에 코드 커밋 push 시 자동으로 `rc.N` → `rc.N+1` bump + 빌드 + Play Store internal 업로드 + Firebase + Slack.**
+4. QA 완료 후 담당자가 `version.properties` 를 rc 제거해 push → **자동으로 live 빌드 + Play Store production `draft` 업로드 + GitHub Release draft/tag 생성 + Firebase + Slack**.
+5. 담당자가 Play Console 에서 production release "Review and release" 클릭 (수동 유지 — blast radius 가드).
+6. 담당자가 GitHub Release 페이지에서 **한국어 릴리스 노트 작성 후 publish** (수동 유지 — 릴리스마다 직접 작성).
+7. `release-X.Y.Z` → `develop` merge back. (수동 유지)
 
-### [ ] 4-3. 릴리스 노트 자동 생성
+### 트랙 정책 (결정됨)
 
-- 할 일: PR 제목/라벨 기반 `release-drafter` 도입 검토.
-- 전제: 커밋/PR 메시지 컨벤션(현재 `[폴더위계정리] refactor: ...` 같은 대괄호 prefix)이 있어서 릴리스 노트 그룹핑 규칙을 어떻게 잡을지 결정 필요.
+- `-rc.N` 포함 버전 → `internal` track
+- 정식 버전 → `production` track, **`status: draft`**. Play Console 에서 release 개시만 수동 클릭. `production` 에 완전 자동 승격은 blast radius 가 너무 큼. (옵션 (a) 자동 승격, (b) internal 만 + 수동 승격, (c) production draft, (d) 단계적 rollout 중 (c) 채택)
+
+### 툴 선정: Fastlane (결정됨)
+
+- 비교군: (A) r0adkll/upload-google-play GHA, (B) Fastlane supply, (C) Triple-T/gradle-play-publisher, (D) 공식 SDK 직접 호출, (E) curl + JWT.
+- 최종 선택: **(B) Fastlane**.
+    - Google 공식은 아니지만 Android 릴리스 자동화의 de facto standard. 유지보수 주체가 크고 오래됨.
+    - CI 밖(로컬)에서도 동일 명령으로 재현 가능. 트러블슈팅 정보 풍부.
+    - 향후 확장(스크린샷/메타데이터 자동화) 용이.
+- (A) 는 단일 개인 메인테이너 의존. (C) 는 Gradle 설정이 과하게 커짐. (D)(E) 는 유지보수 부담.
+
+### [ ] 4-1. Play Store 자동 업로드 (Fastlane)
+
+- 목표: `cd.yml` 에서 AAB 빌드 후 Play Store 에 자동 업로드.
+- 구성:
+    - `Gemfile` 에 `fastlane` gem 추가.
+    - `fastlane/Appfile`: `package_name` (live/staging 모두 `com.wafflestudio.snutt2.live` 등 variant suffix 포함), `json_key_file` 은 env 로 주입.
+    - `fastlane/Fastfile` 에 2 개 레인 정의:
+        - `upload_internal`: `aab` + `track: internal` + `release_status: completed` 로 업로드.
+        - `upload_production_draft`: `aab` + `track: production` + `release_status: draft` 로 업로드.
+    - CI 에서 `ruby/setup-ruby@v1` + `bundle install` → 트랙 판별 후 `bundle exec fastlane <lane>`.
+- 트랙 판별 로직: `version.properties` 읽어 `snuttVersionName` 에 `-rc` 포함 여부로 분기. Shell step 에서 판별 후 `GITHUB_ENV` 에 `FASTLANE_LANE` 내보내거나, Fastfile 내부에서 판단.
+- 필요한 사용자 사전 준비 (코드 변경으로 해결 불가):
+    - Google Play Console → Settings → API access → 서비스 계정 발급 또는 기존 연결 확인.
+    - 계정 권한: Release 를 만들/업로드할 수 있는 수준 ("Release manager" 이상).
+    - 해당 서비스 계정 **JSON key 파일 다운로드**.
+    - GitHub Secrets 에 `GOOGLE_PLAY_SERVICE_ACCOUNT` 이름으로 JSON **원문** 등록.
+    - Play Console 에 **이미 최초 릴리스(internal)가 manual 로 한 번은 올라가 있어야** Fastlane 이후 업로드가 동작. (Play 정책)
+- 개방된 설계 결정:
+    - Fastlane metadata 관리(스크린샷/설명 텍스트 자동화)는 4-1 범위 **밖**. 일단 바이너리 업로드만.
+    - staging variant 도 Play 에 올릴지? 현재 staging 은 applicationIdSuffix `.staging` 이라 별 package. **업로드 대상은 live 만** 으로 한정. staging 은 기존대로 Firebase + Slack.
+
+### [ ] 4-2. reusable workflow 통합
+
+- 현재: Phase 1-2 composite action 덕분에 secrets 중복은 해소. 그러나 Checkout / Setup Java / Setup Gradle / 빌드·Firebase·Slack 로직 자체는 `cd.yml` 과 `manual_deploy.yml` 에 여전히 중복.
+- 4-1 Play Store 업로드까지 합치면 로직 분량이 더 커져 중복 비용이 크다.
+- 설계:
+    - `.github/workflows/_build-and-deploy.yml` (prefix `_` 는 "내부용" 관행) 을 `workflow_call` 로 정의.
+    - inputs: `variant` (live/staging), `upload_firebase` (bool), `upload_play_store` (bool), `slack_message` (string, optional).
+    - secrets: 필요한 모든 secret을 `secrets: inherit` 로 받음.
+    - 책임: Checkout → Setup Java → Setup Gradle → Setup secrets(composite) → build → Firebase(조건부) → Play Store(조건부, 4-1 기준) → Slack(조건부).
+- 호출 측:
+    - `cd.yml`: `release-*` branch + `version.properties` 변경 push → job 2개 (live / staging) 가 각각 reusable workflow 호출.
+    - `manual_deploy.yml`: `workflow_dispatch` → variant / firebase / play_store / slack 입력 받아 reusable workflow 호출.
+    - `rc-bump.yml` (4-4): bump 후 내부적으로 reusable workflow 호출 (또는 commit push 로 cd.yml 간접 트리거).
+- 리스크: reusable workflow 의 `secrets: inherit` 는 caller repo 와 callee 가 같은 repo 에 있을 때 잘 동작. 본 레포에서는 전부 내부 파일이므로 문제 없음.
+
+### [ ] 4-3. GitHub Release draft 자동 생성
+
+- 사용자 결정: PR 기반 자동 노트 생성 **안 함**. `release-drafter` 도입 안 함. 릴리스 노트는 매 릴리스마다 담당자가 한국어로 직접 작성.
+- Phase 4 에서 자동화할 범위: **정식 릴리스 시점에 빈 draft Release + tag 를 자동 생성**. 담당자가 페이지 열어 본문만 작성 → publish.
+- 구현:
+    - `_build-and-deploy.yml` 또는 `cd.yml` 의 live 경로 말미에, `version.properties` 가 `-rc` 없는 정식 버전일 때만 실행되는 스텝 추가.
+    - `softprops/action-gh-release@v2` 로 `tag_name: ${VERSION}`, `draft: true`, `name: v${VERSION}` Release 생성.
+    - tag 도 같은 액션이 만들어줌 (`GITHUB_TOKEN` 권한: `contents: write` 필요).
+- 수동 유지 영역: Release 본문(한국어), publish 버튼.
+- 질문점(추후 결정): tag 기준 커밋을 어디로 할지. 현 흐름상 `release-X.Y.Z` 브랜치의 정식 bump 커밋이 기준이 되는 게 자연스러움. action-gh-release 는 기본적으로 트리거된 ref 기준으로 tag 를 만드므로 정합.
+
+### [ ] 4-4. release 브랜치 push 기반 자동 rc bump
+
+- 사용자 결정: **(iii) 완전 자동** 모드 채택. release 브랜치에 코드 커밋이 들어오면 자동으로 rc 가 +1 되고 빌드/배포까지 연쇄.
+- 설계:
+    - 새 워크플로우 `.github/workflows/rc-bump.yml`.
+    - 트리거:
+        ```yaml
+        on:
+          push:
+            branches: ['release-*']
+            paths-ignore: ['version.properties']
+        ```
+    - 즉 **`version.properties` 가 아닌 파일이 release 브랜치에 push 되면 트리거**. `version.properties` 를 바꾸는 push 는 기존 `cd.yml` 이 담당.
+- 내부 동작:
+    1. 현재 `version.properties` 읽어 `snuttVersionName` 파싱.
+    2. 규칙:
+        - 값이 `X.Y.Z` 형태(rc 없음)면: **에러로 중단**. 정식 버전 상태의 release 브랜치에 코드 커밋이 들어오는 건 의도 불명(이미 릴리스된 상태일 수 있음). 명시적 사용자 개입 필요.
+        - 값이 `X.Y.Z-rc.N` 형태면: `X.Y.Z-rc.(N+1)` 로 계산.
+    3. `version.properties` 업데이트 → commit(작자: `github-actions[bot]`) → push.
+    4. 이 push 는 `version.properties` 변경을 포함하므로 `cd.yml` 이 자연 트리거되어 빌드/배포 수행.
+- 무한 루프 방지:
+    - `rc-bump.yml` 의 `paths-ignore: ['version.properties']` 덕분에 bump 커밋 자체는 `rc-bump.yml` 을 재트리거하지 않음.
+    - 단, 담당자가 한 push 에 **코드 수정 + `version.properties` 를 함께 포함**하면 `paths-ignore` 가 skip 하지 않음 (GitHub Actions 의 paths-ignore semantics: 모든 변경 파일이 ignore 목록 안에 있을 때만 skip). 이 경우 이중 bump 가 일어날 수 있음.
+    - 가드: `rc-bump.yml` 내부에서 "마지막 커밋이 이미 `version.properties` 를 변경했으면 skip" 검사 추가.
+- 트리거 연쇄의 GITHUB_TOKEN 문제:
+    - 일반 `GITHUB_TOKEN` 으로 만든 push 는 **다른 워크플로우를 트리거하지 않음**. 즉 `rc-bump.yml` 이 `GITHUB_TOKEN` 으로 push 하면 `cd.yml` 이 따라 돌지 않음.
+    - 해결: `rc-bump.yml` 이 bump 후 **reusable workflow (`_build-and-deploy.yml`) 를 직접 호출**하여 빌드/배포 연쇄. 별도 workflow 간접 트리거 없이 한 워크플로우 내에서 모두 처리.
+    - 이 설계는 `cd.yml` 의 기존 동작(버전 직접 편집 push)과도 호환됨 — `cd.yml` 역시 같은 reusable workflow 호출.
+- Fastlane 트랙 로직과의 정합: bump 후 버전은 반드시 `-rc.N` 이므로 `upload_internal` 로만 감. 정식 릴리스는 4-4 대상이 아니고 담당자가 직접 `version.properties` 수정.
+
+### 전체 흐름 정리 (Phase 4 완료 시)
+
+```
+[담당자] release-X.Y.Z 브랜치 분기
+[담당자] version.properties → X.Y.Z-rc.1 push
+  └─ cd.yml 트리거
+       └─ _build-and-deploy.yml
+            ├─ live AAB 빌드
+            ├─ Firebase upload
+            ├─ Fastlane: Play Store internal
+            └─ Slack 알림
+
+[담당자] 코드 수정 커밋 push (버그 수정 등)
+  └─ rc-bump.yml 트리거 (paths-ignore: version.properties)
+       ├─ rc.N → rc.N+1 계산
+       ├─ version.properties commit + push
+       └─ _build-and-deploy.yml 직접 호출
+            ├─ live AAB 빌드
+            ├─ Firebase upload
+            ├─ Fastlane: Play Store internal
+            └─ Slack 알림
+
+[담당자] QA 완료 → version.properties → X.Y.Z (rc 제거) push
+  └─ cd.yml 트리거
+       └─ _build-and-deploy.yml
+            ├─ live AAB 빌드
+            ├─ Firebase upload
+            ├─ Fastlane: Play Store production draft ★
+            ├─ GitHub Release draft + tag 생성 ★
+            └─ Slack 알림
+
+[담당자] Play Console "Review and release" 수동 클릭
+[담당자] GitHub Release 페이지에서 한국어 노트 작성 + publish
+[담당자] release-X.Y.Z → develop merge back
+```
+
+### Phase 4 진행 순서
+
+1. **4-2 reusable workflow 틀 먼저 구축**. 기존 `cd.yml`, `manual_deploy.yml` 의 현재 동작을 이 틀로 이관.
+2. **4-1 Fastlane + Play Store 업로드** 를 reusable workflow 에 조건부 스텝으로 추가.
+3. **4-3 GitHub Release draft** 생성 스텝 추가 (정식 버전일 때만).
+4. **4-4 rc-bump 워크플로우** 신설 + reusable workflow 호출.
+
+이 순서로 가는 이유: 4-2 가 나머지 전부의 기반이 되며, 4-4 는 reusable workflow 가 있어야 연쇄 호출이 깔끔. 4-1 은 Phase 4 의 핵심 가치지만 구조가 먼저 정돈된 후 붙이는 것이 리스크가 적음.
+
+### Phase 4 사용자 사전 준비 체크리스트
+
+- [ ] Google Play Console → Settings → API access → 서비스 계정 발급 또는 기존 서비스 계정 연결 확인
+- [ ] 서비스 계정 권한 "Release manager" 이상 부여 (Releases 생성/업로드 필요)
+- [ ] 서비스 계정 JSON key 파일 다운로드
+- [ ] GitHub Secrets 에 `GOOGLE_PLAY_SERVICE_ACCOUNT` 이름으로 JSON 원문 등록
+- [ ] Play Console 에 해당 `applicationId` 앱의 **최초 internal release 가 manual 로 한 번 업로드되어 있을 것** (Play Console 정책상 서비스 계정 업로드는 최초 수동 릴리스 이후에 가능)
 
 ---
 

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -81,11 +81,17 @@
 
 ## Phase 2. 코드 품질 강화
 
-### [ ] 2-1. Android Lint CI 통합
+### [x] 2-1. Android Lint CI 통합
 
 - 현재: ktlint 만. Android Lint 는 돌지 않음.
 - 할 일: `./gradlew lintStagingDebug` 추가. `app/lint-baseline.xml` 도입하여 기존 경고는 baseline 처리.
 - 고려: 경고 양이 많으면 baseline 으로 처음엔 가드만 세우고 점진적으로 줄인다.
+- 결정/결과:
+    - 최초 실측: **86 errors / 254 warnings / 2 hints**. 일괄 수정은 이 PR 범위 밖.
+    - `app/build.gradle.kts` 의 `android { ... }` 에 `lint { baseline = file("lint-baseline.xml") }` 추가, `./gradlew updateLintBaseline` 으로 baseline 생성 (app/lint-baseline.xml, 약 3700 줄).
+    - `ci.yml` 의 `build-and-test` job 이 `assembleStagingDebug testStagingDebugUnitTest lintStagingDebug` 를 한 명령으로 실행 — compile 공유.
+    - 실패 시 lint html report 업로드.
+    - **후속 과제**: baseline 을 점진적으로 줄이는 작업. 별도 이슈/PR 로 단계적으로 처리해야 함. 여기선 가드만 세움.
 
 ### [ ] 2-2. detekt 도입 검토
 

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -58,18 +58,24 @@
     - `ci.yml` 에 한해 `cache-read-only: ${{ github.event_name == 'pull_request' }}` 지정. PR 에서는 캐시 write 금지하여 caching poisoning 방지, develop push 시만 쓰기.
     - 도입 직후 최초 실행은 캐시 미스로 느릴 수 있으나 이후 점진적으로 히트율 상승 예상.
 
-### [ ] 1-4. CI job 분리 (병렬화)
+### [x] 1-4. CI job 분리 (병렬화)
 
 - 현재: ktlint → build → unit test 직렬.
 - 할 일: ktlint / build / unit test 를 별도 job 으로 분리. 독립 실행 가능한 것은 병렬화.
 - 효과: 실패 원인 분명, 빠른 피드백.
 - 고려: Gradle 캐시/warm-up 중복 비용과의 트레이드오프 — 병렬화해도 실제로 빨라지는지 실측 필요.
+- 결정/결과:
+    - **2 job 분리** (`ktlint` / `build-and-test`). 3 job 완전 분리는 setup 오버헤드 × 3 + compile 중복으로 오히려 느려질 가능성 높음.
+    - `build-and-test` 는 `assembleStagingDebug testStagingDebugUnitTest` 를 한 번에 실행 → compile 산출물 공유.
+    - 테스트 실패 시 `./**/build/reports/tests/**` 업로드 추가.
+    - 실제 병렬 효과는 첫 실행 이후 캐시가 데워진 다음에 관측 가능.
 
-### [ ] 1-5. Secrets 주입 방식 개선
+### [x] 1-5. Secrets 주입 방식 개선
 
 - 현재: heredoc 방식. multi-line JSON 에서 변수 expansion / escape 취약점.
 - 할 일: base64 인코딩 → `base64 -d` 디코딩 방식 또는 안전한 write 방식으로 치환.
 - 관련: GitHub Actions 의 secret masking 과도 어울려야 함.
+- 결정/결과: **1-2 에 흡수되어 해소**. composite action 내부에서 `env:` 로 secret 을 주입 후 `printf '%s' "$VAR" > path` 로 기록. base64 인코딩 전환(GitHub Secrets 재등록) 없이도 heredoc 의 expansion/escape 이슈는 제거됨. keystore 만 기존대로 base64 로 저장(바이너리 파일이라 텍스트 기록 불가).
 
 ---
 

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -1,0 +1,153 @@
+# CI/CD 정비 및 자동화 고도화 계획
+
+## 목적
+
+현재 `.github/workflows/` 의 워크플로우(`ci.yml`, `cd.yml`, `manual_deploy.yml`)를 정비하고, 자동화를 점진적으로 확장한다.
+
+원칙:
+
+- **낮은 리스크 / 높은 효과** 부터 먼저. 기반 정비(중복 제거·속도 개선) 이후에 고도화(자동화 추가).
+- 각 Phase는 독립된 PR 단위로 쪼갠다. Phase 내부에서도 항목별로 커밋/PR 가능.
+- 도입 비용이 큰 항목은 "검토 → 도입" 2단계로 나눈다.
+
+---
+
+## 현재 상태 스냅샷
+
+- `ci.yml`: `develop` PR/push 시 ktlint → assembleStagingDebug → testStagingDebugUnitTest (직렬).
+- `cd.yml`: `release-*` 브랜치의 `version.properties` 변경 시 live/staging 빌드 + Firebase + Slack.
+- `manual_deploy.yml`: `workflow_dispatch` 로 live/staging 선택 배포.
+- Java: `ci.yml` 은 21, `cd.yml`/`manual_deploy.yml` 은 17 (불일치).
+- Gradle 캐시: `actions/setup-java` 의 `cache: gradle` 만 사용 중.
+- Secrets 주입: heredoc (`cat << EOF > ... ${{ secrets.* }} EOF`) 방식. 3개 워크플로우에 거의 동일한 블록이 중복.
+
+---
+
+## Phase 1. 기반 정비 (리스크 낮음, 효과 빠름)
+
+### [x] 1-1. Java 버전 통일
+
+- 현재: CI 21, CD/Manual 17.
+- 할 일: 셋 다 동일 버전으로 맞춘다. (앱 실제 빌드 환경과의 정합성 확인 필요 — `gradle/libs.versions.toml`, `build.gradle.kts` 의 `jvmToolchain` / `compileOptions` 기준으로 결정)
+- 리스크: 낮음. 실제 요구되는 JDK 확인만 정확히.
+- 결정/결과:
+    - 근거: `app/build.gradle.kts` 의 `compileOptions.sourceCompatibility = VERSION_17` 과 정합 맞춤. JDK 21 고유 기능 미사용.
+    - 조치: `ci.yml` java-version 21 → 17. `manual_deploy.yml` distribution `adopt`(legacy) → `temurin` 도 함께 정렬.
+    - 별도 발견: `core/network` 모듈은 실제 존재하지 않음. 3개 워크플로우의 `./core/network/...` secrets 셋업 스텝은 쓸모없는 디렉토리만 생성. **1-2 에서 정리**.
+
+### [ ] 1-2. Secrets 셋업 composite action 추출
+
+- 현재: google-services.json / secrets.xml(app, core:network) / gcp-service-account.json / keystore 가 3개 워크플로우에 거의 동일하게 중복.
+- 할 일: `.github/actions/setup-secrets/action.yml` composite action 으로 뽑아 공통화. `variant` (staging/live) 를 입력으로 받아 분기.
+- 효과: 한 곳만 수정하면 됨. 휴먼 에러 감소.
+
+### [ ] 1-3. Gradle 셋업 개선
+
+- 현재: `actions/setup-java@v4` 의 `cache: gradle`.
+- 할 일: `gradle/actions/setup-gradle@v4` 도입. build-cache / configuration-cache / dependency 캐시 전략 개선.
+- 효과: 캐시 히트 향상 → CI 시간 단축.
+
+### [ ] 1-4. CI job 분리 (병렬화)
+
+- 현재: ktlint → build → unit test 직렬.
+- 할 일: ktlint / build / unit test 를 별도 job 으로 분리. 독립 실행 가능한 것은 병렬화.
+- 효과: 실패 원인 분명, 빠른 피드백.
+- 고려: Gradle 캐시/warm-up 중복 비용과의 트레이드오프 — 병렬화해도 실제로 빨라지는지 실측 필요.
+
+### [ ] 1-5. Secrets 주입 방식 개선
+
+- 현재: heredoc 방식. multi-line JSON 에서 변수 expansion / escape 취약점.
+- 할 일: base64 인코딩 → `base64 -d` 디코딩 방식 또는 안전한 write 방식으로 치환.
+- 관련: GitHub Actions 의 secret masking 과도 어울려야 함.
+
+---
+
+## Phase 2. 코드 품질 강화
+
+### [ ] 2-1. Android Lint CI 통합
+
+- 현재: ktlint 만. Android Lint 는 돌지 않음.
+- 할 일: `./gradlew lintStagingDebug` 추가. `app/lint-baseline.xml` 도입하여 기존 경고는 baseline 처리.
+- 고려: 경고 양이 많으면 baseline 으로 처음엔 가드만 세우고 점진적으로 줄인다.
+
+### [ ] 2-2. detekt 도입 검토
+
+- 현재: 없음.
+- 할 일: 먼저 **검토**. 프로젝트 규모 대비 유용성 / ktlint 와의 역할 중복 판단. 도입 결정 시 규칙 세트 선정 후 별 PR.
+- 고려: ktlint 는 포맷팅, detekt 는 코드 스멜 — 역할 다름. 둘 다 돌려도 의미 있음.
+
+---
+
+## Phase 3. PR 자동화
+
+### [ ] 3-1. PR labeler 도입
+
+- 할 일: `actions/labeler` 로 변경된 파일 경로 기반 영역 라벨 (`feature/bookmark`, `core/network`, `ci`, `docs` 등) 자동 부여.
+- 효과: PR 리뷰어/필터링 편의.
+
+### [ ] 3-2. PR size label
+
+- 할 일: `CodelyTV/pr-size-labeler` 또는 유사 액션으로 S/M/L/XL 라벨링.
+
+### [ ] 3-3. Danger-Kotlin 검토
+
+- 현재: 없음.
+- 할 일: 먼저 **검토**. "체크리스트 미작성 / 큰 PR 경고 / CHANGELOG 업데이트 확인" 등 어떤 규칙을 강제할지 먼저 정의 → 규칙 없으면 도입 보류.
+
+---
+
+## Phase 4. 릴리스 자동화
+
+### [ ] 4-1. `cd.yml` ↔ `manual_deploy.yml` 정리
+
+- 현재: 두 워크플로우가 거의 같은 job 을 중복으로 들고 있음. (Phase 1-2 composite action 이 적용되면 부담이 크게 줄어듦)
+- 할 일: reusable workflow (`workflow_call`) 로 공통화 검토.
+
+### [ ] 4-2. `version.properties` 자동 bump
+
+- 할 일: 릴리스 브랜치 생성 시 버전 자동 증분 워크플로우. semver 규칙 선정 필요.
+- 고려: 현재 릴리스 플로우(누가, 언제 `version.properties` 를 바꾸는지)를 먼저 파악해야 안전.
+
+### [ ] 4-3. 릴리스 노트 자동 생성
+
+- 할 일: PR 제목/라벨 기반 `release-drafter` 도입 검토.
+- 전제: 커밋/PR 메시지 컨벤션(현재 `[폴더위계정리] refactor: ...` 같은 대괄호 prefix)이 있어서 릴리스 노트 그룹핑 규칙을 어떻게 잡을지 결정 필요.
+
+---
+
+## Phase 5. 의존성 관리 자동화
+
+### [ ] 5-1. Renovate vs Dependabot 선정
+
+- 현재: 없음.
+- 할 일: Android 생태계에서는 Renovate 가 Gradle version catalog 와의 호환성이 더 좋음. 먼저 **검토**, 정책(자동 머지 범위, PR 빈도) 결정 후 도입.
+
+---
+
+## Phase 6. 테스트 확장
+
+### [ ] 6-1. Instrumented test (Firebase Test Lab) 도입 검토
+
+- 현재: unit test 만.
+- 할 일: 실제 디바이스 테스트 필요성 / 비용 / 유지보수 부담 먼저 평가.
+
+### [ ] 6-2. Screenshot test 도입 검토
+
+- 후보: Paparazzi (JVM 기반, instrumented 불필요).
+- 할 일: Compose 전환 정도 대비 ROI 평가.
+
+---
+
+## Phase 7. 관측 / 성능
+
+### [ ] 7-1. Gradle Build scan / Develocity 검토
+
+- 할 일: OSS build-scan 무료 티어로 먼저 실험 → 빌드 속도 병목 분석 근거 마련.
+
+---
+
+## 진행 규칙
+
+- 각 항목 완료 시 체크박스 갱신 + 커밋 메시지에 항목 번호 포함 (예: `ci: [1-2] secrets setup composite action 추출`).
+- Phase 내부라도 항목끼리 독립성이 있으면 별도 PR. 서로 영향 주는 것(예: 1-2 와 1-4)은 묶어서 가능.
+- 검토 항목(2-2, 3-3, 4-2, 5-1, 6-1, 6-2, 7-1)은 결론이 "도입 보류"라도 결론/근거를 이 문서에 남긴다.

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -93,11 +93,21 @@
     - 실패 시 lint html report 업로드.
     - **후속 과제**: baseline 을 점진적으로 줄이는 작업. 별도 이슈/PR 로 단계적으로 처리해야 함. 여기선 가드만 세움.
 
-### [ ] 2-2. detekt 도입 검토
+### [x] 2-2. detekt 도입 검토
 
 - 현재: 없음.
 - 할 일: 먼저 **검토**. 프로젝트 규모 대비 유용성 / ktlint 와의 역할 중복 판단. 도입 결정 시 규칙 세트 선정 후 별 PR.
 - 고려: ktlint 는 포맷팅, detekt 는 코드 스멜 — 역할 다름. 둘 다 돌려도 의미 있음.
+- 결정/결과: **현 시점 도입 보류**.
+    - 근거:
+        - ktlint (포맷팅) + Android Lint (Android/리소스/버그 패턴) 로 기본 가드 이미 확보 (2-1 도입).
+        - 2-1 에서 경험했듯 기존 Kotlin 코드베이스는 정적 분석 baseline 규모가 크다(lint baseline 3700 줄). detekt 도입 시 또 하나의 baseline 을 관리해야 하며, 초기 규칙 튜닝 / 팀 합의 비용 존재.
+        - 리팩토링이 활발한 시기에는 baseline 이 자주 움직여 가치가 부분적으로 상쇄.
+    - 재도입 트리거:
+        - 복잡도(Cyclomatic, LongMethod 등) 규칙을 팀이 적극적으로 원함.
+        - custom 룰(도메인 패턴 강제) 필요.
+        - Android Lint 커버하지 못하는 Kotlin 특유의 코드 스멜이 리뷰에서 반복적으로 지적됨.
+    - 재도입 시 절차: rule set 선정 → `./gradlew detekt` baseline 생성 → CI 통합 → 팀에 공지.
 
 ---
 

--- a/docs/ci-cd-improvement-plan.md
+++ b/docs/ci-cd-improvement-plan.md
@@ -48,11 +48,15 @@
     - `manual_deploy.yml` 의 `startsWith(inputs.variant, 'live')` 조건은 값이 고정 enum 이라 `== 'live'` 로 단순화.
     - 별도 발견: `app/src/staging/res/value/strings.xml` 디렉토리 오타(`value` 단수형). Android 가 리소스로 인식 안 함. CI/CD 범위 밖이라 플래그만.
 
-### [ ] 1-3. Gradle 셋업 개선
+### [x] 1-3. Gradle 셋업 개선
 
 - 현재: `actions/setup-java@v4` 의 `cache: gradle`.
 - 할 일: `gradle/actions/setup-gradle@v4` 도입. build-cache / configuration-cache / dependency 캐시 전략 개선.
 - 효과: 캐시 히트 향상 → CI 시간 단축.
+- 결정/결과:
+    - 3개 워크플로우 모두 `setup-java` 의 `cache: 'gradle'` 제거 후 `gradle/actions/setup-gradle@v4` 별도 스텝 추가.
+    - `ci.yml` 에 한해 `cache-read-only: ${{ github.event_name == 'pull_request' }}` 지정. PR 에서는 캐시 write 금지하여 caching poisoning 방지, develop push 시만 쓰기.
+    - 도입 직후 최초 실행은 캐시 미스로 느릴 수 있으나 이후 점진적으로 히트율 상승 예상.
 
 ### [ ] 1-4. CI job 분리 (병렬화)
 


### PR DESCRIPTION
## Summary

CI/CD 정비 및 자동화 고도화 로드맵 수립 및 Phase 1·2 실행.

### Phase 1. 기반 정비
- **1-1** Java 버전/distribution 정렬 (`ci.yml` 21 → 17, `manual_deploy.yml` `adopt` → `temurin`)
- **1-2** secrets 셋업 composite action (`.github/actions/setup-secrets`) 추출 — 3개 워크플로우 중복 제거 + 실존하지 않는 `core/network` 스텝 삭제
- **1-3** `gradle/actions/setup-gradle@v4` 도입, PR 에서 cache-read-only
- **1-4** `ci.yml` 을 `ktlint` / `build-and-test` 2 job 으로 분리
- **1-5** heredoc → env + `printf '%s'` 방식으로 secrets 주입 (1-2 에 흡수)

### Phase 2. 코드 품질 강화
- **2-1** Android Lint CI 통합. 최초 실측 **86 errors / 254 warnings** 는 `app/lint-baseline.xml` 에 baseline 처리 (신규 경고만 실패 처리). `build-and-test` job 이 `assembleStagingDebug testStagingDebugUnitTest lintStagingDebug` 를 한 명령으로 실행하여 compile 산출물 공유
- **2-2** detekt 도입 검토 → 현 시점 보류 (근거/재도입 트리거 문서화)

### Phase 3, 4 상태
- **Phase 3** (PR 자동화) ROI 불명확으로 제거
- **Phase 4** (릴리스 자동화) 설계 확정 — 본 PR 에서는 계획 문서만. 구현은 별도 브랜치. 자세한 설계는 `docs/ci-cd-improvement-plan.md` 참조
    - 4-1 Play Store 업로드 (Fastlane)
    - 4-2 reusable workflow 통합
    - 4-3 GitHub Release draft 자동 생성 (노트 본문은 수동)
    - 4-4 release 브랜치 push 시 자동 rc bump

## Test plan

- [x] YAML 문법 검증 (PyYAML safe_load)
- [x] 로컬 `./gradlew ktlintCheck` 통과
- [x] 로컬 `./gradlew updateLintBaseline` → `./gradlew lintStagingDebug` 통과 (baseline 적용 후 "no new issues")
- [ ] 본 PR 의 `ci.yml` 2 job 실행 확인 (ktlint / build-and-test)
- [ ] `cd.yml`, `manual_deploy.yml` 변경은 release 브랜치 푸시 또는 수동 실행 시점에 검증 가능 (본 PR merge 만으로는 트리거되지 않음)

## Follow-ups

- Phase 4 구현 (별도 브랜치)
- `app/lint-baseline.xml` 점진적 축소 (별도 병렬 작업)
- `app/src/staging/res/value/` (단수) 오타 수정 — CI/CD 범위 밖, 별도 처리 필요