### PR TITLE
[CI정비] ci: GitHub Actions 버전 업데이트 (Node 20 deprecation 대응)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup secrets
         uses: ./.github/actions/setup-secrets
         with:
@@ -58,14 +58,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup secrets
         uses: ./.github/actions/setup-secrets
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Setup secrets
@@ -46,14 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Setup secrets

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -26,14 +26,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup secrets (Live)
         if: github.event.inputs.variant == 'live'
         uses: ./.github/actions/setup-secrets


### PR DESCRIPTION
## Summary

- GitHub Actions 러너의 Node.js 20 deprecation 경고 대응 (2026-06-02 강제 Node 24 전환, 2026-09-16 Node 20 제거)
- `actions/checkout@v4 → v6`, `actions/setup-java@v4 → v5`, `gradle/actions/setup-gradle@v4 → v6`
- 3개 워크플로우(`ci.yml`, `cd.yml`, `manual_deploy.yml`) 일괄 적용

## 릴리즈 노트 검토 결과

### `actions/checkout@v6` ([v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0) / [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0))
- v5: Node 24 업그레이드
- v6: `persist-credentials`를 `$RUNNER_TEMP`로 이동 (Docker container action 시나리오용, 우리 사용 패턴과 무관)
- 최소 러너 v2.329.0 필요 (GitHub-hosted runner는 자동 충족)

### `actions/setup-java@v5` ([v5.0.0 release](https://github.com/actions/setup-java/releases/tag/v5.0.0))
- breaking change는 Node 24 업그레이드뿐
- 기존 `java-version`, `distribution` 인풋 그대로 사용

### `gradle/actions/setup-gradle@v6` ([v5.0.0](https://github.com/gradle/actions/releases/tag/v5.0.0) / [v6.0.0](https://github.com/gradle/actions/releases/tag/v6.0.0) / [blog](https://blog.gradle.org/github-actions-for-gradle-v6))
- **라이선스 변경 주의**: v6부터 캐시 기능이 proprietary `gradle-actions-caching` 컴포넌트로 분리
- public repo인 snutt-android는 enhanced caching 무료 사용 가능
- [Gradle Terms of Use](https://gradle.com/legal/terms-of-use/) 동의로 간주됨
- `cache-read-only` 등 기존 인풋 호환

## Test plan

- [x] 로컬 YAML 문법 검증 (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] PR 푸시 후 CI (`ktlint`, `build-and-test`) Node 20 deprecation 경고 사라지는지 확인
- [ ] CI 잡의 Gradle 캐시 히트 정상 동작 확인
- [ ] `cd.yml` / `manual_deploy.yml`은 실제 트리거될 때 검증 (이번 PR 범위 외)