### PR TITLE
fix: 학과 탭이 아닌 검색 필터 탭에서도 '최근 찾아본 학과' 가 노출되던 문제 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchOptionSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchOptionSheet.kt
@@ -99,7 +99,7 @@ fun SearchOptionSheet(
                     )
                     .offset(x = offsetXAnimatedDp)
                     .alpha(alphaAnimatedFloat),
-                recentSearchedDepartments = recentSearchedDepartments,
+                recentSearchedDepartments = if (selectedTagType == TagType.DEPARTMENT) recentSearchedDepartments else emptyList(),
                 searchTags = searchTags,
                 selectedTimes = draggedTimeBlock,
                 onToggleTag = { searchTag ->


### PR DESCRIPTION
## Summary
- 검색 필터 바텀시트에서 학과(`TagType.DEPARTMENT`) 탭이 아닌 다른 태그 탭(학년, 시간 등)을 편집할 때도 '최근 찾아본 학과' 섹션이 그대로 노출되던 버그 수정
- `SearchOptionSheet` 가 `SearchTagsColumn` 에 `recentSearchedDepartments` 를 `selectedTagType` 과 무관하게 전달하고 있던 것이 원인
- 호출부에서 `selectedTagType == TagType.DEPARTMENT` 일 때만 실제 리스트를 전달하고, 그 외에는 `emptyList()` 를 넘기도록 수정

## 설계 선택
- `SearchTagsColumn` 은 이미 'recentSearchedDepartments 가 비어있으면 섹션 숨김' 이라는 contract 를 가지고 있어, 이를 수정하지 않고 호출부만 분기하는 방향으로 처리
- `SearchTagsColumn` 시그니처에 `selectedTagType` 을 추가로 넘기는 건 중복 정보 주입이라고 판단해 배제

## Test plan
- [ ] 빌드 확인
- [ ] 학과 탭에서 '최근 찾아본 학과' 정상 노출 확인
- [ ] 학년 / 시간 / 학점 / 분류 등 다른 탭에서 '최근 찾아본 학과' 가 **노출되지 않음** 확인
- [ ] 학과 탭에서 최근 검색 기록 X 아이콘으로 삭제 동작 정상 확인