### PR TITLE
[CI정비] setup-java rate limit 대응 (GITHUB_TOKEN 주입)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'jetbrains'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Setup secrets
@@ -64,6 +66,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'jetbrains'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Setup secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'jetbrains'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
@@ -52,6 +54,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'jetbrains'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'jetbrains'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Setup secrets (Live)


### PR DESCRIPTION
## 배경
CI에서 가끔 다음과 같은 에러가 발생:
```
Trying to resolve the latest version from remote
##[error]Java setup process failed due to: API rate limit exceeded for 52.159.244.160
```

## 원인 (v5 소스 기준)
- `actions/setup-java@v5`의 `jetbrains` 배포 설치기는 버전 해석을 위해 `https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases` 를 호출
- 해당 설치기는 `GITHUB_TOKEN` **환경변수**가 있을 때만 `Authorization: Bearer` 헤더를 추가 (`src/distributions/jetbrains/installer.ts`)
- setup-java의 `token` **input**은 Maven 서버 인증에만 사용되고 `GITHUB_TOKEN` env로 자동 승격되지 않음 (`src/setup-java.ts`)
- 따라서 워크플로우에서 env를 명시하지 않으면 해당 API 호출은 미인증 → IP당 60회/시간 공유 한도를 쉽게 초과

## 변경사항
- `ci.yml`(2곳), `cd.yml`(2곳), `manual_deploy.yml`(1곳) 총 5군데의 Setup Java 스텝에 `env.GITHUB_TOKEN` 주입
- 인증된 호출은 리포 기준 1000 req/hour 한도 적용

## Test plan
- [ ] 이 PR의 CI 실행이 정상 통과하는지 확인
- [ ] CI 로그의 setup-java 스텝에서 rate limit 에러가 재발하지 않는지 관찰