### PR TITLE
refactor: login feature 입력 상태 ViewModel hoist

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationPage.kt
@@ -17,11 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -33,6 +29,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.EditText
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
@@ -48,12 +45,6 @@ import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 import com.wafflestudio.snutt2.ui.util.toast
 
-// TODO: 뷰모델로 로직 및 상태관리 이전하기
-private enum class VerifyEmailState {
-    AskContinue,
-    SendCode,
-}
-
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EmailVerificationPage(
@@ -63,8 +54,8 @@ fun EmailVerificationPage(
     val context = LocalContext.current
     val keyboardManager = LocalSoftwareKeyboardController.current
     val verificationSuccessMessage = stringResource(R.string.find_password_enter_verification_code_success_alert)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    var flowState by remember { mutableStateOf(VerifyEmailState.AskContinue) }
     // TODO: TimerState 손보기
     val timerState = rememberTimerState(initialValue = TimerValue.Initial, durationInSecond = 180)
 
@@ -72,8 +63,7 @@ fun EmailVerificationPage(
         viewModel.uiEvent.collect { event ->
             when (event) {
                 is EmailVerificationUiEvent.ShowToast -> context.toast(event.message)
-                is EmailVerificationUiEvent.CodeSent -> {
-                    flowState = VerifyEmailState.SendCode
+                is EmailVerificationUiEvent.RestartTimer -> {
                     timerState.reset()
                     timerState.start()
                 }
@@ -90,13 +80,15 @@ fun EmailVerificationPage(
 
     EmailVerificationScreen(
         userEmail = viewModel.userEmail,
-        flowState = flowState,
+        flowState = uiState.flowState,
+        codeField = uiState.codeField,
         timerState = timerState,
-        onSendCode = { viewModel.sendCodeToEmail(it) },
-        onVerifyCode = { viewModel.verifyEmailCode(it) },
+        onCodeFieldChange = viewModel::onCodeFieldChange,
+        onSendCode = viewModel::sendCodeToEmail,
+        onVerifyCode = viewModel::verifyEmailCode,
         onNavigateHome = onNavigateHome,
         onBackToAskContinue = {
-            flowState = VerifyEmailState.AskContinue
+            viewModel.backToAskContinue()
             timerState.reset()
         },
     )
@@ -106,10 +98,12 @@ fun EmailVerificationPage(
 @Composable
 private fun EmailVerificationScreen(
     userEmail: String,
-    flowState: VerifyEmailState,
+    flowState: EmailVerificationUiState.FlowState,
+    codeField: String,
     timerState: TimerState,
-    onSendCode: (String) -> Unit,
-    onVerifyCode: (String) -> Unit,
+    onCodeFieldChange: (String) -> Unit,
+    onSendCode: () -> Unit,
+    onVerifyCode: () -> Unit,
     onNavigateHome: () -> Unit,
     onBackToAskContinue: () -> Unit,
 ) {
@@ -118,8 +112,7 @@ private fun EmailVerificationScreen(
     val emptyAlert = stringResource(R.string.find_password_enter_verification_code_empty_alert)
     val expireMessage = stringResource(R.string.find_password_enter_verification_code_expire_message)
 
-    var codeField by remember { mutableStateOf("") }
-    val buttonEnabled by remember { derivedStateOf { codeField.isNotEmpty() } }
+    val buttonEnabled = codeField.isNotEmpty()
 
     val handleEnterCode = {
         if (codeField.isEmpty()) {
@@ -127,17 +120,14 @@ private fun EmailVerificationScreen(
         } else if (timerState.isEnded) {
             context.toast(expireMessage)
         } else {
-            onVerifyCode(codeField)
+            onVerifyCode()
         }
     }
 
     val onBackPressed: () -> Unit = {
         when (flowState) {
-            VerifyEmailState.AskContinue -> onNavigateHome()
-            VerifyEmailState.SendCode -> {
-                onBackToAskContinue()
-                codeField = ""
-            }
+            EmailVerificationUiState.FlowState.AskContinue -> onNavigateHome()
+            EmailVerificationUiState.FlowState.SendCode -> onBackToAskContinue()
         }
     }
 
@@ -155,7 +145,7 @@ private fun EmailVerificationScreen(
         AnimatedContent(targetState = flowState) { targetState ->
             Column(modifier = Modifier.padding(horizontal = 25.dp)) {
                 when (targetState) {
-                    VerifyEmailState.AskContinue -> {
+                    EmailVerificationUiState.FlowState.AskContinue -> {
                         Text(
                             text = stringResource(R.string.verify_email_question_text, userEmail),
                             style = SNUTTTypography.h3,
@@ -168,7 +158,7 @@ private fun EmailVerificationScreen(
                         Spacer(modifier = Modifier.size(100.dp))
                         WebViewStyleButton(
                             modifier = Modifier.fillMaxWidth(),
-                            onClick = { onSendCode(userEmail) },
+                            onClick = { onSendCode() },
                         ) {
                             Text(
                                 text = stringResource(R.string.verify_email_ok_button),
@@ -188,7 +178,7 @@ private fun EmailVerificationScreen(
                         }
                     }
 
-                    VerifyEmailState.SendCode -> {
+                    EmailVerificationUiState.FlowState.SendCode -> {
                         Text(
                             text = stringResource(R.string.find_password_verification_code_content).format(userEmail),
                             style = SNUTTTypography.h3,
@@ -200,7 +190,7 @@ private fun EmailVerificationScreen(
                         )
                         EditText(
                             value = codeField,
-                            onValueChange = { codeField = it },
+                            onValueChange = onCodeFieldChange,
                             hint = stringResource(R.string.find_password_send_code_hint),
                             keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
                             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Number),
@@ -217,7 +207,7 @@ private fun EmailVerificationScreen(
                                                 color = if (timerState.isRunning) SNUTTColors.Red else SNUTTColors.SNUTTTheme,
                                             ),
                                             modifier = Modifier.clicks {
-                                                if (timerState.isEnded) onSendCode(userEmail)
+                                                if (timerState.isEnded) onSendCode()
                                             },
                                         )
                                     }
@@ -257,8 +247,10 @@ private fun EmailVerificationScreen_AskContinue() {
     SnuttPreviewSurface {
         EmailVerificationScreen(
             userEmail = "user@snu.ac.kr",
-            flowState = VerifyEmailState.AskContinue,
+            flowState = EmailVerificationUiState.FlowState.AskContinue,
+            codeField = "",
             timerState = rememberTimerState(initialValue = TimerValue.Initial, durationInSecond = 180),
+            onCodeFieldChange = {},
             onSendCode = {},
             onVerifyCode = {},
             onNavigateHome = {},
@@ -273,8 +265,10 @@ private fun EmailVerificationScreen_SendCode() {
     SnuttPreviewSurface {
         EmailVerificationScreen(
             userEmail = "user@snu.ac.kr",
-            flowState = VerifyEmailState.SendCode,
+            flowState = EmailVerificationUiState.FlowState.SendCode,
+            codeField = "",
             timerState = rememberTimerState(initialValue = TimerValue.Initial, durationInSecond = 180),
+            onCodeFieldChange = {},
             onSendCode = {},
             onVerifyCode = {},
             onNavigateHome = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/EmailVerificationViewModel.kt
@@ -9,7 +9,11 @@ import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,22 +23,35 @@ class EmailVerificationViewModel @Inject constructor(
     private val displayMessageResolver: DisplayMessageResolver,
 ) : ViewModel() {
 
+    private val _uiState = MutableStateFlow(EmailVerificationUiState())
+    val uiState: StateFlow<EmailVerificationUiState> = _uiState.asStateFlow()
+
     private val _uiEvent = MutableSharedFlow<EmailVerificationUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
     val userEmail: String = userRepository.user.value?.email ?: ""
 
-    fun sendCodeToEmail(email: String) {
+    fun onCodeFieldChange(value: String) {
+        _uiState.update { it.copy(codeField = value) }
+    }
+
+    fun backToAskContinue() {
+        _uiState.update { it.copy(flowState = EmailVerificationUiState.FlowState.AskContinue, codeField = "") }
+    }
+
+    fun sendCodeToEmail() {
         viewModelScope.launch {
-            userRepository.sendCodeToEmail(email)
+            userRepository.sendCodeToEmail(userEmail)
                 .onSuccess {
-                    _uiEvent.emit(EmailVerificationUiEvent.CodeSent)
+                    _uiState.update { it.copy(flowState = EmailVerificationUiState.FlowState.SendCode) }
+                    _uiEvent.emit(EmailVerificationUiEvent.RestartTimer)
                 }
                 .onFailure { handleError(it) }
         }
     }
 
-    fun verifyEmailCode(code: String) {
+    fun verifyEmailCode() {
+        val code = _uiState.value.codeField
         viewModelScope.launch {
             userRepository.verifyEmailCode(code)
                 .onSuccess {
@@ -49,8 +66,15 @@ class EmailVerificationViewModel @Inject constructor(
     }
 }
 
+data class EmailVerificationUiState(
+    val flowState: FlowState = FlowState.AskContinue,
+    val codeField: String = "",
+) {
+    enum class FlowState { AskContinue, SendCode }
+}
+
 sealed interface EmailVerificationUiEvent {
     data class ShowToast(val message: String) : EmailVerificationUiEvent
-    data object CodeSent : EmailVerificationUiEvent
+    data object RestartTimer : EmailVerificationUiEvent
     data object VerificationSuccess : EmailVerificationUiEvent
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/FindIdPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/FindIdPage.kt
@@ -12,11 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalContext
@@ -25,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.isEmailInvalid
 import com.wafflestudio.snutt2.ui.components.compose.EditText
@@ -43,6 +40,7 @@ fun FindIdPage(
     onNavigateBack: () -> Unit,
 ) {
     val context = LocalContext.current
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val successMessageTemplate = stringResource(R.string.find_id_send_email_success_message)
 
     LaunchedEffect(Unit) {
@@ -58,14 +56,18 @@ fun FindIdPage(
     }
 
     FindIdScreen(
-        onSubmit = { email -> viewModel.findIdByEmail(email) },
+        emailField = uiState.emailField,
+        onEmailFieldChange = viewModel::onEmailFieldChange,
+        onSubmit = viewModel::findIdByEmail,
         onNavigateBack = onNavigateBack,
     )
 }
 
 @Composable
 private fun FindIdScreen(
-    onSubmit: (String) -> Unit,
+    emailField: String,
+    onEmailFieldChange: (String) -> Unit,
+    onSubmit: () -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -73,9 +75,7 @@ private fun FindIdScreen(
     val enterEmailMessage = stringResource(R.string.settings_user_config_enter_email)
     val wrongEmailFormatMessage = stringResource(R.string.find_id_wrong_email_format)
 
-    // TODO: 뷰모델로 상태 옮기기
-    var emailField by remember { mutableStateOf("") }
-    val buttonEnabled by remember { derivedStateOf { emailField.isNotEmpty() } }
+    val buttonEnabled = emailField.isNotEmpty()
 
     val handleSendIdToEmail = {
         if (emailField.isEmpty()) {
@@ -83,7 +83,7 @@ private fun FindIdScreen(
         } else if (emailField.isEmailInvalid()) {
             context.toast(wrongEmailFormatMessage)
         } else {
-            onSubmit(emailField)
+            onSubmit()
         }
     }
 
@@ -110,7 +110,7 @@ private fun FindIdScreen(
             )
             EditText(
                 value = emailField,
-                onValueChange = { emailField = it },
+                onValueChange = onEmailFieldChange,
                 hint = stringResource(R.string.settings_user_config_enter_email),
                 keyboardActions = KeyboardActions(
                     onNext = { focusManager.moveFocus(FocusDirection.Down) },
@@ -141,6 +141,8 @@ private fun FindIdScreen(
 private fun FindIdScreen_Default() {
     SnuttPreviewSurface {
         FindIdScreen(
+            emailField = "",
+            onEmailFieldChange = {},
             onSubmit = {},
             onNavigateBack = {},
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/FindIdViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/FindIdViewModel.kt
@@ -9,7 +9,11 @@ import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,10 +23,18 @@ class FindIdViewModel @Inject constructor(
     private val displayMessageResolver: DisplayMessageResolver,
 ) : ViewModel() {
 
+    private val _uiState = MutableStateFlow(FindIdUiState())
+    val uiState: StateFlow<FindIdUiState> = _uiState.asStateFlow()
+
     private val _uiEvent = MutableSharedFlow<FindIdUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
-    fun findIdByEmail(email: String) {
+    fun onEmailFieldChange(value: String) {
+        _uiState.update { it.copy(emailField = value) }
+    }
+
+    fun findIdByEmail() {
+        val email = _uiState.value.emailField
         viewModelScope.launch {
             userRepository.findIdByEmail(email)
                 .onSuccess {
@@ -36,6 +48,10 @@ class FindIdViewModel @Inject constructor(
         _uiEvent.emit(FindIdUiEvent.ShowToast(displayMessageResolver.getDisplayMessage(error)))
     }
 }
+
+data class FindIdUiState(
+    val emailField: String = "",
+)
 
 sealed interface FindIdUiEvent {
     data class ShowToast(val message: String) : FindIdUiEvent

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignInPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignInPage.kt
@@ -16,11 +16,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -69,7 +65,11 @@ fun SignInPage(
     }
 
     SignInScreen(
+        idField = uiState.idField,
+        passwordField = uiState.passwordField,
         isLoading = uiState.isLoading,
+        onIdFieldChange = viewModel::onIdFieldChange,
+        onPasswordFieldChange = viewModel::onPasswordFieldChange,
         onSignIn = viewModel::signIn,
         onNavigateBack = onNavigateBack,
         onNavigateFindId = onNavigateFindId,
@@ -79,18 +79,18 @@ fun SignInPage(
 
 @Composable
 private fun SignInScreen(
+    idField: String,
+    passwordField: String,
     isLoading: Boolean,
-    onSignIn: (id: String, password: String) -> Unit,
+    onIdFieldChange: (String) -> Unit,
+    onPasswordFieldChange: (String) -> Unit,
+    onSignIn: () -> Unit,
     onNavigateBack: () -> Unit,
     onNavigateFindId: () -> Unit,
     onNavigateFindPassword: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
-
-    // TODO: 상태 뷰모델로 올리기
-    var idField by remember { mutableStateOf("") }
-    var passwordField by remember { mutableStateOf("") }
-    val buttonEnabled by remember { derivedStateOf { idField.isNotEmpty() && passwordField.isNotEmpty() } }
+    val buttonEnabled = idField.isNotEmpty() && passwordField.isNotEmpty()
 
     Box {
         Column(
@@ -120,7 +120,7 @@ private fun SignInScreen(
                         )
                         EditText(
                             value = idField,
-                            onValueChange = { idField = it },
+                            onValueChange = onIdFieldChange,
                             hint = stringResource(R.string.sign_in_id_hint),
                             textStyle = SNUTTTypography.subtitle2.copy(color = SNUTTColors.Black900),
                             keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
@@ -136,11 +136,11 @@ private fun SignInScreen(
                         )
                         EditText(
                             value = passwordField,
-                            onValueChange = { passwordField = it },
+                            onValueChange = onPasswordFieldChange,
                             hint = stringResource(R.string.sign_in_password_hint),
                             textStyle = SNUTTTypography.subtitle2.copy(color = SNUTTColors.Black900),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                            keyboardActions = KeyboardActions(onDone = { onSignIn(idField, passwordField) }),
+                            keyboardActions = KeyboardActions(onDone = { onSignIn() }),
                             visualTransformation = PasswordVisualTransformation(),
                             singleLine = true,
                         )
@@ -173,7 +173,7 @@ private fun SignInScreen(
                         .height(45.dp)
                         .fillMaxWidth(),
                     enabled = buttonEnabled,
-                    onClick = { onSignIn(idField, passwordField) },
+                    onClick = { onSignIn() },
                 ) {
                     Text(
                         text = stringResource(R.string.sign_in_sign_in_button),
@@ -203,8 +203,12 @@ private fun SignInScreen(
 private fun SignInScreen_Default() {
     SnuttPreviewSurface {
         SignInScreen(
+            idField = "",
+            passwordField = "",
             isLoading = false,
-            onSignIn = { _, _ -> },
+            onIdFieldChange = {},
+            onPasswordFieldChange = {},
+            onSignIn = {},
             onNavigateBack = {},
             onNavigateFindId = {},
             onNavigateFindPassword = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignInViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignInViewModel.kt
@@ -35,11 +35,20 @@ class SignInViewModel @Inject constructor(
     private val _uiEvent = MutableSharedFlow<SignInUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
-    fun signIn(id: String, password: String) {
+    fun onIdFieldChange(value: String) {
+        _uiState.update { it.copy(idField = value) }
+    }
+
+    fun onPasswordFieldChange(value: String) {
+        _uiState.update { it.copy(passwordField = value) }
+    }
+
+    fun signIn() {
+        val state = _uiState.value
         viewModelScope.launch {
             analyticsLogger.logEvent(AnalyticsEvent.Login(LoginParameter(LoginParameter.Provider.LOCAL)))
             _uiState.update { it.copy(isLoading = true) }
-            userRepository.postSignIn(id, password)
+            userRepository.postSignIn(state.idField, state.passwordField)
                 .onSuccess {
                     refreshInitialDataUseCase()
                     _uiEvent.emit(SignInUiEvent.NavigateHome)
@@ -55,6 +64,8 @@ class SignInViewModel @Inject constructor(
 }
 
 data class SignInUiState(
+    val idField: String = "",
+    val passwordField: String = "",
     val isLoading: Boolean = false,
 )
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignUpPage.kt
@@ -19,11 +19,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -73,7 +69,15 @@ fun SignUpPage(
     }
 
     SignUpScreen(
+        idField = uiState.idField,
+        passwordField = uiState.passwordField,
+        passwordConfirmField = uiState.passwordConfirmField,
+        emailField = uiState.emailField,
         isLoading = uiState.isLoading,
+        onIdFieldChange = viewModel::onIdFieldChange,
+        onPasswordFieldChange = viewModel::onPasswordFieldChange,
+        onPasswordConfirmFieldChange = viewModel::onPasswordConfirmFieldChange,
+        onEmailFieldChange = viewModel::onEmailFieldChange,
         onSignUp = viewModel::signUp,
         onNavigateBack = onNavigateBack,
     )
@@ -81,8 +85,16 @@ fun SignUpPage(
 
 @Composable
 private fun SignUpScreen(
+    idField: String,
+    passwordField: String,
+    passwordConfirmField: String,
+    emailField: String,
     isLoading: Boolean,
-    onSignUp: (id: String, email: String, password: String) -> Unit,
+    onIdFieldChange: (String) -> Unit,
+    onPasswordFieldChange: (String) -> Unit,
+    onPasswordConfirmFieldChange: (String) -> Unit,
+    onEmailFieldChange: (String) -> Unit,
+    onSignUp: (formattedEmail: String) -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -94,16 +106,10 @@ private fun SignUpScreen(
     val apiServer = stringResource(R.string.api_server)
     val termsPath = stringResource(R.string.terms)
 
-    // TODO: 상태 뷰모델로 올리기
-    var idField by remember { mutableStateOf("") }
-    var passwordField by remember { mutableStateOf("") }
-    var passwordConfirmField by remember { mutableStateOf("") }
-    var emailField by remember { mutableStateOf("") }
-    val buttonEnabled by remember {
-        derivedStateOf {
-            idField.isNotEmpty() && passwordField.isNotEmpty() && passwordConfirmField.isNotEmpty() && emailField.isNotEmpty()
-        }
-    }
+    val buttonEnabled = idField.isNotEmpty() &&
+        passwordField.isNotEmpty() &&
+        passwordConfirmField.isNotEmpty() &&
+        emailField.isNotEmpty()
 
     val handleLocalSignUp = {
         val isPasswordConfirmPassed = (passwordConfirmField == passwordField)
@@ -114,7 +120,7 @@ private fun SignUpScreen(
         } else if (isPasswordConfirmPassed.not()) {
             context.toast(passwordConfirmInvalidMessage)
         } else {
-            onSignUp(idField, emailField.plus(emailForm), passwordField)
+            onSignUp(emailField.plus(emailForm))
         }
     }
 
@@ -145,7 +151,7 @@ private fun SignUpScreen(
                         )
                         EditText(
                             value = idField,
-                            onValueChange = { idField = it },
+                            onValueChange = onIdFieldChange,
                             hint = stringResource(R.string.sign_up_id_hint),
                             textStyle = SNUTTTypography.subtitle2.copy(color = SNUTTColors.Black900),
                             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
@@ -161,7 +167,7 @@ private fun SignUpScreen(
                         )
                         EditText(
                             value = passwordField,
-                            onValueChange = { passwordField = it },
+                            onValueChange = onPasswordFieldChange,
                             hint = stringResource(R.string.sign_up_password_hint),
                             textStyle = SNUTTTypography.subtitle2.copy(color = SNUTTColors.Black900),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
@@ -178,7 +184,7 @@ private fun SignUpScreen(
                         )
                         EditText(
                             value = passwordConfirmField,
-                            onValueChange = { passwordConfirmField = it },
+                            onValueChange = onPasswordConfirmFieldChange,
                             hint = stringResource(R.string.sign_up_password_confirm_hint),
                             textStyle = SNUTTTypography.subtitle2.copy(color = SNUTTColors.Black900),
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
@@ -195,7 +201,7 @@ private fun SignUpScreen(
                         )
                         EditText(
                             value = emailField,
-                            onValueChange = { emailField = it },
+                            onValueChange = onEmailFieldChange,
                             hint = stringResource(R.string.sign_up_email_input_hint),
                             textStyle = SNUTTTypography.subtitle2.copy(color = SNUTTColors.Black900),
                             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
@@ -268,8 +274,16 @@ private fun SignUpScreen(
 private fun SignUpScreen_Default() {
     SnuttPreviewSurface {
         SignUpScreen(
+            idField = "",
+            passwordField = "",
+            passwordConfirmField = "",
+            emailField = "",
             isLoading = false,
-            onSignUp = { _, _, _ -> },
+            onIdFieldChange = {},
+            onPasswordFieldChange = {},
+            onPasswordConfirmFieldChange = {},
+            onEmailFieldChange = {},
+            onSignUp = {},
             onNavigateBack = {},
         )
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignUpViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignUpViewModel.kt
@@ -34,11 +34,28 @@ class SignUpViewModel @Inject constructor(
     private val _uiEvent = MutableSharedFlow<SignUpUiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
-    fun signUp(id: String, email: String, password: String) {
+    fun onIdFieldChange(value: String) {
+        _uiState.update { it.copy(idField = value) }
+    }
+
+    fun onPasswordFieldChange(value: String) {
+        _uiState.update { it.copy(passwordField = value) }
+    }
+
+    fun onPasswordConfirmFieldChange(value: String) {
+        _uiState.update { it.copy(passwordConfirmField = value) }
+    }
+
+    fun onEmailFieldChange(value: String) {
+        _uiState.update { it.copy(emailField = value) }
+    }
+
+    fun signUp(formattedEmail: String) {
+        val state = _uiState.value
         viewModelScope.launch {
             analyticsLogger.logEvent(AnalyticsEvent.SignUp)
             _uiState.update { it.copy(isLoading = true) }
-            userRepository.postSignUp(id, password, email)
+            userRepository.postSignUp(state.idField, state.passwordField, formattedEmail)
                 .onSuccess {
                     refreshInitialDataUseCase()
                     _uiEvent.emit(SignUpUiEvent.NavigateEmailVerification)
@@ -54,6 +71,10 @@ class SignUpViewModel @Inject constructor(
 }
 
 data class SignUpUiState(
+    val idField: String = "",
+    val passwordField: String = "",
+    val passwordConfirmField: String = "",
+    val emailField: String = "",
     val isLoading: Boolean = false,
 )
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/CheckIdStep.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/CheckIdStep.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,7 +38,8 @@ import com.wafflestudio.snutt2.ui.util.toast
 @Composable
 fun CheckIdStep(
     uiState: FindPasswordViewModel.UIState.CheckId,
-    onSubmit: (String) -> Unit,
+    onIdFieldChange: (String) -> Unit,
+    onSubmit: () -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
     val context = LocalContext.current
@@ -53,17 +53,13 @@ fun CheckIdStep(
             ),
         )
     }
-    val buttonEnabled by remember {
-        derivedStateOf {
-            idField.text.isNotEmpty()
-        }
-    }
+    val buttonEnabled = idField.text.isNotEmpty()
 
     val sendIdAndRequestMaskedEmail = {
         if (idField.text.isEmpty()) {
             context.toast(enterIdHintMessage)
         } else {
-            onSubmit(idField.text)
+            onSubmit()
         }
     }
 
@@ -98,11 +94,14 @@ fun CheckIdStep(
                     idField = idField.copy(selection = TextRange(idField.text.length))
                 },
             value = idField,
-            onValueChange = { idField = it },
+            onValueChange = {
+                idField = it
+                onIdFieldChange(it.text)
+            },
             hint = stringResource(R.string.find_password_enter_id_hint),
             keyboardActions = KeyboardActions(
                 onDone = {
-                    onSubmit(idField.text)
+                    onSubmit()
                 },
             ),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
@@ -131,6 +130,7 @@ private fun CheckIdStep_Empty() {
     SnuttPreviewSurface {
         CheckIdStep(
             uiState = FindPasswordViewModel.UIState.CheckId(userId = ""),
+            onIdFieldChange = {},
             onSubmit = {},
         )
     }
@@ -142,6 +142,7 @@ private fun CheckIdStep_Filled() {
     SnuttPreviewSurface {
         CheckIdStep(
             uiState = FindPasswordViewModel.UIState.CheckId(userId = "snutt_user"),
+            onIdFieldChange = {},
             onSubmit = {},
         )
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/EnterFullEmailStep.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/EnterFullEmailStep.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,8 +41,9 @@ import com.wafflestudio.snutt2.ui.util.toast
 @Composable
 fun EnterFullEmailStep(
     uiState: FindPasswordViewModel.UIState.EnterFullEmail,
+    onEmailFieldChange: (String) -> Unit,
     notMyEmail: () -> Unit,
-    onSubmitFullEmail: (String) -> Unit,
+    onSubmitFullEmail: () -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
     val context = LocalContext.current
@@ -57,18 +57,14 @@ fun EnterFullEmailStep(
             ),
         )
     }
-    val buttonEnabled by remember {
-        derivedStateOf {
-            !emailField.text.isEmailInvalid()
-        }
-    }
+    val buttonEnabled = !emailField.text.isEmailInvalid()
 
     val sendIdAndRequestMaskedEmail: () -> Unit = {
         if (buttonEnabled) {
             if (emailField.text.isEmpty()) {
                 context.toast(enterIdHintMessage)
             } else {
-                onSubmitFullEmail(emailField.text)
+                onSubmitFullEmail()
             }
         }
     }
@@ -118,7 +114,10 @@ fun EnterFullEmailStep(
                 .fillMaxWidth()
                 .focusRequester(focusRequester),
             value = emailField,
-            onValueChange = { emailField = it },
+            onValueChange = {
+                emailField = it
+                onEmailFieldChange(it.text)
+            },
             hint = stringResource(R.string.find_password_check_email_enter_full_email_hint),
             keyboardActions = KeyboardActions(
                 onDone = {
@@ -174,6 +173,7 @@ private fun EnterFullEmailStep_Default() {
                 maskedEmail = "sn****@snu.ac.kr",
                 fullEmail = "",
             ),
+            onEmailFieldChange = {},
             notMyEmail = {},
             onSubmitFullEmail = {},
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/FindPasswordViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/FindPasswordViewModel.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.snutt2.data.onSuccess
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
+import com.wafflestudio.snutt2.lib.isPasswordInvalid
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,11 +44,90 @@ class FindPasswordViewModel @Inject constructor(
 
         data class VerifyCode(
             val fullEmail: String,
-        ) : UIState()
+            val codeField: String = "",
+            val dialogState: VerifyCodeDialogState = VerifyCodeDialogState.None,
+        ) : UIState() {
+            sealed interface VerifyCodeDialogState {
+                data object None : VerifyCodeDialogState
+                data object WhyNotCodeComing : VerifyCodeDialogState
+            }
+        }
 
         data class EnterNewPassword(
-            val showCompleteDialog: Boolean = false,
-        ) : UIState()
+            val newPasswordField: String = "",
+            val newPasswordConfirmField: String = "",
+            val dialogState: NewPasswordDialogState = NewPasswordDialogState.None,
+        ) : UIState() {
+            sealed interface NewPasswordDialogState {
+                data object None : NewPasswordDialogState
+                data class Error(val type: ErrorType) : NewPasswordDialogState
+                data object Complete : NewPasswordDialogState
+            }
+
+            enum class ErrorType { Expired, ConfirmFail, InvalidPassword }
+        }
+    }
+
+    fun onIdFieldChange(value: String) {
+        _uiState.update {
+            if (it is UIState.CheckId) it.copy(userId = value) else it
+        }
+    }
+
+    fun onEmailFieldChange(value: String) {
+        _uiState.update {
+            if (it is UIState.EnterFullEmail) it.copy(fullEmail = value) else it
+        }
+    }
+
+    fun onCodeFieldChange(value: String) {
+        _uiState.update {
+            if (it is UIState.VerifyCode) it.copy(codeField = value) else it
+        }
+    }
+
+    fun onNewPasswordFieldChange(value: String) {
+        _uiState.update {
+            if (it is UIState.EnterNewPassword) it.copy(newPasswordField = value) else it
+        }
+    }
+
+    fun onNewPasswordConfirmFieldChange(value: String) {
+        _uiState.update {
+            if (it is UIState.EnterNewPassword) it.copy(newPasswordConfirmField = value) else it
+        }
+    }
+
+    fun showWhyNotCodeComingDialog() {
+        _uiState.update {
+            if (it is UIState.VerifyCode) it.copy(dialogState = UIState.VerifyCode.VerifyCodeDialogState.WhyNotCodeComing) else it
+        }
+    }
+
+    fun dismissVerifyCodeDialog() {
+        _uiState.update {
+            if (it is UIState.VerifyCode) it.copy(dialogState = UIState.VerifyCode.VerifyCodeDialogState.None) else it
+        }
+    }
+
+    fun onTimerExpired() {
+        _uiState.update {
+            if (it is UIState.EnterNewPassword) {
+                it.copy(dialogState = UIState.EnterNewPassword.NewPasswordDialogState.Error(UIState.EnterNewPassword.ErrorType.Expired))
+            } else {
+                it
+            }
+        }
+    }
+
+    fun dismissNewPasswordDialog() {
+        _uiState.update {
+            if (it is UIState.EnterNewPassword) {
+                it.copy(dialogState = UIState.EnterNewPassword.NewPasswordDialogState.None)
+            } else {
+                it
+            }
+        }
     }
 
     fun goToPreviousStep() {
@@ -72,7 +152,9 @@ class FindPasswordViewModel @Inject constructor(
         }
     }
 
-    fun checkEmailById(userId: String) {
+    fun checkEmailById() {
+        val state = _uiState.value as? UIState.CheckId ?: return
+        val userId = state.userId
         viewModelScope.launch {
             savedStateHandle["userId"] = userId
             userRepository.checkEmailById(userId)
@@ -85,7 +167,9 @@ class FindPasswordViewModel @Inject constructor(
         }
     }
 
-    fun sendFullEmailAndRequestCode(fullEmail: String) {
+    fun sendFullEmailAndRequestCode() {
+        val state = _uiState.value as? UIState.EnterFullEmail ?: return
+        val fullEmail = state.fullEmail
         viewModelScope.launch {
             savedStateHandle["fullEmail"] = fullEmail
             userRepository.sendPwResetCodeToEmail(fullEmail)
@@ -96,7 +180,17 @@ class FindPasswordViewModel @Inject constructor(
         }
     }
 
-    fun verifyCode(code: String) {
+    fun resendVerifyCode() {
+        val state = _uiState.value as? UIState.VerifyCode ?: return
+        viewModelScope.launch {
+            userRepository.sendPwResetCodeToEmail(state.fullEmail)
+                .onFailure { handleError(it) }
+        }
+    }
+
+    fun verifyCode() {
+        val state = _uiState.value as? UIState.VerifyCode ?: return
+        val code = state.codeField
         viewModelScope.launch {
             val savedUserId = savedStateHandle["userId"] ?: ""
             userRepository.verifyPwResetCode(savedUserId, code)
@@ -108,13 +202,40 @@ class FindPasswordViewModel @Inject constructor(
         }
     }
 
-    fun resetPassword(password: String) {
+    fun validateAndResetPassword(timerRunning: Boolean) {
+        val state = _uiState.value as? UIState.EnterNewPassword ?: return
+        if (!timerRunning) return
+        val password = state.newPasswordField
+        if (password != state.newPasswordConfirmField) {
+            _uiState.update {
+                (it as UIState.EnterNewPassword).copy(
+                    dialogState = UIState.EnterNewPassword.NewPasswordDialogState.Error(UIState.EnterNewPassword.ErrorType.ConfirmFail),
+                )
+            }
+        } else if (password.isPasswordInvalid()) {
+            _uiState.update {
+                (it as UIState.EnterNewPassword).copy(
+                    dialogState = UIState.EnterNewPassword.NewPasswordDialogState.Error(UIState.EnterNewPassword.ErrorType.InvalidPassword),
+                )
+            }
+        } else {
+            resetPassword(password)
+        }
+    }
+
+    private fun resetPassword(password: String) {
         viewModelScope.launch {
             val savedUserId = savedStateHandle["userId"] ?: ""
             val savedCode = savedStateHandle["code"] ?: ""
             userRepository.resetPassword(savedUserId, password, savedCode)
                 .onSuccess {
-                    _uiState.update { UIState.EnterNewPassword(showCompleteDialog = true) }
+                    _uiState.update {
+                        if (it is UIState.EnterNewPassword) {
+                            it.copy(dialogState = UIState.EnterNewPassword.NewPasswordDialogState.Complete)
+                        } else {
+                            it
+                        }
+                    }
                 }
                 .onFailure { handleError(it) }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/NewPasswordStep.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/NewPasswordStep.kt
@@ -12,12 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -29,7 +24,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.lib.isPasswordInvalid
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.components.compose.EditText
 import com.wafflestudio.snutt2.ui.components.compose.Timer
@@ -43,31 +37,27 @@ import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 
 @Composable
 fun NewPasswordStep(
-    onSubmit: (String) -> Unit,
-    showCompleteDialog: State<Boolean>,
+    uiState: FindPasswordViewModel.UIState.EnterNewPassword,
+    onNewPasswordFieldChange: (String) -> Unit,
+    onNewPasswordConfirmFieldChange: (String) -> Unit,
+    onSubmit: (timerRunning: Boolean) -> Unit,
+    onTimerExpired: () -> Unit,
+    onDismissDialog: () -> Unit,
     onComplete: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
-    val expiredAlert = stringResource(R.string.find_password_enter_password_confirm_expired_alert)
-    val confirmFailAlert = stringResource(R.string.find_password_enter_password_confirm_fail_alert)
-    val invalidPasswordAlert = stringResource(R.string.error_invalid_password)
 
-    var newPasswordField by remember { mutableStateOf("") }
-    var newPasswordConfirmField by remember { mutableStateOf("") }
-
-    var showErrorDialog by remember { mutableStateOf(false) }
-    var errorDialogTitle by remember { mutableStateOf("") }
+    val newPasswordField = uiState.newPasswordField
+    val newPasswordConfirmField = uiState.newPasswordConfirmField
+    val dialogState = uiState.dialogState
+    val isCompleteDialogShown = dialogState is FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.Complete
 
     val timerState = rememberTimerState(
         initialValue = TimerValue.Initial,
         durationInSecond = 180,
     )
-    val buttonEnabled by remember {
-        derivedStateOf {
-            timerState.isRunning && newPasswordField.isNotBlank() && newPasswordConfirmField.isNotBlank()
-        }
-    }
+    val buttonEnabled = timerState.isRunning && newPasswordField.isNotBlank() && newPasswordConfirmField.isNotBlank()
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -75,27 +65,12 @@ fun NewPasswordStep(
     }
     LaunchedEffect(timerState.currentValue) {
         if (timerState.isEnded) {
-            errorDialogTitle = expiredAlert
-            showErrorDialog = true
+            onTimerExpired()
         }
     }
-    LaunchedEffect(showCompleteDialog.value) {
-        if (showCompleteDialog.value) {
+    LaunchedEffect(isCompleteDialogShown) {
+        if (isCompleteDialogShown) {
             timerState.pause()
-        }
-    }
-
-    val validateNewPasswordAndSubmit = {
-        if (timerState.isRunning) {
-            if (newPasswordField != newPasswordConfirmField) {
-                errorDialogTitle = confirmFailAlert
-                showErrorDialog = true
-            } else if (newPasswordField.isPasswordInvalid()) {
-                errorDialogTitle = invalidPasswordAlert
-                showErrorDialog = true
-            } else {
-                onSubmit(newPasswordField)
-            }
         }
     }
 
@@ -116,7 +91,7 @@ fun NewPasswordStep(
                 .fillMaxWidth()
                 .focusRequester(focusRequester),
             value = newPasswordField,
-            onValueChange = { newPasswordField = it },
+            onValueChange = onNewPasswordFieldChange,
             hint = stringResource(R.string.find_password_enter_password_hint),
             visualTransformation = PasswordVisualTransformation(),
             keyboardActions = KeyboardActions(
@@ -159,12 +134,12 @@ fun NewPasswordStep(
         EditText(
             modifier = Modifier.fillMaxWidth(),
             value = newPasswordConfirmField,
-            onValueChange = { newPasswordConfirmField = it },
+            onValueChange = onNewPasswordConfirmFieldChange,
             hint = stringResource(R.string.find_password_enter_password_confirm_hint),
             visualTransformation = PasswordVisualTransformation(),
             keyboardActions = KeyboardActions(
                 onDone = {
-                    validateNewPasswordAndSubmit()
+                    onSubmit(timerState.isRunning)
                 },
             ),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
@@ -179,7 +154,7 @@ fun NewPasswordStep(
             modifier = Modifier.fillMaxWidth(),
             enabled = buttonEnabled,
             onClick = {
-                validateNewPasswordAndSubmit()
+                onSubmit(timerState.isRunning)
             },
         ) {
             Text(
@@ -189,11 +164,19 @@ fun NewPasswordStep(
         }
     }
 
-    if (showErrorDialog) {
+    if (dialogState is FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.Error) {
+        val errorTitle = when (dialogState.type) {
+            FindPasswordViewModel.UIState.EnterNewPassword.ErrorType.Expired ->
+                stringResource(R.string.find_password_enter_password_confirm_expired_alert)
+            FindPasswordViewModel.UIState.EnterNewPassword.ErrorType.ConfirmFail ->
+                stringResource(R.string.find_password_enter_password_confirm_fail_alert)
+            FindPasswordViewModel.UIState.EnterNewPassword.ErrorType.InvalidPassword ->
+                stringResource(R.string.error_invalid_password)
+        }
         CustomDialog(
-            title = errorDialogTitle,
+            title = errorTitle,
             onConfirm = {
-                showErrorDialog = false
+                onDismissDialog()
                 focusRequester.requestFocus()
             },
             onDismiss = {},
@@ -203,7 +186,7 @@ fun NewPasswordStep(
         }
     }
 
-    if (showCompleteDialog.value) {
+    if (isCompleteDialogShown) {
         CustomDialog(
             title = stringResource(R.string.find_password_enter_password_success_alert),
             onConfirm = onComplete,
@@ -220,8 +203,12 @@ fun NewPasswordStep(
 private fun NewPasswordStep_Default() {
     SnuttPreviewSurface {
         NewPasswordStep(
+            uiState = FindPasswordViewModel.UIState.EnterNewPassword(),
+            onNewPasswordFieldChange = {},
+            onNewPasswordConfirmFieldChange = {},
             onSubmit = {},
-            showCompleteDialog = remember { mutableStateOf(false) },
+            onTimerExpired = {},
+            onDismissDialog = {},
             onComplete = {},
         )
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/ResetPasswordPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/ResetPasswordPage.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -52,11 +50,21 @@ fun ResetPasswordPage(
 
     ResetPasswordScreen(
         uiState = uiState,
-        onCheckEmailById = { viewModel.checkEmailById(it) },
-        onSendFullEmail = { viewModel.sendFullEmailAndRequestCode(it) },
-        onVerifyCode = { viewModel.verifyCode(it) },
-        onResetPassword = { viewModel.resetPassword(it) },
-        onCompleteDialogConfirm = { viewModel.onCompleteDialogConfirm() },
+        onIdFieldChange = viewModel::onIdFieldChange,
+        onEmailFieldChange = viewModel::onEmailFieldChange,
+        onCodeFieldChange = viewModel::onCodeFieldChange,
+        onNewPasswordFieldChange = viewModel::onNewPasswordFieldChange,
+        onNewPasswordConfirmFieldChange = viewModel::onNewPasswordConfirmFieldChange,
+        onCheckEmailById = viewModel::checkEmailById,
+        onSendFullEmail = viewModel::sendFullEmailAndRequestCode,
+        onResendVerifyCode = viewModel::resendVerifyCode,
+        onVerifyCode = viewModel::verifyCode,
+        onShowWhyNotCodeComingDialog = viewModel::showWhyNotCodeComingDialog,
+        onDismissVerifyCodeDialog = viewModel::dismissVerifyCodeDialog,
+        onValidateAndResetPassword = viewModel::validateAndResetPassword,
+        onTimerExpired = viewModel::onTimerExpired,
+        onDismissNewPasswordDialog = viewModel::dismissNewPasswordDialog,
+        onCompleteDialogConfirm = viewModel::onCompleteDialogConfirm,
         onBack = onBack,
     )
 }
@@ -64,10 +72,20 @@ fun ResetPasswordPage(
 @Composable
 private fun ResetPasswordScreen(
     uiState: FindPasswordViewModel.UIState,
-    onCheckEmailById: (String) -> Unit,
-    onSendFullEmail: (String) -> Unit,
-    onVerifyCode: (String) -> Unit,
-    onResetPassword: (String) -> Unit,
+    onIdFieldChange: (String) -> Unit,
+    onEmailFieldChange: (String) -> Unit,
+    onCodeFieldChange: (String) -> Unit,
+    onNewPasswordFieldChange: (String) -> Unit,
+    onNewPasswordConfirmFieldChange: (String) -> Unit,
+    onCheckEmailById: () -> Unit,
+    onSendFullEmail: () -> Unit,
+    onResendVerifyCode: () -> Unit,
+    onVerifyCode: () -> Unit,
+    onShowWhyNotCodeComingDialog: () -> Unit,
+    onDismissVerifyCodeDialog: () -> Unit,
+    onValidateAndResetPassword: (timerRunning: Boolean) -> Unit,
+    onTimerExpired: () -> Unit,
+    onDismissNewPasswordDialog: () -> Unit,
     onCompleteDialogConfirm: () -> Unit,
     onBack: () -> Unit,
 ) {
@@ -93,31 +111,35 @@ private fun ResetPasswordScreen(
             when (state) {
                 is CheckId -> CheckIdStep(
                     uiState = state,
+                    onIdFieldChange = onIdFieldChange,
                     onSubmit = onCheckEmailById,
                 )
 
                 is EnterFullEmail -> EnterFullEmailStep(
                     uiState = state,
+                    onEmailFieldChange = onEmailFieldChange,
                     notMyEmail = onBack,
                     onSubmitFullEmail = onSendFullEmail,
                 )
 
                 is VerifyCode -> VerifyCodeStep(
                     uiState = state,
-                    onRequestResend = { onSendFullEmail(state.fullEmail) },
+                    onCodeFieldChange = onCodeFieldChange,
+                    onRequestResend = onResendVerifyCode,
                     onSubmit = onVerifyCode,
+                    onShowWhyNotCodeComingDialog = onShowWhyNotCodeComingDialog,
+                    onDismissDialog = onDismissVerifyCodeDialog,
                 )
 
-                is EnterNewPassword -> {
-                    val showCompleteDialog = remember(state) {
-                        derivedStateOf { state.showCompleteDialog }
-                    }
-                    NewPasswordStep(
-                        onSubmit = onResetPassword,
-                        showCompleteDialog = showCompleteDialog,
-                        onComplete = onCompleteDialogConfirm,
-                    )
-                }
+                is EnterNewPassword -> NewPasswordStep(
+                    uiState = state,
+                    onNewPasswordFieldChange = onNewPasswordFieldChange,
+                    onNewPasswordConfirmFieldChange = onNewPasswordConfirmFieldChange,
+                    onSubmit = onValidateAndResetPassword,
+                    onTimerExpired = onTimerExpired,
+                    onDismissDialog = onDismissNewPasswordDialog,
+                    onComplete = onCompleteDialogConfirm,
+                )
             }
         }
     }
@@ -129,10 +151,20 @@ private fun ResetPasswordScreen_CheckId() {
     SnuttPreviewSurface {
         ResetPasswordScreen(
             uiState = CheckId(userId = ""),
+            onIdFieldChange = {},
+            onEmailFieldChange = {},
+            onCodeFieldChange = {},
+            onNewPasswordFieldChange = {},
+            onNewPasswordConfirmFieldChange = {},
             onCheckEmailById = {},
             onSendFullEmail = {},
+            onResendVerifyCode = {},
             onVerifyCode = {},
-            onResetPassword = {},
+            onShowWhyNotCodeComingDialog = {},
+            onDismissVerifyCodeDialog = {},
+            onValidateAndResetPassword = {},
+            onTimerExpired = {},
+            onDismissNewPasswordDialog = {},
             onCompleteDialogConfirm = {},
             onBack = {},
         )
@@ -145,10 +177,20 @@ private fun ResetPasswordScreen_EnterFullEmail() {
     SnuttPreviewSurface {
         ResetPasswordScreen(
             uiState = EnterFullEmail(userId = "testuser", maskedEmail = "te****@snu.ac.kr", fullEmail = ""),
+            onIdFieldChange = {},
+            onEmailFieldChange = {},
+            onCodeFieldChange = {},
+            onNewPasswordFieldChange = {},
+            onNewPasswordConfirmFieldChange = {},
             onCheckEmailById = {},
             onSendFullEmail = {},
+            onResendVerifyCode = {},
             onVerifyCode = {},
-            onResetPassword = {},
+            onShowWhyNotCodeComingDialog = {},
+            onDismissVerifyCodeDialog = {},
+            onValidateAndResetPassword = {},
+            onTimerExpired = {},
+            onDismissNewPasswordDialog = {},
             onCompleteDialogConfirm = {},
             onBack = {},
         )
@@ -161,10 +203,20 @@ private fun ResetPasswordScreen_VerifyCode() {
     SnuttPreviewSurface {
         ResetPasswordScreen(
             uiState = VerifyCode(fullEmail = "testuser@snu.ac.kr"),
+            onIdFieldChange = {},
+            onEmailFieldChange = {},
+            onCodeFieldChange = {},
+            onNewPasswordFieldChange = {},
+            onNewPasswordConfirmFieldChange = {},
             onCheckEmailById = {},
             onSendFullEmail = {},
+            onResendVerifyCode = {},
             onVerifyCode = {},
-            onResetPassword = {},
+            onShowWhyNotCodeComingDialog = {},
+            onDismissVerifyCodeDialog = {},
+            onValidateAndResetPassword = {},
+            onTimerExpired = {},
+            onDismissNewPasswordDialog = {},
             onCompleteDialogConfirm = {},
             onBack = {},
         )
@@ -177,10 +229,20 @@ private fun ResetPasswordScreen_EnterNewPassword() {
     SnuttPreviewSurface {
         ResetPasswordScreen(
             uiState = EnterNewPassword(),
+            onIdFieldChange = {},
+            onEmailFieldChange = {},
+            onCodeFieldChange = {},
+            onNewPasswordFieldChange = {},
+            onNewPasswordConfirmFieldChange = {},
             onCheckEmailById = {},
             onSendFullEmail = {},
+            onResendVerifyCode = {},
             onVerifyCode = {},
-            onResetPassword = {},
+            onShowWhyNotCodeComingDialog = {},
+            onDismissVerifyCodeDialog = {},
+            onValidateAndResetPassword = {},
+            onTimerExpired = {},
+            onDismissNewPasswordDialog = {},
             onCompleteDialogConfirm = {},
             onBack = {},
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/ResetPasswordPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/ResetPasswordPage.kt
@@ -107,7 +107,11 @@ private fun ResetPasswordScreen(
             onBack()
         }
 
-        AnimatedContent(targetState = uiState, label = "") { state ->
+        AnimatedContent(
+            targetState = uiState,
+            contentKey = { it::class },
+            label = "",
+        ) { state ->
             when (state) {
                 is CheckId -> CheckIdStep(
                     uiState = state,

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/VerifyCodeStep.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/resetpassword/VerifyCodeStep.kt
@@ -13,11 +13,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -45,28 +41,27 @@ import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 @Composable
 fun VerifyCodeStep(
     uiState: FindPasswordViewModel.UIState.VerifyCode,
+    onCodeFieldChange: (String) -> Unit,
     onRequestResend: () -> Unit,
-    onSubmit: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onShowWhyNotCodeComingDialog: () -> Unit,
+    onDismissDialog: () -> Unit,
 ) {
     val keyboardManager = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
-    var codeField by remember { mutableStateOf("") }
-    var showWhyNotCodeComingDialog by remember { mutableStateOf(false) }
+    val codeField = uiState.codeField
+    val isWhyNotCodeComingDialogShown = uiState.dialogState is FindPasswordViewModel.UIState.VerifyCode.VerifyCodeDialogState.WhyNotCodeComing
     val timerState = rememberTimerState(
         initialValue = TimerValue.Initial,
         durationInSecond = 180,
     )
-    val buttonEnabled by remember {
-        derivedStateOf {
-            codeField.length == 8 && timerState.isRunning
-        }
-    }
+    val buttonEnabled = codeField.length == 8 && timerState.isRunning
 
     LaunchedEffect(Unit) {
         timerState.start()
     }
-    LaunchedEffect(showWhyNotCodeComingDialog) {
-        if (showWhyNotCodeComingDialog.not()) {
+    LaunchedEffect(isWhyNotCodeComingDialogShown) {
+        if (!isWhyNotCodeComingDialogShown) {
             focusRequester.requestFocus()
             keyboardManager?.show()
         }
@@ -96,12 +91,12 @@ fun VerifyCodeStep(
                 .fillMaxWidth()
                 .focusRequester(focusRequester),
             value = codeField,
-            onValueChange = { codeField = it },
+            onValueChange = onCodeFieldChange,
             hint = stringResource(R.string.find_password_send_code_hint),
             keyboardActions = KeyboardActions(
                 onDone = {
                     if (buttonEnabled) {
-                        onSubmit(codeField)
+                        onSubmit()
                     }
                 },
             ),
@@ -156,7 +151,7 @@ fun VerifyCodeStep(
             modifier = Modifier.fillMaxWidth(),
             enabled = buttonEnabled,
             onClick = {
-                onSubmit(codeField)
+                onSubmit()
             },
         ) {
             Text(
@@ -172,18 +167,16 @@ fun VerifyCodeStep(
                 text = stringResource(R.string.find_password_send_code_not_coming),
                 style = SNUTTTypography.body1.copy(color = SNUTTColors.VacancyGray),
                 modifier = Modifier.clicks {
-                    showWhyNotCodeComingDialog = true
+                    onShowWhyNotCodeComingDialog()
                 },
             )
         }
     }
 
-    if (showWhyNotCodeComingDialog) {
+    if (isWhyNotCodeComingDialogShown) {
         CustomDialog(
             title = stringResource(R.string.find_password_enter_verification_code_why_not_coming),
-            onConfirm = {
-                showWhyNotCodeComingDialog = false
-            },
+            onConfirm = onDismissDialog,
             onDismiss = {},
             positiveButtonText = stringResource(R.string.common_ok),
             negativeButtonText = null,
@@ -198,8 +191,11 @@ private fun VerifyCodeStep_Default() {
     SnuttPreviewSurface {
         VerifyCodeStep(
             uiState = FindPasswordViewModel.UIState.VerifyCode(fullEmail = "snutt_user@snu.ac.kr"),
+            onCodeFieldChange = {},
             onRequestResend = {},
             onSubmit = {},
+            onShowWhyNotCodeComingDialog = {},
+            onDismissDialog = {},
         )
     }
 }

--- a/app/src/test/java/com/wafflestudio/snutt2/feature/login/FindIdViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/feature/login/FindIdViewModelTest.kt
@@ -42,10 +42,11 @@ class FindIdViewModelTest {
     // region findIdByEmail
 
     @Test
-    fun `findIdByEmail 호출 시 입력된 이메일로 repository를 호출한다`() = runTest {
+    fun `findIdByEmail 호출 시 onEmailFieldChange로 입력된 이메일로 repository를 호출한다`() = runTest {
         fakeUserRepository.findIdByEmailResult = Result.Success(Unit)
 
-        viewModel.findIdByEmail("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.findIdByEmail()
 
         assertEquals("test@snu.ac.kr", fakeUserRepository.findIdByEmailCalledWith)
     }
@@ -54,8 +55,10 @@ class FindIdViewModelTest {
     fun `findIdByEmail 성공 시 Success 이벤트가 발생한다`() = runTest {
         fakeUserRepository.findIdByEmailResult = Result.Success(Unit)
 
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+
         viewModel.uiEvent.test {
-            viewModel.findIdByEmail("test@snu.ac.kr")
+            viewModel.findIdByEmail()
             assertEquals(FindIdUiEvent.Success("test@snu.ac.kr"), awaitItem())
         }
     }
@@ -65,8 +68,10 @@ class FindIdViewModelTest {
         val error = Unknown(displayTitle = "", displayMessage = "존재하지 않는 이메일입니다")
         fakeUserRepository.findIdByEmailResult = Result.Fail(error)
 
+        viewModel.onEmailFieldChange("wrong@snu.ac.kr")
+
         viewModel.uiEvent.test {
-            viewModel.findIdByEmail("wrong@snu.ac.kr")
+            viewModel.findIdByEmail()
             assertEquals(FindIdUiEvent.ShowToast("존재하지 않는 이메일입니다"), awaitItem())
         }
     }

--- a/app/src/test/java/com/wafflestudio/snutt2/feature/login/resetpassword/FindPasswordViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/feature/login/resetpassword/FindPasswordViewModelTest.kt
@@ -56,10 +56,11 @@ class FindPasswordViewModelTest {
     // region checkEmailById
 
     @Test
-    fun `checkEmailById 호출 시 repository의 checkEmailById를 호출한다`() = runTest {
+    fun `checkEmailById 호출 시 onIdFieldChange 로 입력한 값으로 repository를 호출한다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
 
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
 
         assertEquals("testuser", fakeUserRepository.checkEmailByIdCalledWith)
     }
@@ -68,7 +69,8 @@ class FindPasswordViewModelTest {
     fun `checkEmailById 성공 시 EnterFullEmail 상태로 전이한다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
 
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
 
         assertEquals(
             FindPasswordViewModel.UIState.EnterFullEmail(
@@ -85,19 +87,36 @@ class FindPasswordViewModelTest {
         fakeUserRepository.checkEmailByIdResult =
             Result.Fail(Unknown(displayTitle = "", displayMessage = "존재하지 않는 ID"))
 
+        viewModel.onIdFieldChange("wronguser")
+
         viewModel.uiEvent.test {
-            viewModel.checkEmailById("wronguser")
+            viewModel.checkEmailById()
             assertEquals(FindPasswordUiEvent.ShowToast("존재하지 않는 ID"), awaitItem())
         }
     }
 
     @Test
-    fun `checkEmailById 실패 시 상태는 변하지 않는다`() = runTest {
+    fun `checkEmailById 실패 시 step 은 변하지 않고 입력값은 보존된다`() = runTest {
         fakeUserRepository.checkEmailByIdResult =
             Result.Fail(Unknown(displayTitle = "", displayMessage = "에러"))
+
+        viewModel.onIdFieldChange("wronguser")
+        viewModel.checkEmailById()
+
+        assertEquals(
+            FindPasswordViewModel.UIState.CheckId(userId = "wronguser"),
+            viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `CheckId step 이 아니면 checkEmailById 는 무시된다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById() // EnterFullEmail 로 전이
         val before = viewModel.uiState.value
 
-        viewModel.checkEmailById("wronguser")
+        viewModel.checkEmailById()
 
         assertEquals(before, viewModel.uiState.value)
     }
@@ -107,19 +126,27 @@ class FindPasswordViewModelTest {
     // region sendFullEmailAndRequestCode
 
     @Test
-    fun `sendFullEmailAndRequestCode 호출 시 repository의 sendPwResetCodeToEmail을 호출한다`() = runTest {
+    fun `sendFullEmailAndRequestCode 호출 시 onEmailFieldChange 입력값으로 repository를 호출한다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
 
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
 
         assertEquals("test@snu.ac.kr", fakeUserRepository.sendPwResetCodeToEmailCalledWith)
     }
 
     @Test
     fun `sendFullEmailAndRequestCode 성공 시 VerifyCode 상태로 전이한다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
 
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
 
         assertEquals(
             FindPasswordViewModel.UIState.VerifyCode(fullEmail = "test@snu.ac.kr"),
@@ -129,13 +156,25 @@ class FindPasswordViewModelTest {
 
     @Test
     fun `sendFullEmailAndRequestCode 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult =
             Result.Fail(Unknown(displayTitle = "", displayMessage = "이메일 불일치"))
 
+        viewModel.onEmailFieldChange("wrong@snu.ac.kr")
+
         viewModel.uiEvent.test {
-            viewModel.sendFullEmailAndRequestCode("wrong@snu.ac.kr")
+            viewModel.sendFullEmailAndRequestCode()
             assertEquals(FindPasswordUiEvent.ShowToast("이메일 불일치"), awaitItem())
         }
+    }
+
+    @Test
+    fun `EnterFullEmail step 이 아니면 sendFullEmailAndRequestCode 는 무시된다`() = runTest {
+        viewModel.sendFullEmailAndRequestCode()
+
+        assertEquals(null, fakeUserRepository.sendPwResetCodeToEmailCalledWith)
     }
 
     // endregion
@@ -143,14 +182,17 @@ class FindPasswordViewModelTest {
     // region verifyCode
 
     @Test
-    fun `verifyCode 호출 시 savedStateHandle의 userId로 repository를 호출한다`() = runTest {
+    fun `verifyCode 호출 시 savedStateHandle의 userId 와 onCodeFieldChange 입력값으로 repository를 호출한다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser") // savedStateHandle에 userId 저장
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
         fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
 
-        viewModel.verifyCode("123456")
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
 
         assertEquals("testuser" to "123456", fakeUserRepository.verifyPwResetCodeCalledWith)
     }
@@ -158,80 +200,302 @@ class FindPasswordViewModelTest {
     @Test
     fun `verifyCode 성공 시 EnterNewPassword 상태로 전이한다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
         fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
 
-        viewModel.verifyCode("123456")
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
 
         assertEquals(
-            FindPasswordViewModel.UIState.EnterNewPassword(showCompleteDialog = false),
+            FindPasswordViewModel.UIState.EnterNewPassword(),
             viewModel.uiState.value,
         )
     }
 
     @Test
     fun `verifyCode 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
         fakeUserRepository.verifyPwResetCodeResult =
             Result.Fail(Unknown(displayTitle = "", displayMessage = "잘못된 코드"))
 
+        viewModel.onCodeFieldChange("000000")
+
         viewModel.uiEvent.test {
-            viewModel.verifyCode("000000")
+            viewModel.verifyCode()
             assertEquals(FindPasswordUiEvent.ShowToast("잘못된 코드"), awaitItem())
         }
     }
 
+    @Test
+    fun `VerifyCode step 이 아니면 verifyCode 는 무시된다`() = runTest {
+        viewModel.verifyCode()
+
+        assertEquals(null, fakeUserRepository.verifyPwResetCodeCalledWith)
+    }
+
     // endregion
 
-    // region resetPassword
+    // region resendVerifyCode
 
     @Test
-    fun `resetPassword 호출 시 savedStateHandle의 userId와 code로 repository를 호출한다`() = runTest {
-        // 전체 플로우를 거쳐 savedStateHandle에 userId, code 저장
+    fun `resendVerifyCode 호출 시 같은 fullEmail 로 sendPwResetCodeToEmail 을 다시 호출한다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+
+        viewModel.resendVerifyCode()
+
+        assertEquals("test@snu.ac.kr", fakeUserRepository.sendPwResetCodeToEmailCalledWith)
+    }
+
+    // endregion
+
+    // region validateAndResetPassword
+
+    @Test
+    fun `validateAndResetPassword 성공 시 savedStateHandle의 userId, code 와 입력 비밀번호로 repository를 호출한다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
         fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
-        viewModel.verifyCode("123456")
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
         fakeUserRepository.resetPasswordResult = Result.Success(Unit)
 
-        viewModel.resetPassword("newPassword!")
+        viewModel.onNewPasswordFieldChange("newPassword1!")
+        viewModel.onNewPasswordConfirmFieldChange("newPassword1!")
+        viewModel.validateAndResetPassword(timerRunning = true)
 
         assertEquals(
-            Triple("testuser", "newPassword!", "123456"),
+            Triple("testuser", "newPassword1!", "123456"),
             fakeUserRepository.resetPasswordCalledWith,
         )
     }
 
     @Test
-    fun `resetPassword 성공 시 showCompleteDialog가 true가 된다`() = runTest {
+    fun `validateAndResetPassword 성공 시 dialogState 가 Complete 가 된다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
         fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
-        viewModel.verifyCode("123456")
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
         fakeUserRepository.resetPasswordResult = Result.Success(Unit)
 
-        viewModel.resetPassword("newPassword!")
+        viewModel.onNewPasswordFieldChange("newPassword1!")
+        viewModel.onNewPasswordConfirmFieldChange("newPassword1!")
+        viewModel.validateAndResetPassword(timerRunning = true)
 
         assertEquals(
-            FindPasswordViewModel.UIState.EnterNewPassword(showCompleteDialog = true),
+            FindPasswordViewModel.UIState.EnterNewPassword(
+                newPasswordField = "newPassword1!",
+                newPasswordConfirmField = "newPassword1!",
+                dialogState = FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.Complete,
+            ),
             viewModel.uiState.value,
         )
     }
 
     @Test
-    fun `resetPassword 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+    fun `validateAndResetPassword 시 비밀번호 미일치면 ConfirmFail 다이얼로그가 뜨고 repository는 호출되지 않는다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
+
+        viewModel.onNewPasswordFieldChange("newPassword1!")
+        viewModel.onNewPasswordConfirmFieldChange("different1!")
+        viewModel.validateAndResetPassword(timerRunning = true)
+
+        val state = viewModel.uiState.value as FindPasswordViewModel.UIState.EnterNewPassword
+        assertEquals(
+            FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.Error(
+                FindPasswordViewModel.UIState.EnterNewPassword.ErrorType.ConfirmFail,
+            ),
+            state.dialogState,
+        )
+        assertEquals(null, fakeUserRepository.resetPasswordCalledWith)
+    }
+
+    @Test
+    fun `validateAndResetPassword 시 비밀번호 형식이 부적합하면 InvalidPassword 다이얼로그가 뜨고 repository는 호출되지 않는다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
+
+        viewModel.onNewPasswordFieldChange("short")
+        viewModel.onNewPasswordConfirmFieldChange("short")
+        viewModel.validateAndResetPassword(timerRunning = true)
+
+        val state = viewModel.uiState.value as FindPasswordViewModel.UIState.EnterNewPassword
+        assertEquals(
+            FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.Error(
+                FindPasswordViewModel.UIState.EnterNewPassword.ErrorType.InvalidPassword,
+            ),
+            state.dialogState,
+        )
+        assertEquals(null, fakeUserRepository.resetPasswordCalledWith)
+    }
+
+    @Test
+    fun `validateAndResetPassword 시 timer 가 종료되었으면 아무 동작도 하지 않는다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
+
+        viewModel.onNewPasswordFieldChange("newPassword1!")
+        viewModel.onNewPasswordConfirmFieldChange("newPassword1!")
+        viewModel.validateAndResetPassword(timerRunning = false)
+
+        assertEquals(null, fakeUserRepository.resetPasswordCalledWith)
+    }
+
+    @Test
+    fun `validateAndResetPassword repository 실패 시 ShowToast 이벤트가 발생한다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
         fakeUserRepository.resetPasswordResult =
-            Result.Fail(Unknown(displayTitle = "", displayMessage = "비밀번호 조건 불충족"))
+            Result.Fail(Unknown(displayTitle = "", displayMessage = "비밀번호 변경 실패"))
+
+        viewModel.onNewPasswordFieldChange("newPassword1!")
+        viewModel.onNewPasswordConfirmFieldChange("newPassword1!")
 
         viewModel.uiEvent.test {
-            viewModel.resetPassword("weak")
-            assertEquals(FindPasswordUiEvent.ShowToast("비밀번호 조건 불충족"), awaitItem())
+            viewModel.validateAndResetPassword(timerRunning = true)
+            assertEquals(FindPasswordUiEvent.ShowToast("비밀번호 변경 실패"), awaitItem())
         }
+    }
+
+    // endregion
+
+    // region onTimerExpired / dismissNewPasswordDialog
+
+    @Test
+    fun `onTimerExpired 호출 시 Expired 다이얼로그가 뜬다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
+
+        viewModel.onTimerExpired()
+
+        val state = viewModel.uiState.value as FindPasswordViewModel.UIState.EnterNewPassword
+        assertEquals(
+            FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.Error(
+                FindPasswordViewModel.UIState.EnterNewPassword.ErrorType.Expired,
+            ),
+            state.dialogState,
+        )
+    }
+
+    @Test
+    fun `dismissNewPasswordDialog 호출 시 dialogState 가 None 으로 돌아간다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
+        viewModel.onTimerExpired()
+
+        viewModel.dismissNewPasswordDialog()
+
+        val state = viewModel.uiState.value as FindPasswordViewModel.UIState.EnterNewPassword
+        assertEquals(
+            FindPasswordViewModel.UIState.EnterNewPassword.NewPasswordDialogState.None,
+            state.dialogState,
+        )
+    }
+
+    // endregion
+
+    // region showWhyNotCodeComingDialog / dismissVerifyCodeDialog
+
+    @Test
+    fun `showWhyNotCodeComingDialog 호출 시 VerifyCode dialogState 가 WhyNotCodeComing 이 된다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+
+        viewModel.showWhyNotCodeComingDialog()
+
+        val state = viewModel.uiState.value as FindPasswordViewModel.UIState.VerifyCode
+        assertEquals(
+            FindPasswordViewModel.UIState.VerifyCode.VerifyCodeDialogState.WhyNotCodeComing,
+            state.dialogState,
+        )
+    }
+
+    @Test
+    fun `dismissVerifyCodeDialog 호출 시 VerifyCode dialogState 가 None 이 된다`() = runTest {
+        fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
+        fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
+        viewModel.showWhyNotCodeComingDialog()
+
+        viewModel.dismissVerifyCodeDialog()
+
+        val state = viewModel.uiState.value as FindPasswordViewModel.UIState.VerifyCode
+        assertEquals(
+            FindPasswordViewModel.UIState.VerifyCode.VerifyCodeDialogState.None,
+            state.dialogState,
+        )
     }
 
     // endregion
@@ -241,7 +505,8 @@ class FindPasswordViewModelTest {
     @Test
     fun `EnterFullEmail에서 goToPreviousStep 호출 시 CheckId로 돌아가고 userId가 복원된다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
 
         viewModel.goToPreviousStep()
 
@@ -254,9 +519,11 @@ class FindPasswordViewModelTest {
     @Test
     fun `VerifyCode에서 goToPreviousStep 호출 시 EnterFullEmail로 돌아가고 저장값이 복원된다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
 
         viewModel.goToPreviousStep()
 
@@ -273,11 +540,14 @@ class FindPasswordViewModelTest {
     @Test
     fun `EnterNewPassword에서 goToPreviousStep 호출 시 CheckId로 돌아간다`() = runTest {
         fakeUserRepository.checkEmailByIdResult = Result.Success("t***@snu.ac.kr")
-        viewModel.checkEmailById("testuser")
+        viewModel.onIdFieldChange("testuser")
+        viewModel.checkEmailById()
         fakeUserRepository.sendPwResetCodeToEmailResult = Result.Success(Unit)
-        viewModel.sendFullEmailAndRequestCode("test@snu.ac.kr")
+        viewModel.onEmailFieldChange("test@snu.ac.kr")
+        viewModel.sendFullEmailAndRequestCode()
         fakeUserRepository.verifyPwResetCodeResult = Result.Success(Unit)
-        viewModel.verifyCode("123456")
+        viewModel.onCodeFieldChange("123456")
+        viewModel.verifyCode()
 
         viewModel.goToPreviousStep()
 


### PR DESCRIPTION
## Summary
- 백로그 (`docs/state-hoisting-backlog.md` §1.1) 의 login + resetpassword 8개 hoist 후보를 일괄 처리.
- SignIn/SignUp/FindId 폼 입력값을 ViewModel UiState 로 이동.
- EmailVerification: \`flowState\` + \`codeField\` hoist. CodeSent → RestartTimer 로 분리해 step 전이는 ViewModel 책임.
- FindPasswordViewModel: VerifyCode/EnterNewPassword 에 \`dialogState\` nested sealed interface 추가. NewPasswordStep 검증 로직을 \`validateAndResetPassword\` 로 이동.

## Notes
- CheckIdStep / EnterFullEmailStep 의 \`TextFieldValue\` 는 selection 추적 때문에 UI remember 그대로 두되, \`onValueChange\` 에서 \`onIdFieldChange(it.text)\` / \`onEmailFieldChange(it.text)\` 로 ViewModel 과 텍스트만 sync — 데이터(text)는 ViewModel, selection 은 UI 책임으로 분리.
- 검증 메시지가 stringResource 라 SignUp 의 검증 로직만 UI 에 남겼고, NewPasswordStep 은 ErrorType enum 으로 변환해 ViewModel 로 옮김.

## Test plan
- [ ] SignIn / SignUp / FindId 폼 입력 → 회전 시 입력값 보존 확인
- [ ] EmailVerification AskContinue ↔ SendCode 전이, BackHandler, code 검증
- [ ] FindPassword 4 step 모두 — 입력 보존, dialog 표시, 뒤로가기, 비밀번호 재설정 완료까지
- [ ] NewPasswordStep 의 timer 만료 / 비밀번호 미일치 / invalid password / 성공 — 모든 다이얼로그 분기 확인