### PR TITLE
fix: configuration change 시 현재 화면이 초기화되는 문제 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
@@ -72,7 +72,7 @@ class RootActivity : AppCompatActivity() {
         splashScreen.setKeepOnScreenCondition { isLoading }
 
         enableEdgeToEdge()
-        super.onCreate(null)
+        super.onCreate(savedInstanceState)
 
         FirebaseApp.initializeApp(this)
         parseDeeplinkExtra()


### PR DESCRIPTION
## Summary
- `RootActivity.onCreate` 에서 `super.onCreate(null)` 로 `savedInstanceState` 를 강제로 버리고 있어, 다크모드 토글 등 configuration change 발생 시 NavController 백스택이 복원되지 않고 항상 `startDestination` 으로 초기화되는 문제가 있었음
- 해당 `null` 전달은 PR #182 에서 React Native 통합을 위해 도입됐으나, PR #492 에서 RN 코드가 제거된 이후로는 명분이 사라진 잔재로 남아 있었음
- `super.onCreate(savedInstanceState)` 로 원복하여 NavController 백스택 / `rememberSaveable` / `SavedStateHandle` 등이 정상 복원되도록 수정

## 배경
- route 별 `hiltViewModel()` 은 NavBackStackEntry 에 scope 되어 있어, 백스택이 재생성되면 ViewModel 도 함께 날아감
- 따라서 "ViewModel 에 상태를 다 두었는데도 다크모드 토글 시 홈으로 돌아가는" 현상이 ViewModel 문제가 아닌 NavController 백스택 복원 실패에서 기인

## Test plan
- [ ] 빌드 확인
- [ ] 비 홈 화면 진입 → 다크모드 토글 → 원래 화면이 유지되는지 확인
- [ ] 비 홈 화면 진입 → 시스템 폰트 크기 변경 등 기타 configuration change → 화면 유지 확인
- [ ] 콜드 스타트 / 딥링크 진입 등 기존 플로우 회귀 없음 확인