### PR TITLE
fix: HomeDrawer 다크모드 scrim 색 명시

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerBottomSheetLayout.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerBottomSheetLayout.kt
@@ -130,6 +130,7 @@ fun HomeDrawerBottomSheetLayout(
                 )
             },
             drawerState = drawerState,
+            scrimColor = SNUTTColors.Black.copy(alpha = 0.32f),
         ) {
             content()
         }


### PR DESCRIPTION
## Summary
- 다크모드에서 HomeDrawer 를 열었을 때 dim 이 옅은 흰색처럼 보이는 문제를 수정합니다.
- `ModalDrawer` 의 `scrimColor` 가 미지정 상태라 Material 기본값(`MaterialTheme.colors.onSurface.copy(alpha = 0.32f)`) 이 적용되고 있었고, 다크 테마에서는 `onSurface = SNUTTColors.White` 이라 흰색 베이스의 dim 이 그려지고 있었습니다.
- 같은 파일의 `ModalBottomSheetLayout` 이 이미 사용 중인 `SNUTTColors.Black.copy(alpha = 0.32f)` 와 동일하게 명시해 라이트/다크 모두 일관된 검정 32% dim 으로 통일했습니다.

## Test plan
- [ ] 다크모드 진입 후 햄버거 메뉴로 HomeDrawer 열어 dim 이 검정 계열인지 확인
- [ ] 라이트모드에서 HomeDrawer dim 이 기존과 동일하게 보이는지 회귀 확인
- [ ] HomeDrawer 위로 BottomSheet 띄웠을 때 두 scrim 의 톤이 어색하지 않은지 확인