### PR TITLE
fix: 상시강의 상세 복귀 시 위로 스크롤이 막히는 문제 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/ScrollableTimetable.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/ScrollableTimetable.kt
@@ -60,7 +60,8 @@ fun ScrollableTimetableContent(
     val isSessionlessLectureExists = sessionlessLectures.isNotEmpty()
 
     val scrollState = rememberLazyListState()
-    var scrollUnlocked by remember { mutableStateOf(false) }
+    // scrollState가 saveable이라 화면 복귀 시 위치는 복원되므로, lock 상태도 visited와 동기화한다.
+    var scrollUnlocked by remember { mutableStateOf(!isSessionlessLectureHintVisible) }
 
     val isHintVisible = isSessionlessLectureHintVisible && !scrollUnlocked
 


### PR DESCRIPTION
## Summary

- 상시강의 영역까지 스크롤한 뒤 강의 아이템을 눌러 상세 페이지에 진입했다가 돌아오면, 위로 스크롤이 동작하지 않고 한 번 아래로 (이미 맨 밑이라도) 강하게 내려야 위로 다시 올릴 수 있던 문제 수정.

## Cause

`ScrollableTimetable.kt`에 두 종류의 상태가 공존하는데, 화면 복귀 시 동기화가 깨지고 있었습니다.

| 상태 | 저장 방식 | 복귀 시 |
|---|---|---|
| `scrollState = rememberLazyListState()` | 내부적으로 `rememberSaveable` | 스크롤 위치 복원 (상시강의 영역) |
| `scrollUnlocked = remember { mutableStateOf(false) }` | 일반 `remember` | `false`로 리셋 |

`NestedScrollConnection.onPreScroll`은 `velocity <= -50 || scrollUnlocked` 조건일 때만 자식 LazyColumn에 스크롤을 위임합니다. 복귀 후에는 위치는 sessionless 영역이지만 `scrollUnlocked = false`라서, 위로 스크롤(양수 velocity)이 부모에서 모두 소비되어 차단됩니다. 한 번 아래로 강하게 내리면 그제서야 `scrollUnlocked = true`로 바뀌어 정상 동작.

## Fix

ViewModel에는 이미 `tableDisplayRepository`로 영속화된 visited 상태가 있고, 그 결과가 `isSessionlessLectureHintVisible` 파라미터로 들어옵니다. `scrollUnlocked`의 초기값을 `!isSessionlessLectureHintVisible`로 두어 visited 상태와 동기화했습니다.

```kotlin
var scrollUnlocked by remember { mutableStateOf(!isSessionlessLectureHintVisible) }
```

별도의 `rememberSaveable` 도입 없이 한 줄 변경으로 해결됩니다.

## Test plan

- [ ] 첫 진입 (visit 전): hint 노출, 한 번 강하게 아래로 당겨야 sessionless 영역으로 진입 (기존과 동일)
- [ ] visit 후 같은 컴포지션에서: hint 페이드아웃 후 자유 스크롤 (기존과 동일)
- [ ] **상시강의 아이템 → 상세 → 뒤로 가기 후 위로 스크롤이 즉시 동작하는지 확인 (이번 수정 대상)**
- [ ] 상시강의가 없는 시간표: `userScrollEnabled = false`로 어차피 스크롤 불가 → 영향 없음 확인