### PR TITLE
refactor: Icon wrapper 인라인화 + SnuttIcon 공통 컴포넌트 도입

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/SNUTTFirebaseMessagingService.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/SNUTTFirebaseMessagingService.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.wafflestudio.snutt2.R
 
 class SNUTTFirebaseMessagingService : FirebaseMessagingService() {
 

--- a/app/src/main/java/com/wafflestudio/snutt2/SNUTTFirebaseMessagingService.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/SNUTTFirebaseMessagingService.kt
@@ -10,7 +10,6 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.wafflestudio.snutt2.R
 
 class SNUTTFirebaseMessagingService : FirebaseMessagingService() {
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/debug/TestScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/debug/TestScreen.kt
@@ -24,8 +24,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -201,9 +202,11 @@ fun SettingItemForTest(
         Spacer(modifier = Modifier.weight(1f))
         content()
         if (hasNextPage) {
-            RightArrowIcon(
+            SnuttIcon(
+                R.drawable.ic_arrow_right,
                 modifier = Modifier.size(22.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Black500),
+                contentDescription = "add arrow",
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
@@ -33,7 +33,7 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
 import com.wafflestudio.snutt2.domain.model.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.feature.diary.DiaryTheme
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -110,10 +110,11 @@ fun DiaryHistoryScreen(
                 )
             },
             navigationIcon = {
-                ArrowBackIcon(
+                SnuttIcon(
+                    R.drawable.ic_arrow_back,
                     modifier = Modifier
                         .size(30.dp)
-                        .clicks { onNavigateBack() },
+                        .clicks { onNavigateBack() }.size(30.dp),
                     colorFilter = ColorFilter.tint(DiaryTheme.colors.iconPrimary),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
@@ -114,7 +114,7 @@ fun DiaryHistoryScreen(
                     R.drawable.ic_arrow_back,
                     modifier = Modifier
                         .size(30.dp)
-                        .clicks { onNavigateBack() }.size(30.dp),
+                        .clicks { onNavigateBack() },
                     colorFilter = ColorFilter.tint(DiaryTheme.colors.iconPrimary),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiarySummary.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiarySummary.kt
@@ -29,11 +29,11 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
 import com.wafflestudio.snutt2.domain.model.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.feature.diary.DiaryTheme
-import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
-import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
+import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -80,10 +80,12 @@ fun DiarySummariesOfDay(
                     color = DiaryTheme.colors.textSecondary,
                     modifier = Modifier.weight(1f),
                 )
-                ArrowDownIcon(
+                SnuttIcon(
+                    R.drawable.ic_arrow_down,
                     modifier = Modifier
                         .height(20.dp)
                         .rotate(if (expanded) 180f else 0f),
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             }
         }
@@ -140,7 +142,8 @@ private fun DiarySummary(
                     diarySummary.courseName,
                     style = SNUTTTypography.body1.copy(color = DiaryTheme.colors.textLabel),
                 )
-                TrashIcon(
+                SnuttIcon(
+                    R.drawable.ic_trash,
                     modifier = Modifier
                         .size(28.dp, 28.dp)
                         .clicks { onClickDeleteButton() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diarywrite/DiaryWriteComponents.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diarywrite/DiaryWriteComponents.kt
@@ -37,8 +37,8 @@ import com.wafflestudio.snutt2.domain.model.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.feature.diary.DiaryTheme
 import com.wafflestudio.snutt2.lib.Selectable
 import com.wafflestudio.snutt2.lib.anySelected
-import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.EditText
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -262,7 +262,8 @@ fun MoreTextItem(
                     lineHeight = 15.sp,
                 )
             }
-            ArrowDownIcon(
+            SnuttIcon(
+                R.drawable.ic_arrow_down,
                 modifier = Modifier
                     .height(24.dp)
                     .rotate(if (isExpanded) 180f else 0f),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diarywrite/DiaryWritePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diarywrite/DiaryWritePage.kt
@@ -240,7 +240,7 @@ private fun DiaryWriting(
                     .width(24.dp)
                     .clicks {
                         onClickBackButton()
-                    }.size(30.dp),
+                    },
                 colorFilter = ColorFilter.tint(
                     DiaryTheme.colors.exitIcon,
                 ),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diarywrite/DiaryWritePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diarywrite/DiaryWritePage.kt
@@ -60,7 +60,7 @@ import com.wafflestudio.snutt2.domain.model.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.feature.diary.DiaryTheme
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -233,13 +233,14 @@ private fun DiaryWriting(
                 )
             }
 
-            ExitIcon(
+            SnuttIcon(
+                R.drawable.ic_exit,
                 modifier = Modifier
                     .padding(start = 57.dp)
                     .width(24.dp)
                     .clicks {
                         onClickBackButton()
-                    },
+                    }.size(30.dp),
                 colorFilter = ColorFilter.tint(
                     DiaryTheme.colors.exitIcon,
                 ),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsBottomSheet.kt
@@ -21,12 +21,10 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Friend
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.EditText
-import com.wafflestudio.snutt2.ui.components.compose.FriendHashIcon
-import com.wafflestudio.snutt2.ui.components.compose.KakaoTalkIcon
 import com.wafflestudio.snutt2.ui.components.compose.ModalBottomSheetPlaceholder
 import com.wafflestudio.snutt2.ui.components.compose.MoreActionItem
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
-import com.wafflestudio.snutt2.ui.components.compose.WarningIcon
 import com.wafflestudio.snutt2.ui.components.compose.WriteIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -101,7 +99,8 @@ private fun AddFriendMethodListBottomSheet(
     ) {
         MoreActionItem(
             icon = {
-                KakaoTalkIcon(
+                SnuttIcon(
+                    R.drawable.ic_kakao_talk,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Gray600),
                 )
@@ -112,7 +111,8 @@ private fun AddFriendMethodListBottomSheet(
         }
         MoreActionItem(
             icon = {
-                FriendHashIcon(
+                SnuttIcon(
+                    R.drawable.ic_friend_hash,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Gray600),
                 )
@@ -175,7 +175,8 @@ private fun RequestWithNicknameBottomSheet(
         Row(
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            WarningIcon(
+            SnuttIcon(
+                R.drawable.ic_warning,
                 modifier = Modifier.size(18.dp),
                 colorFilter = if (nickname.isNotBlank()) ColorFilter.tint(SNUTTColors.SNUTTTheme) else null,
             )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsBottomSheet.kt
@@ -24,8 +24,6 @@ import com.wafflestudio.snutt2.ui.components.compose.EditText
 import com.wafflestudio.snutt2.ui.components.compose.ModalBottomSheetPlaceholder
 import com.wafflestudio.snutt2.ui.components.compose.MoreActionItem
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
-import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
-import com.wafflestudio.snutt2.ui.components.compose.WriteIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -203,13 +201,13 @@ private fun FriendDetailBottomSheet(
             .padding(vertical = 12.dp),
     ) {
         MoreActionItem(
-            icon = { WriteIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_write, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.friend_display_name_title),
         ) {
             onEditDisplayName()
         }
         MoreActionItem(
-            icon = { TrashIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_trash, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.friend_delete_from_list),
         ) {
             onDeleteFriend()

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
@@ -34,7 +34,7 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
-import com.wafflestudio.snutt2.ui.components.compose.TipCloseIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -144,7 +144,8 @@ private fun GuideDialog(
                         modifier = Modifier.padding(start = 24.dp, end = 24.dp, top = 24.dp),
                     ) {
                         Spacer(modifier = Modifier.weight(1f))
-                        TipCloseIcon(
+                        SnuttIcon(
+                            R.drawable.btntipclose,
                             modifier = Modifier
                                 .size(15.dp)
                                 .clicks { onDismiss() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
@@ -33,7 +33,6 @@ import com.wafflestudio.snutt2.domain.model.Friend
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
-import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -203,7 +202,8 @@ private fun GuideDialog(
                             )
                         }
                         if (pagerState.currentPage < 4) {
-                            RightArrowIcon(
+                            SnuttIcon(
+                                R.drawable.ic_arrow_right,
                                 modifier = Modifier
                                     .align(Alignment.CenterEnd)
                                     .size(30.dp)
@@ -213,6 +213,7 @@ private fun GuideDialog(
                                         }
                                     },
                                 colorFilter = ColorFilter.tint(SNUTTColors.VacancyGray),
+                                contentDescription = "add arrow",
                             )
                         }
                     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
@@ -197,7 +197,7 @@ private fun GuideDialog(
                                         scope.launch {
                                             pagerState.animateScrollToPage(pagerState.currentPage - 1)
                                         }
-                                    }.size(30.dp),
+                                    },
                                 colorFilter = ColorFilter.tint(SNUTTColors.VacancyGray),
                             )
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDialog.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.window.Dialog
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Friend
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -189,7 +188,8 @@ private fun GuideDialog(
                         }
 
                         if (pagerState.currentPage > 0) {
-                            ArrowBackIcon(
+                            SnuttIcon(
+                                R.drawable.ic_arrow_back,
                                 modifier = Modifier
                                     .align(Alignment.CenterStart)
                                     .size(30.dp)
@@ -197,7 +197,7 @@ private fun GuideDialog(
                                         scope.launch {
                                             pagerState.animateScrollToPage(pagerState.currentPage - 1)
                                         }
-                                    },
+                                    }.size(30.dp),
                                 colorFilter = ColorFilter.tint(SNUTTColors.VacancyGray),
                             )
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDrawer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDrawer.kt
@@ -32,11 +32,9 @@ import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Friend
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.AddFriendIcon
 import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
-import com.wafflestudio.snutt2.ui.components.compose.LogoIcon
-import com.wafflestudio.snutt2.ui.components.compose.MoreIcon
 import com.wafflestudio.snutt2.ui.components.compose.RedDot
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -64,7 +62,7 @@ fun FriendsDrawerContent(
             modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 22.5.dp, bottom = 20.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            LogoIcon(modifier = Modifier.size(20.dp))
+            SnuttIcon(R.drawable.logo, modifier = Modifier.size(20.dp))
             Spacer(modifier = Modifier.width(11.dp))
             Text(
                 text = stringResource(R.string.sign_in_logo_title),
@@ -153,7 +151,8 @@ fun FriendsDrawerContent(
                 color = SNUTTColors.Gray600,
                 modifier = Modifier.weight(1f),
             )
-            AddFriendIcon(
+            SnuttIcon(
+                R.drawable.ic_user_add,
                 modifier = Modifier.size(20.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Gray600),
             )
@@ -220,7 +219,8 @@ private fun FriendsActiveList(
                     style = SNUTTTypography.subtitle2.copy(fontSize = 11.sp),
                     color = SNUTTColors.Gray600,
                 )
-                AddFriendIcon(
+                SnuttIcon(
+                    R.drawable.ic_user_add,
                     modifier = Modifier.size(11.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Gray600),
                 )
@@ -326,7 +326,8 @@ private fun FriendListItem(
             fontSize = 14.sp,
             modifier = Modifier.weight(1f),
         )
-        MoreIcon(
+        SnuttIcon(
+            R.drawable.ic_more,
             modifier = Modifier
                 .size(30.dp)
                 .clicks { onMoreClick() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDrawer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDrawer.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Friend
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
 import com.wafflestudio.snutt2.ui.components.compose.RedDot
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -69,12 +68,14 @@ fun FriendsDrawerContent(
                 style = SNUTTTypography.h2,
             )
             Spacer(modifier = Modifier.weight(1f))
-            ExitIcon(
+            SnuttIcon(
+                R.drawable.ic_exit,
                 modifier = Modifier
                     .size(30.dp)
                     .clicks {
                         onClose()
-                    },
+                    }.size(30.dp),
+                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDrawer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsDrawer.kt
@@ -74,7 +74,7 @@ fun FriendsDrawerContent(
                     .size(30.dp)
                     .clicks {
                         onClose()
-                    }.size(30.dp),
+                    },
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
@@ -51,7 +51,6 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.feature.home.timetable.TimeTable
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.BottomSheetDismissEffect
 import com.wafflestudio.snutt2.ui.components.compose.DrawerIcon
 import com.wafflestudio.snutt2.ui.components.compose.IconWithAlertDot
@@ -595,7 +594,7 @@ private fun SemesterDropdown(
                 style = SNUTTTypography.body2.copy(color = SNUTTColors.Black900),
             )
             Spacer(modifier = Modifier.width(5.dp))
-            ArrowDownIcon(modifier = Modifier.size(15.dp))
+            SnuttIcon(R.drawable.ic_arrow_down, modifier = Modifier.size(15.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
         }
 
         DropdownMenu(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
@@ -365,7 +365,7 @@ private fun FriendsLoadedScreen(
                                 R.drawable.ic_drawer,
                                 modifier = centerAlignedModifier
                                     .size(30.dp)
-                                    .clicks { onOpenDrawer() }.size(30.dp),
+                                    .clicks { onOpenDrawer() },
                                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                                 contentDescription = stringResource(R.string.home_timetable_drawer),
                             )
@@ -528,7 +528,7 @@ private fun FriendsLoadedScreen(
                                 )
                                 SnuttIcon(
                                     R.drawable.ic_drawer,
-                                    modifier = Modifier.size(12.5.dp).size(30.dp),
+                                    modifier = Modifier.size(12.5.dp),
                                     colorFilter = ColorFilter.tint(SNUTTColors.TextMed),
                                     contentDescription = stringResource(R.string.home_timetable_drawer),
                                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
@@ -51,13 +51,11 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.feature.home.timetable.TimeTable
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.AddFriendIcon
 import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.BottomSheetDismissEffect
 import com.wafflestudio.snutt2.ui.components.compose.DrawerIcon
 import com.wafflestudio.snutt2.ui.components.compose.IconWithAlertDot
-import com.wafflestudio.snutt2.ui.components.compose.PersonIcon
-import com.wafflestudio.snutt2.ui.components.compose.QuestionCircleIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -379,7 +377,8 @@ private fun FriendsLoadedScreen(
                                 style = SNUTTTypography.subtitle1.copy(color = SNUTTColors.Black900),
                             )
                             Spacer(modifier = Modifier.width(6.dp))
-                            QuestionCircleIcon(
+                            SnuttIcon(
+                                R.drawable.ic_question_circle,
                                 modifier = Modifier
                                     .size(16.dp)
                                     .clicks {
@@ -387,7 +386,8 @@ private fun FriendsLoadedScreen(
                                     },
                             )
                         }
-                        AddFriendIcon(
+                        SnuttIcon(
+                            R.drawable.ic_user_add,
                             modifier = Modifier
                                 .size(25.dp)
                                 .clicks { onOpenRequestFriendBottomSheet() },
@@ -413,7 +413,8 @@ private fun FriendsLoadedScreen(
                                 modifier = Modifier.weight(1f, fill = false),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                PersonIcon(
+                                SnuttIcon(
+                                    R.drawable.ic_person,
                                     modifier = Modifier.size(15.dp),
                                     colorFilter = ColorFilter.tint(SNUTTColors.SNUTTTheme),
                                 )
@@ -498,7 +499,8 @@ private fun FriendsLoadedScreen(
                                     style = SNUTTTypography.subtitle2.copy(fontSize = 12.sp),
                                     color = SNUTTColors.Gray600,
                                 )
-                                AddFriendIcon(
+                                SnuttIcon(
+                                    R.drawable.ic_user_add,
                                     modifier = Modifier.size(12.5.dp),
                                     colorFilter = ColorFilter.tint(SNUTTColors.Gray600),
                                 )
@@ -541,7 +543,7 @@ private fun FriendsLoadedScreen(
                                     onShowGuideDialog()
                                 },
                             ) {
-                                QuestionCircleIcon(modifier = Modifier.size(11.5.dp))
+                                SnuttIcon(R.drawable.ic_question_circle, modifier = Modifier.size(11.5.dp))
                                 Text(
                                     text = stringResource(R.string.friend_guide_detail),
                                     style = SNUTTTypography.subtitle2.copy(fontSize = 11.sp),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/friend/FriendsPage2.kt
@@ -52,7 +52,6 @@ import com.wafflestudio.snutt2.feature.home.timetable.TimeTable
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.BottomSheetDismissEffect
-import com.wafflestudio.snutt2.ui.components.compose.DrawerIcon
 import com.wafflestudio.snutt2.ui.components.compose.IconWithAlertDot
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -362,10 +361,13 @@ private fun FriendsLoadedScreen(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         IconWithAlertDot(uiState.requestedFriends.isNotEmpty()) { centerAlignedModifier ->
-                            DrawerIcon(
+                            SnuttIcon(
+                                R.drawable.ic_drawer,
                                 modifier = centerAlignedModifier
                                     .size(30.dp)
-                                    .clicks { onOpenDrawer() },
+                                    .clicks { onOpenDrawer() }.size(30.dp),
+                                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                                contentDescription = stringResource(R.string.home_timetable_drawer),
                             )
                         }
                         Row(
@@ -524,9 +526,11 @@ private fun FriendsLoadedScreen(
                                     style = SNUTTTypography.subtitle2.copy(fontSize = 12.sp),
                                     color = SNUTTColors.TextMed,
                                 )
-                                DrawerIcon(
-                                    modifier = Modifier.size(12.5.dp),
+                                SnuttIcon(
+                                    R.drawable.ic_drawer,
+                                    modifier = Modifier.size(12.5.dp).size(30.dp),
                                     colorFilter = ColorFilter.tint(SNUTTColors.TextMed),
+                                    contentDescription = stringResource(R.string.home_timetable_drawer),
                                 )
                                 Text(
                                     text = stringResource(R.string.friend_empty_guide_sidebar2),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/BottomNavigation.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/BottomNavigation.kt
@@ -10,13 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
-import com.wafflestudio.snutt2.ui.components.compose.BigPeopleIcon
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.BorderButton
-import com.wafflestudio.snutt2.ui.components.compose.HorizontalMoreIcon
 import com.wafflestudio.snutt2.ui.components.compose.IconWithAlertDot
-import com.wafflestudio.snutt2.ui.components.compose.ReviewIcon
-import com.wafflestudio.snutt2.ui.components.compose.SearchIcon
-import com.wafflestudio.snutt2.ui.components.compose.TimetableIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -42,9 +39,10 @@ internal fun BottomNavigation(
                 onUpdatePageState(HomeItem.Timetable)
             },
         ) {
-            TimetableIcon(
+            SnuttIcon(
+                if (pageState == HomeItem.Timetable) R.drawable.ic_timetable_selected else R.drawable.ic_timetable_unselected,
                 modifier = Modifier.size(30.dp),
-                isSelected = pageState == HomeItem.Timetable,
+
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -58,9 +56,10 @@ internal fun BottomNavigation(
                 onUpdatePageState(HomeItem.Search)
             },
         ) {
-            SearchIcon(
+            SnuttIcon(
+                if (pageState == HomeItem.Search) R.drawable.ic_search_selected else R.drawable.ic_search_unselected,
                 modifier = Modifier.size(30.dp),
-                isSelected = pageState == HomeItem.Search,
+
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -74,9 +73,10 @@ internal fun BottomNavigation(
                 onUpdatePageState(HomeItem.Review())
             },
         ) {
-            ReviewIcon(
+            SnuttIcon(
+                if (pageState is HomeItem.Review) R.drawable.ic_review_selected else R.drawable.ic_review_unselected,
                 modifier = Modifier.size(30.dp),
-                isSelected = pageState is HomeItem.Review,
+
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -90,9 +90,10 @@ internal fun BottomNavigation(
                 onUpdatePageState(HomeItem.Friends)
             },
         ) {
-            BigPeopleIcon(
+            SnuttIcon(
+                if (pageState is HomeItem.Friends) R.drawable.ic_people_selected else R.drawable.ic_people_unselected,
                 modifier = Modifier.size(30.dp),
-                isSelected = pageState is HomeItem.Friends,
+
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -111,9 +112,10 @@ internal fun BottomNavigation(
                 dotSize = 4.dp,
                 dotYOffset = 3.dp,
             ) {
-                HorizontalMoreIcon(
+                SnuttIcon(
+                    if (pageState == HomeItem.Settings) R.drawable.ic_horizontal_more_selected else R.drawable.ic_horizontal_more_unselected,
                     modifier = Modifier.size(30.dp),
-                    isSelected = pageState == HomeItem.Settings,
+
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/BottomNavigation.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/BottomNavigation.kt
@@ -42,7 +42,6 @@ internal fun BottomNavigation(
             SnuttIcon(
                 if (pageState == HomeItem.Timetable) R.drawable.ic_timetable_selected else R.drawable.ic_timetable_unselected,
                 modifier = Modifier.size(30.dp),
-
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -59,7 +58,6 @@ internal fun BottomNavigation(
             SnuttIcon(
                 if (pageState == HomeItem.Search) R.drawable.ic_search_selected else R.drawable.ic_search_unselected,
                 modifier = Modifier.size(30.dp),
-
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -76,7 +74,6 @@ internal fun BottomNavigation(
             SnuttIcon(
                 if (pageState is HomeItem.Review) R.drawable.ic_review_selected else R.drawable.ic_review_unselected,
                 modifier = Modifier.size(30.dp),
-
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -93,7 +90,6 @@ internal fun BottomNavigation(
             SnuttIcon(
                 if (pageState is HomeItem.Friends) R.drawable.ic_people_selected else R.drawable.ic_people_unselected,
                 modifier = Modifier.size(30.dp),
-
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
@@ -115,7 +111,6 @@ internal fun BottomNavigation(
                 SnuttIcon(
                     if (pageState == HomeItem.Settings) R.drawable.ic_horizontal_more_selected else R.drawable.ic_horizontal_more_unselected,
                     modifier = Modifier.size(30.dp),
-
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -28,7 +29,6 @@ import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.TableSummary
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.lib.toDataWithState
-import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
 import com.wafflestudio.snutt2.ui.components.compose.RedDot
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
@@ -132,10 +132,12 @@ fun HomeDrawerContent(
                         style = SNUTTTypography.h3,
                     )
                     Spacer(modifier = Modifier.width(6.dp))
-                    ArrowDownIcon(
+                    SnuttIcon(
+                        R.drawable.ic_arrow_down,
                         modifier = Modifier
                             .size(22.dp)
                             .rotate(rotation),
+                        colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     if (courseBookDrawerItem.showNewCoursebookDot) {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerContent.kt
@@ -30,8 +30,8 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.lib.toDataWithState
 import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
-import com.wafflestudio.snutt2.ui.components.compose.LogoIcon
 import com.wafflestudio.snutt2.ui.components.compose.RedDot
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -76,7 +76,7 @@ fun HomeDrawerContent(
             .padding(20.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            LogoIcon(modifier = Modifier.size(20.dp))
+            SnuttIcon(R.drawable.logo, modifier = Modifier.size(20.dp))
             Spacer(modifier = Modifier.width(10.dp))
             Text(
                 text = stringResource(R.string.sign_in_logo_title),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerContent.kt
@@ -29,7 +29,6 @@ import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.TableSummary
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.lib.toDataWithState
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
 import com.wafflestudio.snutt2.ui.components.compose.RedDot
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -83,10 +82,12 @@ fun HomeDrawerContent(
                 style = SNUTTTypography.h2,
             )
             Spacer(modifier = Modifier.weight(1f))
-            ExitIcon(
+            SnuttIcon(
+                R.drawable.ic_exit,
                 modifier = Modifier.clicks {
                     onClickExitIcon()
-                },
+                }.size(30.dp),
+                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         }
         Divider(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerTableSummaryItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerTableSummaryItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.TableSummary
-import com.wafflestudio.snutt2.ui.components.compose.BigPeopleIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -73,9 +72,10 @@ fun CourseBookDrawerItem(
                 maxLines = 1,
             )
             if (tableSummary.isPrimary) {
-                BigPeopleIcon(
+                SnuttIcon(
+                    if (true) R.drawable.ic_people_selected else R.drawable.ic_people_unselected,
                     modifier = Modifier.size(15.dp),
-                    isSelected = true,
+
                     colorFilter = ColorFilter.tint(SNUTTColors.SNUTTTheme),
                 )
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerTableSummaryItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerTableSummaryItem.kt
@@ -73,9 +73,8 @@ fun CourseBookDrawerItem(
             )
             if (tableSummary.isPrimary) {
                 SnuttIcon(
-                    if (true) R.drawable.ic_people_selected else R.drawable.ic_people_unselected,
+                    R.drawable.ic_people_selected,
                     modifier = Modifier.size(15.dp),
-
                     colorFilter = ColorFilter.tint(SNUTTColors.SNUTTTheme),
                 )
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerTableSummaryItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerTableSummaryItem.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.TableSummary
 import com.wafflestudio.snutt2.ui.components.compose.BigPeopleIcon
-import com.wafflestudio.snutt2.ui.components.compose.DuplicateIcon
-import com.wafflestudio.snutt2.ui.components.compose.MoreIcon
-import com.wafflestudio.snutt2.ui.components.compose.VividCheckedIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -53,7 +51,8 @@ fun CourseBookDrawerItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(5.dp),
         ) {
-            VividCheckedIcon(
+            SnuttIcon(
+                R.drawable.ic_vivid_checked,
                 modifier = Modifier
                     .size(15.dp)
                     .alpha(if (isSelectedTable) 1f else 0f),
@@ -81,7 +80,8 @@ fun CourseBookDrawerItem(
                 )
             }
         }
-        DuplicateIcon(
+        SnuttIcon(
+            R.drawable.ic_duplicate,
             modifier = Modifier
                 .size(30.dp)
                 .clicks {
@@ -90,7 +90,8 @@ fun CourseBookDrawerItem(
             colorFilter = ColorFilter.tint(SNUTTColors.Black500),
         )
         Spacer(modifier = Modifier.width(10.dp))
-        MoreIcon(
+        SnuttIcon(
+            R.drawable.ic_more,
             modifier = Modifier
                 .size(30.dp)
                 .clicks {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/VacancyBanner.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/VacancyBanner.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.RingingAlarmIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -37,7 +37,8 @@ fun VacancyBanner(
             .padding(horizontal = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        RingingAlarmIcon(
+        SnuttIcon(
+            R.drawable.ic_ringing_alarm_unselected,
             modifier = Modifier.size(22.dp),
         )
         Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
@@ -18,11 +18,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.TableSummary
-import com.wafflestudio.snutt2.ui.components.compose.PaletteIcon
 import com.wafflestudio.snutt2.ui.components.compose.ShareIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
-import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
-import com.wafflestudio.snutt2.ui.components.compose.WriteIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -47,7 +44,7 @@ fun MoreActionSheet(
             .fillMaxWidth(),
     ) {
         MoreActionItem(
-            icon = { WriteIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_write, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.home_drawer_table_title_change),
             onClick = { onClickChangeTableName(tableSummary) },
         )
@@ -88,13 +85,13 @@ fun MoreActionSheet(
             onClickShare(tableSummary)
         }
         MoreActionItem(
-            icon = { PaletteIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_palette, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.home_drawer_table_theme_change),
         ) {
             onClickSetTheme(tableSummary)
         }
         MoreActionItem(
-            icon = { TrashIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_trash, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.home_drawer_table_delete),
         ) {
             onClickDeleteTable(tableSummary)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.TableSummary
-import com.wafflestudio.snutt2.ui.components.compose.ShareIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -79,7 +78,7 @@ fun MoreActionSheet(
             }
         }
         MoreActionItem(
-            icon = { ShareIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_share, modifier = Modifier.size(30.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.home_drawer_table_share),
         ) {
             onClickShare(tableSummary)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
@@ -19,9 +19,8 @@ import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.TableSummary
 import com.wafflestudio.snutt2.ui.components.compose.PaletteIcon
-import com.wafflestudio.snutt2.ui.components.compose.PeopleIcon
-import com.wafflestudio.snutt2.ui.components.compose.PeopleOffIcon
 import com.wafflestudio.snutt2.ui.components.compose.ShareIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
 import com.wafflestudio.snutt2.ui.components.compose.WriteIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -55,12 +54,14 @@ fun MoreActionSheet(
         MoreActionItem(
             icon = {
                 if (tableSummary.isPrimary) {
-                    PeopleOffIcon(
+                    SnuttIcon(
+                        R.drawable.ic_people_off,
                         modifier = Modifier.size(30.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                 } else {
-                    PeopleIcon(
+                    SnuttIcon(
+                        R.drawable.ic_people_on,
                         modifier = Modifier.size(30.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/bottomsheet/MoreActionBottomSheet.kt
@@ -78,7 +78,7 @@ fun MoreActionSheet(
             }
         }
         MoreActionItem(
-            icon = { SnuttIcon(R.drawable.ic_share, modifier = Modifier.size(30.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
+            icon = { SnuttIcon(R.drawable.ic_share, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = stringResource(R.string.home_drawer_table_share),
         ) {
             onClickShare(tableSummary)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/HomeSessionlessLectureHint.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/HomeSessionlessLectureHint.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.ArrowLeftBold
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -126,13 +126,15 @@ fun HomeSessionlessLectureHint(
                 color = SNUTTColors.SNUTTDarkMintBlue,
             )
         }
-        ArrowLeftBold(
+        SnuttIcon(
+            R.drawable.arrow_left_bold,
             modifier = Modifier
                 .rotate(-90F)
                 .offset { IntOffset((5.dp + yOffsetTop).roundToPx(), 0) },
             colorFilter = ColorFilter.tint(SNUTTColors.Hint1),
         )
-        ArrowLeftBold(
+        SnuttIcon(
+            R.drawable.arrow_left_bold,
             modifier = Modifier
                 .rotate(-90F)
                 .offset { IntOffset((40.dp + yOffsetBottom).roundToPx(), 0) },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimeTableScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimeTableScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -19,8 +20,8 @@ import com.wafflestudio.snutt2.domain.model.getCreditSumFromLectureList
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
-import com.wafflestudio.snutt2.ui.components.compose.DrawerIcon
 import com.wafflestudio.snutt2.ui.components.compose.IconWithAlertDot
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -82,10 +83,13 @@ fun TimeTableScreen(
                     },
                     navigationIcon = {
                         IconWithAlertDot(uiState.newSemesterExist) { centerAlignedModifier ->
-                            DrawerIcon(
+                            SnuttIcon(
+                                R.drawable.ic_drawer,
                                 modifier = centerAlignedModifier
                                     .size(30.dp)
-                                    .clicks { onClickDrawerIcon() },
+                                    .clicks { onClickDrawerIcon() }.size(30.dp),
+                                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                                contentDescription = stringResource(R.string.home_timetable_drawer),
                             )
                         }
                     },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimeTableScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimeTableScreen.kt
@@ -19,7 +19,6 @@ import com.wafflestudio.snutt2.domain.model.TableSummary
 import com.wafflestudio.snutt2.domain.model.getCreditSumFromLectureList
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
 import com.wafflestudio.snutt2.ui.components.compose.IconWithAlertDot
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
@@ -94,10 +93,12 @@ fun TimeTableScreen(
                         }
                     },
                     actions = {
-                        BookmarkIcon(
+                        SnuttIcon(
+                            R.drawable.ic_bookmark_unselected,
                             modifier = Modifier
                                 .size(30.dp)
                                 .clicks { onClickBookmarkIcon() },
+                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                         )
                         TimetableMoreAction(
                             onClickAddBySearch = onClickAddBySearch,

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimeTableScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimeTableScreen.kt
@@ -86,7 +86,7 @@ fun TimeTableScreen(
                                 R.drawable.ic_drawer,
                                 modifier = centerAlignedModifier
                                     .size(30.dp)
-                                    .clicks { onClickDrawerIcon() }.size(30.dp),
+                                    .clicks { onClickDrawerIcon() },
                                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                                 contentDescription = stringResource(R.string.home_timetable_drawer),
                             )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
@@ -58,7 +58,7 @@ fun TimetableMoreAction(
         modifier = Modifier
             .size(30.dp)
             .graphicsLayer { rotationZ = iconRotation }
-            .clicks { expanded = true }.size(30.dp),
+            .clicks { expanded = true },
         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
     )
 
@@ -168,7 +168,7 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                SnuttIcon(R.drawable.ic_drawer, modifier = Modifier.size(22.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900), contentDescription = stringResource(R.string.home_timetable_drawer))
+                SnuttIcon(R.drawable.ic_drawer, modifier = Modifier.size(22.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900), contentDescription = stringResource(R.string.home_timetable_drawer))
                 Text(
                     text = stringResource(R.string.home_dropdown_menu_content_current_timetable_lecture_list),
                     style = SNUTTTypography.h3.copy(fontWeight = FontWeight.Normal),
@@ -182,7 +182,7 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                SnuttIcon(R.drawable.ic_ringing_alarm_notification, modifier = Modifier.size(22.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+                SnuttIcon(R.drawable.ic_ringing_alarm_notification, modifier = Modifier.size(22.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
                 Text(
                     text = stringResource(R.string.home_dropdown_menu_content_vacancy_lecture_list),
                     style = SNUTTTypography.h3.copy(fontWeight = FontWeight.Normal),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.SearchIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -129,7 +128,8 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                SearchIcon(
+                SnuttIcon(
+                    R.drawable.ic_search_unselected,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
@@ -130,7 +130,7 @@ fun TimetableDropdownOverlay(
             ) {
                 SnuttIcon(
                     R.drawable.ic_search_unselected,
-                    modifier = Modifier.size(30.dp),
+                    modifier = Modifier.size(22.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
                 Text(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
@@ -37,7 +37,7 @@ import com.wafflestudio.snutt2.ui.components.compose.DrawerIcon
 import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationVacancyIcon
 import com.wafflestudio.snutt2.ui.components.compose.SearchIcon
-import com.wafflestudio.snutt2.ui.components.compose.WriteUnderlineIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -147,7 +147,7 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                WriteUnderlineIcon(modifier = Modifier.size(22.dp))
+                SnuttIcon(R.drawable.ic_write_underline, modifier = Modifier.size(22.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
                 Text(
                     text = stringResource(R.string.home_dropdown_menu_content_add_lecture_manually),
                     style = SNUTTTypography.h3.copy(fontWeight = FontWeight.Normal),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
@@ -33,9 +33,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.DrawerIcon
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
-import com.wafflestudio.snutt2.ui.components.compose.NotificationVacancyIcon
 import com.wafflestudio.snutt2.ui.components.compose.SearchIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -57,11 +54,13 @@ fun TimetableMoreAction(
         animationSpec = spring(),
     )
 
-    ExitIcon(
+    SnuttIcon(
+        R.drawable.ic_exit,
         modifier = Modifier
             .size(30.dp)
             .graphicsLayer { rotationZ = iconRotation }
-            .clicks { expanded = true },
+            .clicks { expanded = true }.size(30.dp),
+        colorFilter = ColorFilter.tint(SNUTTColors.Black900),
     )
 
     if (expanded) {
@@ -169,7 +168,7 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                DrawerIcon(modifier = Modifier.size(22.dp))
+                SnuttIcon(R.drawable.ic_drawer, modifier = Modifier.size(22.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900), contentDescription = stringResource(R.string.home_timetable_drawer))
                 Text(
                     text = stringResource(R.string.home_dropdown_menu_content_current_timetable_lecture_list),
                     style = SNUTTTypography.h3.copy(fontWeight = FontWeight.Normal),
@@ -183,7 +182,7 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                NotificationVacancyIcon(modifier = Modifier.size(22.dp))
+                SnuttIcon(R.drawable.ic_ringing_alarm_notification, modifier = Modifier.size(22.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
                 Text(
                     text = stringResource(R.string.home_dropdown_menu_content_vacancy_lecture_list),
                     style = SNUTTTypography.h3.copy(fontWeight = FontWeight.Normal),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/timetable/TimetableDropdownMenu.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -129,7 +130,10 @@ fun TimetableDropdownOverlay(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                SearchIcon(modifier = Modifier.size(22.dp))
+                SearchIcon(
+                    modifier = Modifier.size(30.dp),
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                )
                 Text(
                     text = stringResource(R.string.home_dropdown_menu_content_add_lecture_by_search),
                     style = SNUTTTypography.h3.copy(fontWeight = FontWeight.Normal),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/ColorSelectorContent.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/ColorSelectorContent.kt
@@ -23,11 +23,11 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.CheckedIcon
 import com.wafflestudio.snutt2.ui.components.compose.ColorBox
 import com.wafflestudio.snutt2.ui.components.compose.ColorCircle
 import com.wafflestudio.snutt2.ui.components.compose.ColorPicker
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -58,7 +58,8 @@ internal fun ColorItem(
             style = SNUTTTypography.body1,
         )
         if (isSelected) {
-            CheckedIcon(
+            SnuttIcon(
+                R.drawable.checked,
                 modifier = Modifier.size(20.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Black500),
             )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/FloatingButton.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/FloatingButton.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.ArrowLeftBold
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -39,7 +39,8 @@ internal fun FloatingButton(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        ArrowLeftBold(
+        SnuttIcon(
+            R.drawable.arrow_left_bold,
             modifier = Modifier.size(23.dp),
             colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
         )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
@@ -13,9 +13,9 @@ import com.wafflestudio.snutt2.domain.model.Lecture
 import com.wafflestudio.snutt2.domain.model.LectureSyllabusInfo
 import com.wafflestudio.snutt2.domain.model.LocalLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
 import com.wafflestudio.snutt2.ui.components.compose.RingingAlarmIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -45,10 +45,11 @@ internal fun LectureDetailTopBar(
             )
         },
         navigationIcon = {
-            ArrowBackIcon(
+            SnuttIcon(
+                R.drawable.ic_arrow_back,
                 modifier = Modifier
                     .size(30.dp)
-                    .clicks { onBackPressed() },
+                    .clicks { onBackPressed() }.size(30.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
@@ -59,7 +59,6 @@ internal fun LectureDetailTopBar(
                         .size(30.dp)
                         .clicks { onVacancyToggle() },
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-
                 )
                 SnuttIcon(
                     if (isBookmarked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
@@ -13,8 +13,6 @@ import com.wafflestudio.snutt2.domain.model.Lecture
 import com.wafflestudio.snutt2.domain.model.LectureSyllabusInfo
 import com.wafflestudio.snutt2.domain.model.LocalLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
-import com.wafflestudio.snutt2.ui.components.compose.RingingAlarmIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -55,18 +53,20 @@ internal fun LectureDetailTopBar(
         },
         actions = {
             if (lecture is LectureSyllabusInfo && !editMode) {
-                RingingAlarmIcon(
+                SnuttIcon(
+                    if (isVacancyRegistered) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
                     modifier = Modifier
                         .size(30.dp)
                         .clicks { onVacancyToggle() },
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
-                    marked = isVacancyRegistered,
+
                 )
-                BookmarkIcon(
+                SnuttIcon(
+                    if (isBookmarked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,
                     modifier = Modifier
                         .size(30.dp)
                         .clicks { onBookmarkToggle() },
-                    marked = isBookmarked,
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetailTopBar.kt
@@ -47,7 +47,7 @@ internal fun LectureDetailTopBar(
                 R.drawable.ic_arrow_back,
                 modifier = Modifier
                     .size(30.dp)
-                    .clicks { onBackPressed() }.size(30.dp),
+                    .clicks { onBackPressed() },
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureHeaderFields.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureHeaderFields.kt
@@ -20,8 +20,8 @@ import com.wafflestudio.snutt2.domain.model.LectureColor
 import com.wafflestudio.snutt2.domain.model.LectureUIInfo
 import com.wafflestudio.snutt2.domain.model.TableTheme
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.ArrowRight
 import com.wafflestudio.snutt2.ui.components.compose.ColorBox
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -107,7 +107,8 @@ private fun LectureColorField(
             }
             Spacer(modifier = Modifier.weight(1f))
             AnimatedVisibility(visible = editMode) {
-                ArrowRight(
+                SnuttIcon(
+                    R.drawable.arrowright,
                     modifier = Modifier.size(16.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureReviewRatingField.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureReviewRatingField.kt
@@ -46,8 +46,7 @@ internal fun LectureReviewRatingField(
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
             ) {
                 SnuttIcon(
-                    if (true) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
-
+                    R.drawable.ic_star_filled,
                     modifier = Modifier
                         .size(18.dp)
                         .offset(y = 1.dp),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureReviewRatingField.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureReviewRatingField.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.LectureReviewInfo
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.StarIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -45,8 +45,9 @@ internal fun LectureReviewRatingField(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                StarIcon(
-                    filled = true,
+                SnuttIcon(
+                    if (true) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
+
                     modifier = Modifier
                         .size(18.dp)
                         .offset(y = 1.dp),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureSessionSection.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureSessionSection.kt
@@ -32,7 +32,7 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.LectureSession
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.EditText
-import com.wafflestudio.snutt2.ui.components.compose.TipCloseIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -174,7 +174,8 @@ private fun TimeAndLocationItem(
                         .clicks { onClickDeleteIcon() },
                     contentAlignment = Alignment.Center,
                 ) {
-                    TipCloseIcon(
+                    SnuttIcon(
+                        R.drawable.btntipclose,
                         modifier = Modifier.size(16.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
@@ -35,7 +35,6 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.NotificationFriendIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationTrashIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationVacancyIcon
-import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -170,9 +169,11 @@ fun NotificationItem(notification: Notification, onClick: () -> Unit) {
                     )
                     if (!notification.deeplink.isNullOrEmpty()) {
                         Spacer(modifier = Modifier.width(16.dp))
-                        RightArrowIcon(
+                        SnuttIcon(
+                            R.drawable.ic_arrow_right,
                             modifier = Modifier.size(20.dp),
                             colorFilter = null,
+                            contentDescription = "add arrow",
                         )
                     }
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
@@ -34,12 +34,12 @@ import com.wafflestudio.snutt2.domain.model.NotificationType
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.AlarmOnIcon
 import com.wafflestudio.snutt2.ui.components.compose.CalendarIcon
-import com.wafflestudio.snutt2.ui.components.compose.ChevronIcon
 import com.wafflestudio.snutt2.ui.components.compose.MegaphoneIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationFriendIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationTrashIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationVacancyIcon
 import com.wafflestudio.snutt2.ui.components.compose.RefreshTimeIcon
+import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.components.compose.WarningIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -174,7 +174,10 @@ fun NotificationItem(notification: Notification, onClick: () -> Unit) {
                     )
                     if (!notification.deeplink.isNullOrEmpty()) {
                         Spacer(modifier = Modifier.width(16.dp))
-                        ChevronIcon(modifier = Modifier.size(20.dp))
+                        RightArrowIcon(
+                            modifier = Modifier.size(20.dp),
+                            colorFilter = null,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
@@ -203,19 +203,19 @@ fun NotificationIcon(type: NotificationType) {
 
         NotificationType.Trash -> SnuttIcon(
             R.drawable.ic_trash_new,
-            modifier = Modifier.size(30.dp).size(30.dp),
+            modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
         NotificationType.Vacancy -> SnuttIcon(
             R.drawable.ic_ringing_alarm_notification,
-            modifier = Modifier.size(30.dp).size(30.dp),
+            modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
         NotificationType.Friend -> SnuttIcon(
             R.drawable.ic_ringing_alarm_notification,
-            modifier = Modifier.size(30.dp).size(30.dp),
+            modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
@@ -32,16 +32,12 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Notification
 import com.wafflestudio.snutt2.domain.model.NotificationType
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.AlarmOnIcon
-import com.wafflestudio.snutt2.ui.components.compose.CalendarIcon
-import com.wafflestudio.snutt2.ui.components.compose.MegaphoneIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationFriendIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationTrashIcon
 import com.wafflestudio.snutt2.ui.components.compose.NotificationVacancyIcon
-import com.wafflestudio.snutt2.ui.components.compose.RefreshTimeIcon
 import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
-import com.wafflestudio.snutt2.ui.components.compose.WarningIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -189,17 +185,20 @@ fun NotificationItem(notification: Notification, onClick: () -> Unit) {
 @Composable
 fun NotificationIcon(type: NotificationType) {
     when (type) {
-        NotificationType.Warning -> WarningIcon(
+        NotificationType.Warning -> SnuttIcon(
+            R.drawable.ic_warning,
             modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
-        NotificationType.Calendar -> CalendarIcon(
+        NotificationType.Calendar -> SnuttIcon(
+            R.drawable.ic_calendar,
             modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
-        NotificationType.RefreshTime -> RefreshTimeIcon(
+        NotificationType.RefreshTime -> SnuttIcon(
+            R.drawable.ic_refresh_time,
             modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
@@ -219,7 +218,8 @@ fun NotificationIcon(type: NotificationType) {
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
-        NotificationType.Megaphone -> MegaphoneIcon(
+        NotificationType.Megaphone -> SnuttIcon(
+            R.drawable.ic_megaphone,
             modifier = Modifier.size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
@@ -233,7 +233,8 @@ fun NotificationError() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        WarningIcon(
+        SnuttIcon(
+            R.drawable.ic_warning,
             modifier = Modifier.size(40.dp),
             colorFilter = ColorFilter.tint(SNUTTColors.Gray200),
         )
@@ -254,7 +255,8 @@ fun NotificationPlaceholder() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AlarmOnIcon(
+        SnuttIcon(
+            R.drawable.tab_alarm_on,
             modifier = Modifier.size(40.dp),
         )
         Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
@@ -32,9 +32,6 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Notification
 import com.wafflestudio.snutt2.domain.model.NotificationType
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.NotificationFriendIcon
-import com.wafflestudio.snutt2.ui.components.compose.NotificationTrashIcon
-import com.wafflestudio.snutt2.ui.components.compose.NotificationVacancyIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -204,18 +201,21 @@ fun NotificationIcon(type: NotificationType) {
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
-        NotificationType.Trash -> NotificationTrashIcon(
-            modifier = Modifier.size(30.dp),
+        NotificationType.Trash -> SnuttIcon(
+            R.drawable.ic_trash_new,
+            modifier = Modifier.size(30.dp).size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
-        NotificationType.Vacancy -> NotificationVacancyIcon(
-            modifier = Modifier.size(30.dp),
+        NotificationType.Vacancy -> SnuttIcon(
+            R.drawable.ic_ringing_alarm_notification,
+            modifier = Modifier.size(30.dp).size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 
-        NotificationType.Friend -> NotificationFriendIcon(
-            modifier = Modifier.size(30.dp),
+        NotificationType.Friend -> SnuttIcon(
+            R.drawable.ic_ringing_alarm_notification,
+            modifier = Modifier.size(30.dp).size(30.dp),
             colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.Gray10 else SNUTTColors.Black900),
         )
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/reviews/ReviewPage.kt
@@ -32,7 +32,7 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.android.webview.LoadState
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.TimetableIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -110,9 +110,10 @@ private fun WebViewErrorPage(modifier: Modifier, onRetry: () -> Unit) {
                 )
             },
             navigationIcon = {
-                TimetableIcon(
+                SnuttIcon(
+                    if (true) R.drawable.ic_timetable_selected else R.drawable.ic_timetable_unselected,
                     modifier = Modifier.size(30.dp),
-                    isSelected = true,
+
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/reviews/ReviewPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/reviews/ReviewPage.kt
@@ -111,9 +111,8 @@ private fun WebViewErrorPage(modifier: Modifier, onRetry: () -> Unit) {
             },
             navigationIcon = {
                 SnuttIcon(
-                    if (true) R.drawable.ic_timetable_selected else R.drawable.ic_timetable_unselected,
+                    R.drawable.ic_timetable_selected,
                     modifier = Modifier.size(30.dp),
-
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
@@ -28,17 +28,14 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.LectureReviewInfo
 import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.AddCircleIcon
 import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
 import com.wafflestudio.snutt2.ui.components.compose.ClockIcon
-import com.wafflestudio.snutt2.ui.components.compose.DetailIcon
 import com.wafflestudio.snutt2.ui.components.compose.LocationIcon
 import com.wafflestudio.snutt2.ui.components.compose.RemarkIcon
-import com.wafflestudio.snutt2.ui.components.compose.RemoveCircleIcon
 import com.wafflestudio.snutt2.ui.components.compose.RingingAlarmIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.StarIcon
 import com.wafflestudio.snutt2.ui.components.compose.TagIcon
-import com.wafflestudio.snutt2.ui.components.compose.ThickReviewIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -233,7 +230,8 @@ private fun LectureActionBar(
             modifier = Modifier.weight(1f),
             onClick = onClickDetail,
         ) {
-            DetailIcon(
+            SnuttIcon(
+                R.drawable.ic_detail,
                 modifier = Modifier.size(23.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
             )
@@ -244,7 +242,8 @@ private fun LectureActionBar(
             modifier = Modifier.weight(1f),
             onClick = onClickReview,
         ) {
-            ThickReviewIcon(
+            SnuttIcon(
+                R.drawable.ic_review_thick,
                 modifier = Modifier.size(23.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
             )
@@ -284,12 +283,14 @@ private fun LectureActionBar(
             onClick = onClickAddOrRemove,
         ) {
             if (contained) {
-                RemoveCircleIcon(
+                SnuttIcon(
+                    R.drawable.ic_remove_circle,
                     modifier = Modifier.size(23.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
                 )
             } else {
-                AddCircleIcon(
+                SnuttIcon(
+                    R.drawable.ic_add_circle,
                     modifier = Modifier.size(23.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
@@ -28,10 +28,7 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.LectureReviewInfo
 import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
-import com.wafflestudio.snutt2.ui.components.compose.RingingAlarmIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
-import com.wafflestudio.snutt2.ui.components.compose.StarIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -169,11 +166,12 @@ private fun ReviewRating(reviewInfo: LectureReviewInfo) {
     val displayText = "$ratingText (${reviewInfo.reviewCount})"
 
     Row(verticalAlignment = Alignment.CenterVertically) {
-        StarIcon(
+        SnuttIcon(
+            if (false) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
             modifier = Modifier
                 .size(12.dp)
                 .offset(y = 1.dp),
-            filled = false,
+
             colorFilter = ColorFilter.tint(SNUTTColors.White),
         )
         Spacer(modifier = Modifier.width(2.dp))
@@ -254,9 +252,10 @@ private fun LectureActionBar(
             modifier = Modifier.weight(1f),
             onClick = onClickBookmark,
         ) {
-            BookmarkIcon(
+            SnuttIcon(
+                if (isBookmarked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,
                 modifier = Modifier.size(23.dp),
-                marked = isBookmarked,
+
                 colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
             )
         }
@@ -266,10 +265,11 @@ private fun LectureActionBar(
             modifier = Modifier.weight(1f),
             onClick = onClickVacancy,
         ) {
-            RingingAlarmIcon(
+            SnuttIcon(
+                if (isVacancyRegistered) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
                 modifier = Modifier.size(23.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
-                marked = isVacancyRegistered,
+
             )
         }
         Spacer(modifier = Modifier.weight(0.3f))

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
@@ -29,13 +29,9 @@ import com.wafflestudio.snutt2.domain.model.LectureReviewInfo
 import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.ui.components.compose.BookmarkIcon
-import com.wafflestudio.snutt2.ui.components.compose.ClockIcon
-import com.wafflestudio.snutt2.ui.components.compose.LocationIcon
-import com.wafflestudio.snutt2.ui.components.compose.RemarkIcon
 import com.wafflestudio.snutt2.ui.components.compose.RingingAlarmIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.StarIcon
-import com.wafflestudio.snutt2.ui.components.compose.TagIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -88,7 +84,8 @@ fun SearchLectureListItem(
             }
             // 태그 + 평점
             Row(verticalAlignment = Alignment.CenterVertically) {
-                TagIcon(
+                SnuttIcon(
+                    R.drawable.ic_tag,
                     modifier = Modifier.size(15.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
                 )
@@ -111,7 +108,8 @@ fun SearchLectureListItem(
             // 시간
             LectureInfoRow(
                 icon = {
-                    ClockIcon(
+                    SnuttIcon(
+                        R.drawable.ic_clock,
                         modifier = Modifier.size(15.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
                     )
@@ -121,7 +119,8 @@ fun SearchLectureListItem(
             // 장소
             LectureInfoRow(
                 icon = {
-                    LocationIcon(
+                    SnuttIcon(
+                        R.drawable.ic_location,
                         modifier = Modifier.size(15.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
                     )
@@ -131,7 +130,8 @@ fun SearchLectureListItem(
             // 비고
             LectureInfoRow(
                 icon = {
-                    RemarkIcon(
+                    SnuttIcon(
+                        R.drawable.ic_remark,
                         modifier = Modifier.size(15.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
                     )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchLectureListItem.kt
@@ -167,11 +167,10 @@ private fun ReviewRating(reviewInfo: LectureReviewInfo) {
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         SnuttIcon(
-            if (false) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
+            R.drawable.ic_star_outline,
             modifier = Modifier
                 .size(12.dp)
                 .offset(y = 1.dp),
-
             colorFilter = ColorFilter.tint(SNUTTColors.White),
         )
         Spacer(modifier = Modifier.width(2.dp))
@@ -255,7 +254,6 @@ private fun LectureActionBar(
             SnuttIcon(
                 if (isBookmarked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,
                 modifier = Modifier.size(23.dp),
-
                 colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
             )
         }
@@ -269,7 +267,6 @@ private fun LectureActionBar(
                 if (isVacancyRegistered) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
                 modifier = Modifier.size(23.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.AllWhite),
-
             )
         }
         Spacer(modifier = Modifier.weight(0.3f))

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchPlaceHolder.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchPlaceHolder.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.BigSearchIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -34,7 +34,8 @@ fun SearchPlaceHolder(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        BigSearchIcon(
+        SnuttIcon(
+            R.drawable.img_search_big,
             modifier = Modifier
                 .width(78.dp)
                 .height(76.dp)
@@ -89,7 +90,8 @@ fun SearchEmptyPlaceholder(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        BigSearchIcon(
+        SnuttIcon(
+            R.drawable.img_search_big,
             modifier = Modifier
                 .width(58.dp)
                 .height(56.dp),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
@@ -42,7 +42,6 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.feature.home.timetable.TimeTable
 import com.wafflestudio.snutt2.lib.DataWithState
 import com.wafflestudio.snutt2.ui.components.compose.EditText
-import com.wafflestudio.snutt2.ui.components.compose.SearchIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clearFocusOnKeyboardDismiss
@@ -164,7 +163,8 @@ private fun RowScope.SearchTopBarContent(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        SearchIcon(
+        SnuttIcon(
+            R.drawable.ic_search_unselected,
             modifier = Modifier
                 .size(30.dp)
                 .clicks { onSearch() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -164,7 +166,10 @@ private fun RowScope.SearchTopBarContent(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         SearchIcon(
-            modifier = Modifier.clicks { onSearch() },
+            modifier = Modifier
+                .size(30.dp)
+                .clicks { onSearch() },
+            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
         )
         EditText(
             modifier = Modifier

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
@@ -42,9 +42,8 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.feature.home.timetable.TimeTable
 import com.wafflestudio.snutt2.lib.DataWithState
 import com.wafflestudio.snutt2.ui.components.compose.EditText
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
-import com.wafflestudio.snutt2.ui.components.compose.FilterIcon
 import com.wafflestudio.snutt2.ui.components.compose.SearchIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clearFocusOnKeyboardDismiss
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -191,9 +190,9 @@ private fun RowScope.SearchTopBarContent(
             clearFocusFlag = !searchEditTextFocused,
         )
         if (searchEditTextFocused) {
-            ExitIcon(modifier = Modifier.clicks { onClearEditText() })
+            SnuttIcon(R.drawable.ic_exit, modifier = Modifier.clicks { onClearEditText() }.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
         } else {
-            FilterIcon(modifier = Modifier.clicks { onFilter() })
+            SnuttIcon(R.drawable.ic_filter, modifier = Modifier.clicks { onFilter() }.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
         }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchTagCell.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchTagCell.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.SearchTag
 import com.wafflestudio.snutt2.domain.model.TagType
-import com.wafflestudio.snutt2.ui.components.compose.CloseIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.components.compose.displayName
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -46,7 +46,8 @@ fun SearchTagCell(
             style = SNUTTTypography.body1.copy(fontSize = 14.sp, color = SNUTTColors.AllWhite),
             textAlign = TextAlign.Center,
         )
-        CloseIcon(
+        SnuttIcon(
+            R.drawable.ic_close,
             modifier = Modifier
                 .width(20.dp)
                 .clicks { onClick() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchOptionSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchOptionSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
@@ -35,7 +36,7 @@ import com.wafflestudio.snutt2.domain.model.TableTrimParam
 import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.lib.DataWithState
 import com.wafflestudio.snutt2.lib.Selectable
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -156,7 +157,7 @@ fun SearchOptionSheet(
             Row(
                 modifier = Modifier.clicks { hideBottomSheet() },
             ) {
-                ExitIcon()
+                SnuttIcon(R.drawable.ic_exit, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
             }
         }.first().measure(constraints)
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchTagsColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchTagsColumn.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -24,7 +25,6 @@ import com.wafflestudio.snutt2.domain.model.SearchTag
 import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.lib.DataWithState
 import com.wafflestudio.snutt2.lib.Selectable
-import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.components.compose.displayName
@@ -127,7 +127,7 @@ private fun SelectableTagItem(
                     modifier = Modifier.clicks { onRemoveRecent(selectableTag.item) },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ExitIcon(modifier = Modifier.size(18.dp))
+                    SnuttIcon(R.drawable.ic_exit, modifier = Modifier.size(18.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchTagsColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchTagsColumn.kt
@@ -19,13 +19,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.SearchTag
 import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.lib.DataWithState
 import com.wafflestudio.snutt2.lib.Selectable
 import com.wafflestudio.snutt2.ui.components.compose.ExitIcon
-import com.wafflestudio.snutt2.ui.components.compose.VividCheckedIcon
-import com.wafflestudio.snutt2.ui.components.compose.VividUncheckedIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.components.compose.displayName
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -111,9 +111,9 @@ private fun SelectableTagItem(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (selectableTag.state) {
-                    VividCheckedIcon(modifier = Modifier.size(15.dp))
+                    SnuttIcon(R.drawable.ic_vivid_checked, modifier = Modifier.size(15.dp))
                 } else {
-                    VividUncheckedIcon(modifier = Modifier.size(15.dp))
+                    SnuttIcon(R.drawable.ic_vivid_unchecked, modifier = Modifier.size(15.dp))
                 }
                 Spacer(modifier = Modifier.width(10.dp))
                 Text(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchTagsColumn.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/SearchTagsColumn.kt
@@ -127,7 +127,7 @@ private fun SelectableTagItem(
                     modifier = Modifier.clicks { onRemoveRecent(selectableTag.item) },
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    SnuttIcon(R.drawable.ic_exit, modifier = Modifier.size(18.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+                    SnuttIcon(R.drawable.ic_exit, modifier = Modifier.size(18.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/TimeSelectSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/searchoption/TimeSelectSheet.kt
@@ -51,8 +51,7 @@ import com.wafflestudio.snutt2.domain.model.trimByTrimParam
 import com.wafflestudio.snutt2.feature.home.timetable.DrawClassTime
 import com.wafflestudio.snutt2.feature.home.timetable.DrawTableGrid
 import com.wafflestudio.snutt2.feature.home.timetable.TimetableCanvasObjects
-import com.wafflestudio.snutt2.ui.components.compose.MagicIcon
-import com.wafflestudio.snutt2.ui.components.compose.ResetIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -142,7 +141,8 @@ fun TimeSelectSheet(
                     .padding(vertical = 4.dp, horizontal = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                MagicIcon(
+                SnuttIcon(
+                    R.drawable.ic_magic,
                     modifier = Modifier
                         .size(20.dp)
                         .padding(3.dp),
@@ -166,7 +166,8 @@ fun TimeSelectSheet(
                     .padding(vertical = 4.dp, horizontal = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                ResetIcon(
+                SnuttIcon(
+                    R.drawable.ic_reset,
                     modifier = Modifier.size(20.dp),
                 )
                 Text(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt
@@ -35,7 +35,7 @@ import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.EditText
-import com.wafflestudio.snutt2.ui.components.compose.SendIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -126,7 +126,8 @@ private fun AppReportScreen(
                 )
             },
             actions = {
-                SendIcon(
+                SnuttIcon(
+                    R.drawable.ic_send,
                     modifier = Modifier
                         .size(20.dp)
                         .clicks(throttleMs = 1000L, enabled = sentEnabled) { sendFeedback() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt
@@ -121,7 +121,7 @@ private fun AppReportScreen(
                     R.drawable.ic_arrow_back,
                     modifier = Modifier
                         .size(30.dp)
-                        .clicks { onNavigateBack() }.size(30.dp),
+                        .clicks { onNavigateBack() },
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/AppReportPage.kt
@@ -33,7 +33,6 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.isEmailInvalid
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.EditText
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
@@ -118,10 +117,11 @@ private fun AppReportScreen(
                 )
             },
             navigationIcon = {
-                ArrowBackIcon(
+                SnuttIcon(
+                    R.drawable.ic_arrow_back,
                     modifier = Modifier
                         .size(30.dp)
-                        .clicks { onNavigateBack() },
+                        .clicks { onNavigateBack() }.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ChangeNicknamePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ChangeNicknamePage.kt
@@ -112,7 +112,7 @@ private fun ChangeNicknameScreen(
                     R.drawable.ic_arrow_back,
                     modifier = Modifier
                         .size(30.dp)
-                        .clicks { onNavigateBack() }.size(30.dp),
+                        .clicks { onNavigateBack() },
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ChangeNicknamePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ChangeNicknamePage.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.EditText
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
@@ -109,10 +108,11 @@ private fun ChangeNicknameScreen(
                 )
             },
             navigationIcon = {
-                ArrowBackIcon(
+                SnuttIcon(
+                    R.drawable.ic_arrow_back,
                     modifier = Modifier
                         .size(30.dp)
-                        .clicks { onNavigateBack() },
+                        .clicks { onNavigateBack() }.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ChangeNicknamePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ChangeNicknamePage.kt
@@ -41,8 +41,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
-import com.wafflestudio.snutt2.ui.components.compose.CloseCircleIcon
 import com.wafflestudio.snutt2.ui.components.compose.EditText
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clearFocusOnKeyboardDismiss
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -200,7 +200,8 @@ private fun NicknameEditText(
             textStyle = SNUTTTypography.body1.copy(fontSize = 16.sp),
         )
         if (isFocused && value.isNotEmpty()) {
-            CloseCircleIcon(
+            SnuttIcon(
+                R.drawable.ic_close_circle,
                 modifier = Modifier
                     .size(30.dp)
                     .clicks {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
@@ -38,7 +38,7 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.android.NetworkLog
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
-import com.wafflestudio.snutt2.ui.components.compose.DuplicateIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -120,7 +120,8 @@ private fun NetworkLogItem(log: NetworkLog) {
                 overflow = if (expanded.not()) TextOverflow.Ellipsis else TextOverflow.Visible,
                 maxLines = if (expanded.not()) 1 else Int.MAX_VALUE,
             )
-            DuplicateIcon(
+            SnuttIcon(
+                R.drawable.ic_duplicate,
                 modifier = Modifier
                     .size(20.dp)
                     .clicks {
@@ -171,7 +172,8 @@ private fun SimpleTextToggle(
                 .padding(10.dp),
         ) {
             Text(text = content, style = SNUTTTypography.body1)
-            DuplicateIcon(
+            SnuttIcon(
+                R.drawable.ic_duplicate,
                 modifier = Modifier
                     .size(20.dp)
                     .align(Alignment.TopEnd)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.android.NetworkLog
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -60,8 +59,9 @@ fun NetworkLogPage(
                 Text(stringResource(R.string.debug_network_log_title), style = SNUTTTypography.h2)
             },
             navigationIcon = {
-                ArrowBackIcon(
-                    modifier = Modifier.clicks { onNavigateBack() },
+                SnuttIcon(
+                    R.drawable.ic_arrow_back,
+                    modifier = Modifier.clicks { onNavigateBack() }.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
@@ -37,7 +37,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.lib.android.NetworkLog
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
-import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -155,10 +154,12 @@ private fun SimpleTextToggle(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(text = title, style = SNUTTTypography.subtitle1)
-        ArrowDownIcon(
+        SnuttIcon(
+            R.drawable.ic_arrow_down,
             modifier = Modifier
                 .size(15.dp)
                 .rotate(rotation),
+            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
         )
     }
     AnimatedVisibility(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsComponents.kt
@@ -23,9 +23,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.wafflestudio.snutt2.ui.components.compose.PersonIcon
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.RedDotWithNumber
 import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -147,7 +148,8 @@ private fun SettingItem_WithLeadingIconAndContent() {
         SettingItem(
             title = "내 계정",
             leadingIcon = {
-                PersonIcon(
+                SnuttIcon(
+                    R.drawable.ic_person,
                     modifier = Modifier
                         .size(22.dp)
                         .padding(end = 5.dp),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsComponents.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.RedDotWithNumber
-import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -99,9 +98,11 @@ fun SettingItem(
         Spacer(modifier = Modifier.weight(1f))
         content()
         if (hasNextPage) {
-            RightArrowIcon(
+            SnuttIcon(
+                R.drawable.ic_arrow_right,
                 modifier = Modifier.size(22.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Black500),
+                contentDescription = "add arrow",
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
@@ -25,7 +25,6 @@ import com.wafflestudio.snutt2.config.FeatureFlag
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
-import com.wafflestudio.snutt2.ui.components.compose.HorizontalMoreIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -137,7 +136,8 @@ fun SettingsScreen(
                 )
             },
             navigationIcon = {
-                HorizontalMoreIcon(
+                SnuttIcon(
+                    R.drawable.ic_horizontal_more_unselected,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
@@ -26,7 +26,7 @@ import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.components.compose.HorizontalMoreIcon
-import com.wafflestudio.snutt2.ui.components.compose.PersonIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -154,7 +154,8 @@ fun SettingsScreen(
                 title = stringResource(R.string.user_settings_app_bar_title),
                 modifier = Modifier.height(66.dp),
                 leadingIcon = {
-                    PersonIcon(
+                    SnuttIcon(
+                        R.drawable.ic_person,
                         modifier = Modifier
                             .size(22.dp)
                             .padding(end = 5.dp),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ThemeModeSelectPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ThemeModeSelectPage.kt
@@ -19,8 +19,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.CheckedIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -68,7 +68,8 @@ private fun ColorModeSelectScreen(
                     onClick = { onSelectMode(ThemeMode.AUTO) },
                 ) {
                     if (themeMode == ThemeMode.AUTO) {
-                        CheckedIcon(
+                        SnuttIcon(
+                            R.drawable.checked,
                             modifier = Modifier.size(22.dp),
                             colorFilter = ColorFilter.tint(SNUTTColors.Black500),
                         )
@@ -80,7 +81,8 @@ private fun ColorModeSelectScreen(
                     onClick = { onSelectMode(ThemeMode.DARK) },
                 ) {
                     if (themeMode == ThemeMode.DARK) {
-                        CheckedIcon(
+                        SnuttIcon(
+                            R.drawable.checked,
                             modifier = Modifier.size(22.dp),
                             colorFilter = ColorFilter.tint(SNUTTColors.Black500),
                         )
@@ -92,7 +94,8 @@ private fun ColorModeSelectScreen(
                     onClick = { onSelectMode(ThemeMode.LIGHT) },
                 ) {
                     if (themeMode == ThemeMode.LIGHT) {
-                        CheckedIcon(
+                        SnuttIcon(
+                            R.drawable.checked,
                             modifier = Modifier.size(22.dp),
                             colorFilter = ColorFilter.tint(SNUTTColors.Black500),
                         )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/UserConfigPage.kt
@@ -23,8 +23,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.DuplicateIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -174,7 +174,8 @@ fun UserConfigScreen(
                     hasNextPage = false,
                     onClick = onCopyNicknameToClipboard,
                 ) {
-                    DuplicateIcon(
+                    SnuttIcon(
+                        R.drawable.ic_duplicate,
                         modifier = Modifier.size(30.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.Black500),
                     )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/tablelectures/TableLecturesScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/tablelectures/TableLecturesScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -31,10 +32,8 @@ import com.wafflestudio.snutt2.domain.model.LocalLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.ClockIcon
-import com.wafflestudio.snutt2.ui.components.compose.LocationIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
-import com.wafflestudio.snutt2.ui.components.compose.TagIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -135,7 +134,7 @@ fun TableLectureItem(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            TagIcon(modifier = Modifier.size(15.dp))
+            SnuttIcon(R.drawable.ic_tag, modifier = Modifier.size(15.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
             Spacer(Modifier.width(10.dp))
             Text(
                 text = tagText,
@@ -144,7 +143,7 @@ fun TableLectureItem(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            ClockIcon(modifier = Modifier.size(15.dp))
+            SnuttIcon(R.drawable.ic_clock, modifier = Modifier.size(15.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
             Spacer(Modifier.width(10.dp))
             Text(
                 text = classTimeText,
@@ -153,7 +152,7 @@ fun TableLectureItem(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            LocationIcon(modifier = Modifier.size(15.dp, 15.dp))
+            SnuttIcon(R.drawable.ic_location, modifier = Modifier.size(15.dp, 15.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
             Spacer(Modifier.width(10.dp))
             Text(
                 text = locationText,

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/CustomThemeMoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/CustomThemeMoreActionBottomSheet.kt
@@ -13,10 +13,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.MoreActionItem
-import com.wafflestudio.snutt2.ui.components.compose.PaletteIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TimetableIcon
-import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 
@@ -36,7 +34,8 @@ fun MyCustomThemeMoreActionBottomSheet(
     ) {
         MoreActionItem(
             icon = {
-                PaletteIcon(
+                SnuttIcon(
+                    R.drawable.ic_palette,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )
@@ -67,7 +66,8 @@ fun MyCustomThemeMoreActionBottomSheet(
         )
         MoreActionItem(
             icon = {
-                TrashIcon(
+                SnuttIcon(
+                    R.drawable.ic_trash,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )
@@ -93,7 +93,8 @@ fun MarketCustomThemeMoreActionBottomSheet(
     ) {
         MoreActionItem(
             icon = {
-                PaletteIcon(
+                SnuttIcon(
+                    R.drawable.ic_palette,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )
@@ -113,7 +114,8 @@ fun MarketCustomThemeMoreActionBottomSheet(
         )
         MoreActionItem(
             icon = {
-                TrashIcon(
+                SnuttIcon(
+                    R.drawable.ic_trash,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )
@@ -138,7 +140,8 @@ fun BuiltInThemeClickBottomSheet(
     ) {
         MoreActionItem(
             icon = {
-                PaletteIcon(
+                SnuttIcon(
+                    R.drawable.ic_palette,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/CustomThemeMoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/CustomThemeMoreActionBottomSheet.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.components.compose.MoreActionItem
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
-import com.wafflestudio.snutt2.ui.components.compose.TimetableIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 
@@ -45,7 +44,8 @@ fun MyCustomThemeMoreActionBottomSheet(
         )
         MoreActionItem(
             icon = {
-                TimetableIcon(
+                SnuttIcon(
+                    R.drawable.ic_timetable_unselected,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )
@@ -104,7 +104,8 @@ fun MarketCustomThemeMoreActionBottomSheet(
         )
         MoreActionItem(
             icon = {
-                TimetableIcon(
+                SnuttIcon(
+                    R.drawable.ic_timetable_unselected,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )
@@ -151,7 +152,8 @@ fun BuiltInThemeClickBottomSheet(
         )
         MoreActionItem(
             icon = {
-                TimetableIcon(
+                SnuttIcon(
+                    R.drawable.ic_timetable_unselected,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/CustomThemeMoreActionBottomSheet.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/CustomThemeMoreActionBottomSheet.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.components.compose.DuplicateIcon
 import com.wafflestudio.snutt2.ui.components.compose.MoreActionItem
 import com.wafflestudio.snutt2.ui.components.compose.PaletteIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TimetableIcon
 import com.wafflestudio.snutt2.ui.components.compose.TrashIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -56,7 +56,8 @@ fun MyCustomThemeMoreActionBottomSheet(
         )
         MoreActionItem(
             icon = {
-                DuplicateIcon(
+                SnuttIcon(
+                    R.drawable.ic_duplicate,
                     modifier = Modifier.size(30.dp),
                     colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
                 )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/ThemeConfigComponents.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/ThemeConfigComponents.kt
@@ -36,8 +36,7 @@ import com.wafflestudio.snutt2.domain.model.BuiltInTheme
 import com.wafflestudio.snutt2.domain.model.TableTheme
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.feature.settings.SettingColumn
-import com.wafflestudio.snutt2.ui.components.compose.AddIcon
-import com.wafflestudio.snutt2.ui.components.compose.QuestionCircleIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.ThemeIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.components.compose.displayName
@@ -103,7 +102,8 @@ fun AddThemeItem(
                 .size(80.dp)
                 .background(color = SNUTTColors.VacancyGray, shape = RoundedCornerShape(6.dp)),
         ) {
-            AddIcon(
+            SnuttIcon(
+                R.drawable.ic_add,
                 modifier = Modifier
                     .size(30.dp)
                     .align(Alignment.Center),
@@ -166,7 +166,8 @@ internal fun ThemeGuideTexts(
     )
     Column(modifier = modifier) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            QuestionCircleIcon(
+            SnuttIcon(
+                R.drawable.ic_question_circle,
                 modifier = Modifier.size(14.dp),
                 colorFilter = ColorFilter.tint(if (isDarkMode()) SNUTTColors.DarkGray else SNUTTColors.Gray2),
             )

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/ThemeDetailComponents.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/themeconfig/ThemeDetailComponents.kt
@@ -32,12 +32,11 @@ import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.ThemeColor
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
-import com.wafflestudio.snutt2.ui.components.compose.CloseIcon
 import com.wafflestudio.snutt2.ui.components.compose.ColorBox
 import com.wafflestudio.snutt2.ui.components.compose.ColorCircle
 import com.wafflestudio.snutt2.ui.components.compose.ColorPicker
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
-import com.wafflestudio.snutt2.ui.components.compose.DuplicateIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -81,7 +80,8 @@ internal fun ThemeColorRow(
                 },
                 actions = {
                     if (isEditable) {
-                        DuplicateIcon(
+                        SnuttIcon(
+                            R.drawable.ic_duplicate,
                             modifier = Modifier
                                 .size(30.dp)
                                 .clicks {
@@ -94,7 +94,8 @@ internal fun ThemeColorRow(
                             ),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        CloseIcon(
+                        SnuttIcon(
+                            R.drawable.ic_close,
                             modifier = Modifier
                                 .size(30.dp)
                                 .clicks {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyListItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyListItem.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -36,10 +37,8 @@ import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.lib.Selectable
 import com.wafflestudio.snutt2.lib.toDataWithState
-import com.wafflestudio.snutt2.ui.components.compose.ClockIcon
-import com.wafflestudio.snutt2.ui.components.compose.LocationIcon
 import com.wafflestudio.snutt2.ui.components.compose.RoundCheckbox
-import com.wafflestudio.snutt2.ui.components.compose.TagIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
@@ -145,10 +144,12 @@ fun LazyItemScope.VacancyListItem(
                             .weight(1f),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        TagIcon(
+                        SnuttIcon(
+                            R.drawable.ic_tag,
                             modifier = Modifier
                                 .padding(top = 2.dp) // 태그 텍스트의 알 수 없는 수직 위치 때문에 쓴 꼼수
                                 .size(13.dp),
+                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                         )
                         Spacer(modifier = Modifier.width(7.dp))
                         Text(
@@ -176,8 +177,10 @@ fun LazyItemScope.VacancyListItem(
                     modifier = Modifier.padding(bottom = 6.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ClockIcon(
+                    SnuttIcon(
+                        R.drawable.ic_clock,
                         modifier = Modifier.size(13.dp),
+                        colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                     Spacer(modifier = Modifier.width(7.dp))
                     Text(
@@ -191,8 +194,10 @@ fun LazyItemScope.VacancyListItem(
                     )
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    LocationIcon(
+                    SnuttIcon(
+                        R.drawable.ic_location,
                         modifier = Modifier.size(13.dp),
+                        colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                     Spacer(modifier = Modifier.width(7.dp))
                     Text(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
@@ -67,10 +67,9 @@ import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
-import com.wafflestudio.snutt2.ui.components.compose.QuestionCircleIcon
 import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
-import com.wafflestudio.snutt2.ui.components.compose.TipCloseIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.WebViewStyleButton
 import com.wafflestudio.snutt2.ui.components.compose.clicks
@@ -269,7 +268,8 @@ fun VacancyEmpty(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Spacer(modifier = Modifier.size(5.dp))
-                    QuestionCircleIcon(
+                    SnuttIcon(
+                        R.drawable.ic_question_circle,
                         modifier = Modifier
                             .size(18.dp)
                             .clicks { onShowIntroDialog() },
@@ -342,7 +342,8 @@ fun VacancyPlaceholder(
                 .clicks { onClickDetail() },
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            QuestionCircleIcon(
+            SnuttIcon(
+                R.drawable.ic_question_circle,
                 modifier = Modifier.size(12.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.DARKER_GRAY),
             )
@@ -394,7 +395,8 @@ fun VacancySuccess(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Spacer(modifier = Modifier.size(5.dp))
-                    QuestionCircleIcon(
+                    SnuttIcon(
+                        R.drawable.ic_question_circle,
                         modifier = Modifier
                             .size(18.dp)
                             .clicks { onShowIntroDialog() },
@@ -549,7 +551,8 @@ fun VacancyIntroDialog(
                         modifier = Modifier.padding(start = 24.dp, end = 24.dp, top = 24.dp),
                     ) {
                         Spacer(modifier = Modifier.weight(1f))
-                        TipCloseIcon(
+                        SnuttIcon(
+                            R.drawable.btntipclose,
                             modifier = Modifier
                                 .size(15.dp)
                                 .clicks { onDismiss() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
@@ -67,7 +67,6 @@ import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
-import com.wafflestudio.snutt2.ui.components.compose.RightArrowIcon
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
@@ -608,7 +607,8 @@ fun VacancyIntroDialog(
                             )
                         }
                         if (pagerState.currentPage < 3) {
-                            RightArrowIcon(
+                            SnuttIcon(
+                                R.drawable.ic_arrow_right,
                                 modifier = Modifier
                                     .align(Alignment.CenterEnd)
                                     .size(30.dp)
@@ -618,6 +618,7 @@ fun VacancyIntroDialog(
                                         }
                                     },
                                 colorFilter = ColorFilter.tint(SNUTTColors.VacancyGray),
+                                contentDescription = "add arrow",
                             )
                         }
                     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
@@ -278,7 +278,7 @@ fun VacancyEmpty(
                         R.drawable.ic_arrow_back,
                         modifier = Modifier
                             .size(30.dp)
-                            .clicks { onClickBack() }.size(30.dp),
+                            .clicks { onClickBack() },
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                 },
@@ -406,7 +406,7 @@ fun VacancySuccess(
                         R.drawable.ic_arrow_back,
                         modifier = Modifier
                             .size(30.dp)
-                            .clicks { onClickBack() }.size(30.dp),
+                            .clicks { onClickBack() },
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                 },
@@ -604,7 +604,7 @@ fun VacancyIntroDialog(
                                         scope.launch {
                                             pagerState.animateScrollToPage(pagerState.currentPage - 1)
                                         }
-                                    }.size(30.dp),
+                                    },
                                 colorFilter = ColorFilter.tint(SNUTTColors.VacancyGray),
                             )
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/vacancynoti/VacancyScreen.kt
@@ -65,7 +65,6 @@ import com.wafflestudio.snutt2.domain.model.preview.PreviewData
 import com.wafflestudio.snutt2.lib.toDataWithState
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
-import com.wafflestudio.snutt2.ui.components.compose.ArrowBackIcon
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
@@ -275,10 +274,11 @@ fun VacancyEmpty(
                     )
                 },
                 navigationIcon = {
-                    ArrowBackIcon(
+                    SnuttIcon(
+                        R.drawable.ic_arrow_back,
                         modifier = Modifier
                             .size(30.dp)
-                            .clicks { onClickBack() },
+                            .clicks { onClickBack() }.size(30.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                 },
@@ -402,10 +402,11 @@ fun VacancySuccess(
                     )
                 },
                 navigationIcon = {
-                    ArrowBackIcon(
+                    SnuttIcon(
+                        R.drawable.ic_arrow_back,
                         modifier = Modifier
                             .size(30.dp)
-                            .clicks { onClickBack() },
+                            .clicks { onClickBack() }.size(30.dp),
                         colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                     )
                 },
@@ -594,7 +595,8 @@ fun VacancyIntroDialog(
                         }
 
                         if (pagerState.currentPage > 0) {
-                            ArrowBackIcon(
+                            SnuttIcon(
+                                R.drawable.ic_arrow_back,
                                 modifier = Modifier
                                     .align(Alignment.CenterStart)
                                     .size(30.dp)
@@ -602,7 +604,7 @@ fun VacancyIntroDialog(
                                         scope.launch {
                                             pagerState.animateScrollToPage(pagerState.currentPage - 1)
                                         }
-                                    },
+                                    }.size(30.dp),
                                 colorFilter = ColorFilter.tint(SNUTTColors.VacancyGray),
                             )
                         }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/IOSStyleTopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/IOSStyleTopBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -16,6 +17,7 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -51,8 +53,10 @@ fun IOSStyleTopBar(
             modifier = Modifier.clicks(1000L) { onBack() },
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            ArrowBackIcon(
+            SnuttIcon(
+                R.drawable.ic_arrow_back,
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                modifier = Modifier.size(30.dp),
             )
             AnimatedContent(backButtonText, label = "") {
                 Text(

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -43,16 +43,6 @@ fun DrawerIcon(
 }
 
 @Composable
-fun ListIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_lecture_list,
-        modifier = modifier.size(30.dp),
-    )
-}
-
-@Composable
 fun NotificationIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
@@ -25,79 +24,6 @@ fun SnuttIcon(
         modifier = modifier,
         painter = painterResource(id = id),
         contentDescription = contentDescription,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun DrawerIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_drawer,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-        contentDescription = stringResource(R.string.home_timetable_drawer),
-    )
-}
-
-@Composable
-fun NotificationIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_alarm_default,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ShareIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_share,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ArrowBackIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_arrow_back,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun FilterIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_filter,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ExitIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_exit,
-        modifier = modifier.size(30.dp),
         colorFilter = colorFilter,
     )
 }
@@ -189,42 +115,6 @@ fun RingingAlarmIcon(
     SnuttIcon(
         id = if (marked) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
         modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun NotificationVacancyIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_ringing_alarm_notification,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun NotificationFriendIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_ringing_alarm_notification,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun NotificationTrashIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_trash_new,
-        modifier = modifier.size(30.dp),
         colorFilter = colorFilter,
     )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -1,26 +1,18 @@
 package com.wafflestudio.snutt2.ui.components.compose
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
-import com.wafflestudio.snutt2.ui.theme.isDarkMode
 
 @Composable
 fun SnuttIcon(
@@ -167,18 +159,6 @@ fun LogoIcon(
 }
 
 @Composable
-fun ArrowUpIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_arrow_up,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun ArrowDownIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
@@ -283,30 +263,6 @@ fun PaletteIcon(
 }
 
 @Composable
-fun PinIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_pin,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun PinOffIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_pin_off,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun TimetableIcon(
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
@@ -395,19 +351,6 @@ fun ThickReviewIcon(
 }
 
 @Composable
-fun SettingIcon(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (isSelected) R.drawable.ic_setting_selected else R.drawable.ic_setting_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun HorizontalMoreIcon(
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
@@ -481,45 +424,6 @@ fun SendIcon(
 }
 
 @Composable
-fun RedDot() {
-    Canvas(modifier = Modifier.size(5.dp)) {
-        drawCircle(SNUTTColors.Red)
-    }
-}
-
-@Composable
-fun RedDotWithNumber(
-    modifier: Modifier = Modifier,
-    number: Long,
-) {
-    Canvas(
-        modifier = modifier.size(16.dp),
-    ) {
-        drawCircle(
-            color = SNUTTColors.Red,
-            radius = size.minDimension / 2,
-        )
-
-        drawContext.canvas.nativeCanvas.apply {
-            val text = number.toString()
-
-            val paint = android.graphics.Paint().apply {
-                color = android.graphics.Color.WHITE
-                textAlign = android.graphics.Paint.Align.CENTER
-                isAntiAlias = true
-                textSize = size.minDimension * 0.7f
-                typeface = android.graphics.Typeface.DEFAULT_BOLD
-            }
-
-            val x = size.width / 2
-            val y = size.height / 2 - (paint.descent() + paint.ascent()) / 2
-
-            drawText(text, x, y, paint)
-        }
-    }
-}
-
-@Composable
 fun BigSearchIcon(
     modifier: Modifier = Modifier,
 ) {
@@ -548,19 +452,6 @@ fun AlarmOnIcon(
     SnuttIcon(
         id = R.drawable.tab_alarm_on,
         modifier = modifier,
-    )
-}
-
-@Composable
-fun LectureListIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_lecture_list,
-        modifier = modifier,
-        colorFilter = colorFilter,
-        contentDescription = stringResource(R.string.home_timetable_drawer),
     )
 }
 
@@ -599,82 +490,6 @@ fun BookmarkIcon(
         modifier = modifier,
         colorFilter = colorFilter,
     )
-}
-
-@Composable
-fun BookmarkPageIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_bookmark_page,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun IconWithAlertDot(
-    redDotExist: Boolean = false,
-    dotSize: Dp = 5.dp,
-    dotYOffset: Dp = 0.dp,
-    color: Color = SNUTTColors.Red,
-    content: @Composable (Modifier) -> Unit,
-) {
-    Box {
-        content(Modifier.align(Alignment.Center))
-        if (redDotExist) {
-            Canvas(
-                modifier = Modifier
-                    .size(dotSize)
-                    .align(Alignment.TopEnd)
-                    .offset(y = dotYOffset),
-            ) {
-                drawCircle(color)
-            }
-        }
-    }
-}
-
-@Composable
-fun IconWithAlertDotNumber(
-    modifier: Modifier = Modifier,
-    redDotNumber: Long = 0,
-    content: @Composable (Modifier) -> Unit,
-) {
-    Box {
-        content(Modifier.align(Alignment.Center))
-        if (redDotNumber > 0) {
-            Canvas(
-                modifier = Modifier
-                    .size(16.dp)
-                    .align(Alignment.TopEnd)
-                    .offset(x = 9.dp, y = (-5).dp),
-            ) {
-                drawCircle(
-                    color = SNUTTColors.Red,
-                    radius = size.minDimension / 2,
-                )
-
-                drawContext.canvas.nativeCanvas.apply {
-                    val text = redDotNumber.toString()
-
-                    val paint = android.graphics.Paint().apply {
-                        color = android.graphics.Color.WHITE
-                        textAlign = android.graphics.Paint.Align.CENTER
-                        isAntiAlias = true
-                        textSize = size.minDimension * 0.7f
-                        typeface = android.graphics.Typeface.DEFAULT_BOLD
-                    }
-
-                    val x = size.width / 2
-                    val y = size.height / 2 - (paint.descent() + paint.ascent()) / 2
-
-                    drawText(text, x, y, paint)
-                }
-            }
-        }
-    }
 }
 
 @Composable
@@ -884,16 +699,6 @@ fun NotificationTrashIcon(
 }
 
 @Composable
-fun CustomThemeMoreIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = if (isDarkMode()) R.drawable.ic_custom_theme_more_dark else R.drawable.ic_custom_theme_more,
-        modifier = modifier,
-    )
-}
-
-@Composable
 fun ArrowLeftBold(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
@@ -952,38 +757,6 @@ fun FriendHashIcon(
         modifier = modifier,
         colorFilter = colorFilter,
     )
-}
-
-@SnuttPreview
-@Composable
-private fun RedDot_Default() {
-    SnuttPreviewSurface {
-        Box(modifier = Modifier.size(20.dp), contentAlignment = Alignment.Center) {
-            RedDot()
-        }
-    }
-}
-
-@SnuttPreview
-@Composable
-private fun RedDotWithNumber_Default() {
-    SnuttPreviewSurface {
-        Box(modifier = Modifier.size(30.dp), contentAlignment = Alignment.Center) {
-            RedDotWithNumber(number = 3)
-        }
-    }
-}
-
-@SnuttPreview
-@Composable
-private fun IconWithAlertDot_Default() {
-    SnuttPreviewSurface {
-        Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
-            IconWithAlertDot(redDotExist = true) {
-                NotificationIcon(modifier = it.size(30.dp))
-            }
-        }
-    }
 }
 
 @SnuttPreview

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -103,102 +103,6 @@ fun ExitIcon(
 }
 
 @Composable
-fun TagIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_tag,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ClockIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_clock,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun LocationIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_location,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ArrowDownIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_arrow_down,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun WriteIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_write,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun WriteUnderlineIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_write_underline,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun TrashIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_trash,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun PaletteIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_palette,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun TimetableIcon(
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
@@ -271,31 +175,6 @@ fun BookmarkIcon(
 ) {
     SnuttIcon(
         id = if (marked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun RightArrowIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_arrow_right,
-        modifier = modifier,
-        colorFilter = colorFilter,
-        contentDescription = "add arrow",
-    )
-}
-
-@Composable
-fun RemarkIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_remark,
         modifier = modifier,
         colorFilter = colorFilter,
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.ui.components.compose
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
@@ -22,15 +23,30 @@ import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.isDarkMode
 
 @Composable
+fun SnuttIcon(
+    @DrawableRes id: Int,
+    modifier: Modifier = Modifier,
+    colorFilter: ColorFilter? = null,
+    contentDescription: String? = null,
+) {
+    Image(
+        modifier = modifier,
+        painter = painterResource(id = id),
+        contentDescription = contentDescription,
+        colorFilter = colorFilter,
+    )
+}
+
+@Composable
 fun DrawerIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_drawer,
         modifier = modifier.size(30.dp),
-        painter = painterResource(id = R.drawable.ic_drawer),
-        contentDescription = stringResource(R.string.home_timetable_drawer),
         colorFilter = colorFilter,
+        contentDescription = stringResource(R.string.home_timetable_drawer),
     )
 }
 
@@ -38,10 +54,9 @@ fun DrawerIcon(
 fun ListIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_lecture_list,
         modifier = modifier.size(30.dp),
-        painter = painterResource(id = R.drawable.ic_lecture_list),
-        contentDescription = "",
     )
 }
 
@@ -50,10 +65,9 @@ fun NotificationIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_alarm_default,
         modifier = modifier.size(30.dp),
-        painter = painterResource(R.drawable.ic_alarm_default),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -63,10 +77,9 @@ fun ShareIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_share,
         modifier = modifier.size(30.dp),
-        painter = painterResource(id = R.drawable.ic_share),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -76,10 +89,9 @@ fun ArrowBackIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_arrow_back,
         modifier = modifier.size(30.dp),
-        painter = painterResource(id = R.drawable.ic_arrow_back),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -89,10 +101,9 @@ fun SearchIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_search_unselected,
         modifier = modifier.size(30.dp),
-        painter = painterResource(id = R.drawable.ic_search_unselected),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -102,10 +113,9 @@ fun FilterIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_filter,
         modifier = modifier.size(30.dp),
-        painter = painterResource(id = R.drawable.ic_filter),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -115,10 +125,9 @@ fun ExitIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_exit,
         modifier = modifier.size(30.dp),
-        painter = painterResource(R.drawable.ic_exit),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -128,10 +137,9 @@ fun TagIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_tag,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_tag),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -141,10 +149,9 @@ fun ClockIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_clock,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_clock),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -154,10 +161,9 @@ fun LocationIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_location,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_location),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -166,10 +172,9 @@ fun LocationIcon(
 fun LogoIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.logo,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.logo),
-        contentDescription = "",
     )
 }
 
@@ -178,10 +183,9 @@ fun ArrowUpIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_arrow_up,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_arrow_up),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -191,10 +195,9 @@ fun ArrowDownIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_arrow_down,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_arrow_down),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -203,10 +206,9 @@ fun ArrowDownIcon(
 fun VividCheckedIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_vivid_checked,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_vivid_checked),
-        contentDescription = "",
     )
 }
 
@@ -214,10 +216,9 @@ fun VividCheckedIcon(
 fun VividUncheckedIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_vivid_unchecked,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_vivid_unchecked),
-        contentDescription = "",
     )
 }
 
@@ -226,10 +227,9 @@ fun DuplicateIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_duplicate,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_duplicate),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -239,10 +239,9 @@ fun MoreIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_more,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_more),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -252,10 +251,9 @@ fun WriteIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_write,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_write),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -265,10 +263,9 @@ fun WriteUnderlineIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_write_underline,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_write_underline),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -278,10 +275,9 @@ fun TrashIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_trash,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_trash),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -291,10 +287,9 @@ fun PaletteIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_palette,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_palette),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -304,10 +299,9 @@ fun PinIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_pin,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_pin),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -317,10 +311,9 @@ fun PinOffIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_pin_off,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_pin_off),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -331,16 +324,9 @@ fun TimetableIcon(
     isSelected: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isSelected) R.drawable.ic_timetable_selected else R.drawable.ic_timetable_unselected,
         modifier = modifier,
-        painter = painterResource(
-            if (isSelected) {
-                R.drawable.ic_timetable_selected
-            } else {
-                R.drawable.ic_timetable_unselected
-            },
-        ),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -351,16 +337,9 @@ fun SearchIcon(
     isSelected: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isSelected) R.drawable.ic_search_selected else R.drawable.ic_search_unselected,
         modifier = modifier,
-        painter = painterResource(
-            if (isSelected) {
-                R.drawable.ic_search_selected
-            } else {
-                R.drawable.ic_search_unselected
-            },
-        ),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -371,16 +350,9 @@ fun ReviewIcon(
     isSelected: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isSelected) R.drawable.ic_review_selected else R.drawable.ic_review_unselected,
         modifier = modifier,
-        painter = painterResource(
-            if (isSelected) {
-                R.drawable.ic_review_selected
-            } else {
-                R.drawable.ic_review_unselected
-            },
-        ),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -391,16 +363,9 @@ fun BigPeopleIcon(
     isSelected: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isSelected) R.drawable.ic_people_selected else R.drawable.ic_people_unselected,
         modifier = modifier,
-        painter = painterResource(
-            if (isSelected) {
-                R.drawable.ic_people_selected
-            } else {
-                R.drawable.ic_people_unselected
-            },
-        ),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -410,10 +375,9 @@ fun PeopleIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_people_on,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_people_on),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -423,10 +387,9 @@ fun PeopleOffIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_people_off,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_people_off),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -436,10 +399,9 @@ fun ThickReviewIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_review_thick,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_review_thick),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -450,16 +412,9 @@ fun SettingIcon(
     isSelected: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isSelected) R.drawable.ic_setting_selected else R.drawable.ic_setting_unselected,
         modifier = modifier,
-        painter = painterResource(
-            if (isSelected) {
-                R.drawable.ic_setting_selected
-            } else {
-                R.drawable.ic_setting_unselected
-            },
-        ),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -470,16 +425,9 @@ fun HorizontalMoreIcon(
     isSelected: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isSelected) R.drawable.ic_horizontal_more_selected else R.drawable.ic_horizontal_more_unselected,
         modifier = modifier,
-        painter = painterResource(
-            if (isSelected) {
-                R.drawable.ic_horizontal_more_selected
-            } else {
-                R.drawable.ic_horizontal_more_unselected
-            },
-        ),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -489,10 +437,9 @@ fun TipCloseIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.btntipclose,
         modifier = modifier,
-        painter = painterResource(R.drawable.btntipclose),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -502,10 +449,9 @@ fun ArrowRight(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.arrowright,
         modifier = modifier,
-        painter = painterResource(R.drawable.arrowright),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -515,10 +461,9 @@ fun CheckedIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.checked,
         modifier = modifier,
-        painter = painterResource(R.drawable.checked),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -528,10 +473,9 @@ fun CloseIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_close,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_close),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -541,11 +485,10 @@ fun SendIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_send,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_send),
         colorFilter = colorFilter,
-        contentDescription = "",
     )
 }
 
@@ -592,10 +535,9 @@ fun RedDotWithNumber(
 fun BigSearchIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.img_search_big,
         modifier = modifier,
-        painter = painterResource(R.drawable.img_search_big),
-        contentDescription = "",
     )
 }
 
@@ -604,10 +546,9 @@ fun WarningIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_warning,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_warning),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -616,10 +557,9 @@ fun WarningIcon(
 fun AlarmOnIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.tab_alarm_on,
         modifier = modifier,
-        painter = painterResource(R.drawable.tab_alarm_on),
-        contentDescription = "",
     )
 }
 
@@ -628,11 +568,11 @@ fun LectureListIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_lecture_list,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_lecture_list),
-        contentDescription = stringResource(R.string.home_timetable_drawer),
         colorFilter = colorFilter,
+        contentDescription = stringResource(R.string.home_timetable_drawer),
     )
 }
 
@@ -641,10 +581,9 @@ fun CalendarIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_calendar,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_calendar),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -654,10 +593,9 @@ fun RefreshTimeIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_refresh_time,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_refresh_time),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -668,10 +606,9 @@ fun BookmarkIcon(
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
     marked: Boolean = false,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (marked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,
         modifier = modifier,
-        painter = painterResource(id = if (marked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -681,10 +618,9 @@ fun BookmarkPageIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_bookmark_page,
         modifier = modifier.size(30.dp),
-        painter = painterResource(R.drawable.ic_bookmark_page),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -758,11 +694,11 @@ fun RightArrowIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_arrow_right,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_arrow_right),
-        contentDescription = "add arrow",
         colorFilter = colorFilter,
+        contentDescription = "add arrow",
     )
 }
 
@@ -771,10 +707,9 @@ fun RemarkIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_remark,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_remark),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -784,10 +719,9 @@ fun PersonIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_person,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_person),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -797,10 +731,9 @@ fun DetailIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_detail,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_detail),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -811,10 +744,9 @@ fun RingingAlarmIcon(
     colorFilter: ColorFilter? = null,
     marked: Boolean = false,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (marked) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
         modifier = modifier,
-        painter = painterResource(id = if (marked) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -824,10 +756,9 @@ fun AddCircleIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_add_circle,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_add_circle),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -837,10 +768,9 @@ fun RemoveCircleIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_remove_circle,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_remove_circle),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -850,10 +780,9 @@ fun QuestionCircleIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_question_circle,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_question_circle),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -863,10 +792,9 @@ fun CloseCircleIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_close_circle,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_close_circle),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -876,10 +804,9 @@ fun MagicIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_magic,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_magic),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -889,10 +816,9 @@ fun AddIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_add,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_add),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -902,10 +828,9 @@ fun MapIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_map,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_map),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -915,10 +840,9 @@ fun ResetIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_reset,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_reset),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -928,10 +852,9 @@ fun MegaphoneIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_megaphone,
         modifier = modifier,
-        painter = painterResource(id = R.drawable.ic_megaphone),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -941,10 +864,9 @@ fun NotificationVacancyIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_ringing_alarm_notification,
         modifier = modifier.size(30.dp),
-        painter = painterResource(R.drawable.ic_ringing_alarm_notification),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -954,10 +876,9 @@ fun NotificationFriendIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_ringing_alarm_notification,
         modifier = modifier.size(30.dp),
-        painter = painterResource(R.drawable.ic_ringing_alarm_notification),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -967,10 +888,9 @@ fun NotificationTrashIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_trash_new,
         modifier = modifier.size(30.dp),
-        painter = painterResource(R.drawable.ic_trash_new),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -979,12 +899,9 @@ fun NotificationTrashIcon(
 fun CustomThemeMoreIcon(
     modifier: Modifier = Modifier,
 ) {
-    Image(
+    SnuttIcon(
+        id = if (isDarkMode()) R.drawable.ic_custom_theme_more_dark else R.drawable.ic_custom_theme_more,
         modifier = modifier,
-        painter = painterResource(
-            if (isDarkMode()) R.drawable.ic_custom_theme_more_dark else R.drawable.ic_custom_theme_more,
-        ),
-        contentDescription = "",
     )
 }
 
@@ -993,10 +910,9 @@ fun ArrowLeftBold(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.arrow_left_bold,
         modifier = modifier,
-        painter = painterResource(R.drawable.arrow_left_bold),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -1007,21 +923,11 @@ fun StarIcon(
     filled: Boolean = false,
     colorFilter: ColorFilter? = null,
 ) {
-    if (filled) {
-        Image(
-            modifier = modifier,
-            painter = painterResource(R.drawable.ic_star_filled),
-            contentDescription = "",
-            colorFilter = colorFilter,
-        )
-    } else {
-        Image(
-            modifier = modifier,
-            painter = painterResource(R.drawable.ic_star_outline),
-            contentDescription = "",
-            colorFilter = colorFilter,
-        )
-    }
+    SnuttIcon(
+        id = if (filled) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
+        modifier = modifier,
+        colorFilter = colorFilter,
+    )
 }
 
 @Composable
@@ -1029,10 +935,9 @@ fun ChevronIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_arrow_right,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_arrow_right),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -1042,10 +947,9 @@ fun AddFriendIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_user_add,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_user_add),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -1055,10 +959,9 @@ fun KakaoTalkIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_kakao_talk,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_kakao_talk),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }
@@ -1068,10 +971,9 @@ fun FriendHashIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
 ) {
-    Image(
+    SnuttIcon(
+        id = R.drawable.ic_friend_hash,
         modifier = modifier,
-        painter = painterResource(R.drawable.ic_friend_hash),
-        contentDescription = "",
         colorFilter = colorFilter,
     )
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -139,66 +139,12 @@ fun LocationIcon(
 }
 
 @Composable
-fun LogoIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = R.drawable.logo,
-        modifier = modifier,
-    )
-}
-
-@Composable
 fun ArrowDownIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
 ) {
     SnuttIcon(
         id = R.drawable.ic_arrow_down,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun VividCheckedIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_vivid_checked,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun VividUncheckedIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_vivid_unchecked,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun DuplicateIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_duplicate,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun MoreIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_more,
         modifier = modifier,
         colorFilter = colorFilter,
     )
@@ -305,42 +251,6 @@ fun BigPeopleIcon(
 }
 
 @Composable
-fun PeopleIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_people_on,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun PeopleOffIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_people_off,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ThickReviewIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_review_thick,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun HorizontalMoreIcon(
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
@@ -348,122 +258,6 @@ fun HorizontalMoreIcon(
 ) {
     SnuttIcon(
         id = if (isSelected) R.drawable.ic_horizontal_more_selected else R.drawable.ic_horizontal_more_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun TipCloseIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.btntipclose,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ArrowRight(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.arrowright,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun CheckedIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.checked,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun CloseIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_close,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun SendIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_send,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun BigSearchIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = R.drawable.img_search_big,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun WarningIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_warning,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun AlarmOnIcon(
-    modifier: Modifier = Modifier,
-) {
-    SnuttIcon(
-        id = R.drawable.tab_alarm_on,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun CalendarIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_calendar,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun RefreshTimeIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_refresh_time,
         modifier = modifier,
         colorFilter = colorFilter,
     )
@@ -508,30 +302,6 @@ fun RemarkIcon(
 }
 
 @Composable
-fun PersonIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_person,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun DetailIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_detail,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun RingingAlarmIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = null,
@@ -539,114 +309,6 @@ fun RingingAlarmIcon(
 ) {
     SnuttIcon(
         id = if (marked) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun AddCircleIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_add_circle,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun RemoveCircleIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_remove_circle,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun QuestionCircleIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_question_circle,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun CloseCircleIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_close_circle,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun MagicIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_magic,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun AddIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_add,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun MapIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_map,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ResetIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_reset,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun MegaphoneIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_megaphone,
         modifier = modifier,
         colorFilter = colorFilter,
     )
@@ -689,18 +351,6 @@ fun NotificationTrashIcon(
 }
 
 @Composable
-fun ArrowLeftBold(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.arrow_left_bold,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun StarIcon(
     modifier: Modifier = Modifier,
     filled: Boolean = false,
@@ -708,42 +358,6 @@ fun StarIcon(
 ) {
     SnuttIcon(
         id = if (filled) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun AddFriendIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_user_add,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun KakaoTalkIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_kakao_talk,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun FriendHashIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_friend_hash,
         modifier = modifier,
         colorFilter = colorFilter,
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -2,16 +2,10 @@ package com.wafflestudio.snutt2.ui.components.compose
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
-import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.ui.preview.SnuttPreview
-import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
-import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 
 @Composable
 fun SnuttIcon(
@@ -26,124 +20,4 @@ fun SnuttIcon(
         contentDescription = contentDescription,
         colorFilter = colorFilter,
     )
-}
-
-@Composable
-fun TimetableIcon(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (isSelected) R.drawable.ic_timetable_selected else R.drawable.ic_timetable_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun SearchIcon(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (isSelected) R.drawable.ic_search_selected else R.drawable.ic_search_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ReviewIcon(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (isSelected) R.drawable.ic_review_selected else R.drawable.ic_review_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun BigPeopleIcon(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (isSelected) R.drawable.ic_people_selected else R.drawable.ic_people_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun HorizontalMoreIcon(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (isSelected) R.drawable.ic_horizontal_more_selected else R.drawable.ic_horizontal_more_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun BookmarkIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-    marked: Boolean = false,
-) {
-    SnuttIcon(
-        id = if (marked) R.drawable.ic_bookmark_selected else R.drawable.ic_bookmark_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun RingingAlarmIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-    marked: Boolean = false,
-) {
-    SnuttIcon(
-        id = if (marked) R.drawable.ic_ringing_alarm_selected else R.drawable.ic_ringing_alarm_unselected,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun StarIcon(
-    modifier: Modifier = Modifier,
-    filled: Boolean = false,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = if (filled) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@SnuttPreview
-@Composable
-private fun StarIcon_Filled() {
-    SnuttPreviewSurface {
-        StarIcon(modifier = Modifier.size(24.dp), filled = true)
-    }
-}
-
-@SnuttPreview
-@Composable
-private fun StarIcon_Empty() {
-    SnuttPreviewSurface {
-        StarIcon(modifier = Modifier.size(24.dp), filled = false)
-    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/Icon.kt
@@ -97,18 +97,6 @@ fun ArrowBackIcon(
 }
 
 @Composable
-fun SearchIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
-) {
-    SnuttIcon(
-        id = R.drawable.ic_search_unselected,
-        modifier = modifier.size(30.dp),
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
 fun FilterIcon(
     modifier: Modifier = Modifier,
     colorFilter: ColorFilter? = ColorFilter.tint(SNUTTColors.Black900),
@@ -925,18 +913,6 @@ fun StarIcon(
 ) {
     SnuttIcon(
         id = if (filled) R.drawable.ic_star_filled else R.drawable.ic_star_outline,
-        modifier = modifier,
-        colorFilter = colorFilter,
-    )
-}
-
-@Composable
-fun ChevronIcon(
-    modifier: Modifier = Modifier,
-    colorFilter: ColorFilter? = null,
-) {
-    SnuttIcon(
-        id = R.drawable.ic_arrow_right,
         modifier = modifier,
         colorFilter = colorFilter,
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/MoreActionItem.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/MoreActionItem.kt
@@ -11,7 +11,9 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -56,7 +58,7 @@ fun MoreActionItem(
 private fun MoreActionItem_Enabled() {
     SnuttPreviewSurface {
         MoreActionItem(
-            icon = { TrashIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_trash, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = "친구 삭제",
             onClick = {},
         )
@@ -68,7 +70,7 @@ private fun MoreActionItem_Enabled() {
 private fun MoreActionItem_Disabled() {
     SnuttPreviewSurface {
         MoreActionItem(
-            icon = { TrashIcon(modifier = Modifier.size(30.dp)) },
+            icon = { SnuttIcon(R.drawable.ic_trash, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900)) },
             text = "친구 삭제",
             enabled = false,
             onClick = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/RedDot.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/RedDot.kt
@@ -1,0 +1,110 @@
+package com.wafflestudio.snutt2.ui.components.compose
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.wafflestudio.snutt2.ui.preview.SnuttPreview
+import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
+import com.wafflestudio.snutt2.ui.theme.SNUTTColors
+
+@Composable
+fun RedDot() {
+    Canvas(modifier = Modifier.size(5.dp)) {
+        drawCircle(SNUTTColors.Red)
+    }
+}
+
+@Composable
+fun RedDotWithNumber(
+    modifier: Modifier = Modifier,
+    number: Long,
+) {
+    Canvas(
+        modifier = modifier.size(16.dp),
+    ) {
+        drawCircle(
+            color = SNUTTColors.Red,
+            radius = size.minDimension / 2,
+        )
+
+        drawContext.canvas.nativeCanvas.apply {
+            val text = number.toString()
+
+            val paint = android.graphics.Paint().apply {
+                color = android.graphics.Color.WHITE
+                textAlign = android.graphics.Paint.Align.CENTER
+                isAntiAlias = true
+                textSize = size.minDimension * 0.7f
+                typeface = android.graphics.Typeface.DEFAULT_BOLD
+            }
+
+            val x = size.width / 2
+            val y = size.height / 2 - (paint.descent() + paint.ascent()) / 2
+
+            drawText(text, x, y, paint)
+        }
+    }
+}
+
+@Composable
+fun IconWithAlertDot(
+    redDotExist: Boolean = false,
+    dotSize: Dp = 5.dp,
+    dotYOffset: Dp = 0.dp,
+    color: Color = SNUTTColors.Red,
+    content: @Composable (Modifier) -> Unit,
+) {
+    Box {
+        content(Modifier.align(Alignment.Center))
+        if (redDotExist) {
+            Canvas(
+                modifier = Modifier
+                    .size(dotSize)
+                    .align(Alignment.TopEnd)
+                    .offset(y = dotYOffset),
+            ) {
+                drawCircle(color)
+            }
+        }
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun RedDot_Default() {
+    SnuttPreviewSurface {
+        Box(modifier = Modifier.size(20.dp), contentAlignment = Alignment.Center) {
+            RedDot()
+        }
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun RedDotWithNumber_Default() {
+    SnuttPreviewSurface {
+        Box(modifier = Modifier.size(30.dp), contentAlignment = Alignment.Center) {
+            RedDotWithNumber(number = 3)
+        }
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun IconWithAlertDot_Default() {
+    SnuttPreviewSurface {
+        Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+            IconWithAlertDot(redDotExist = true) {
+                NotificationIcon(modifier = it.size(30.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/RedDot.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/RedDot.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -103,7 +104,7 @@ private fun IconWithAlertDot_Default() {
     SnuttPreviewSurface {
         Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
             IconWithAlertDot(redDotExist = true) {
-                NotificationIcon(modifier = it.size(30.dp))
+                SnuttIcon(R.drawable.ic_alarm_default, modifier = it.size(30.dp))
             }
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/TopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -18,8 +19,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -43,8 +46,9 @@ fun SimpleTopBar(
             )
         },
         navigationIcon = {
-            ArrowBackIcon(
-                modifier = Modifier.clicks(1000L) { onClickNavigateBack() },
+            SnuttIcon(
+                R.drawable.ic_arrow_back,
+                modifier = Modifier.clicks(1000L) { onClickNavigateBack() }.size(30.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         },
@@ -155,11 +159,15 @@ private fun TopBar_TitleWithActions() {
                 )
             },
             navigationIcon = {
-                DrawerIcon()
+                SnuttIcon(R.drawable.ic_drawer, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900), contentDescription = stringResource(R.string.home_timetable_drawer))
             },
             actions = {
-                ShareIcon(Modifier.padding(end = 8.dp))
-                NotificationIcon(Modifier.padding(end = 12.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+                SnuttIcon(R.drawable.ic_share, Modifier.padding(end = 8.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+                SnuttIcon(
+                    R.drawable.ic_alarm_default,
+                    modifier = Modifier.padding(end = 12.dp).size(30.dp),
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                )
             },
         )
     }
@@ -185,10 +193,10 @@ private fun CenteredTopBar_TitleWithActions() {
                 )
             },
             navigationIcon = {
-                ArrowBackIcon(colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+                SnuttIcon(R.drawable.ic_arrow_back, colorFilter = ColorFilter.tint(SNUTTColors.Black900), modifier = Modifier.size(30.dp))
             },
             actions = {
-                FilterIcon()
+                SnuttIcon(R.drawable.ic_filter, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
             },
         )
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/TopBar.kt
@@ -158,7 +158,6 @@ private fun TopBar_TitleWithActions() {
                 DrawerIcon()
             },
             actions = {
-                ListIcon(Modifier.padding(end = 8.dp))
                 ShareIcon(Modifier.padding(end = 8.dp))
                 NotificationIcon(Modifier.padding(end = 12.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/TopBar.kt
@@ -48,7 +48,9 @@ fun SimpleTopBar(
         navigationIcon = {
             SnuttIcon(
                 R.drawable.ic_arrow_back,
-                modifier = Modifier.clicks(1000L) { onClickNavigateBack() }.size(30.dp),
+                modifier = Modifier
+                    .clicks(1000L) { onClickNavigateBack() }
+                    .size(30.dp),
                 colorFilter = ColorFilter.tint(SNUTTColors.Black900),
             )
         },
@@ -162,10 +164,18 @@ private fun TopBar_TitleWithActions() {
                 SnuttIcon(R.drawable.ic_drawer, modifier = Modifier.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900), contentDescription = stringResource(R.string.home_timetable_drawer))
             },
             actions = {
-                SnuttIcon(R.drawable.ic_share, Modifier.padding(end = 8.dp).size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+                SnuttIcon(
+                    R.drawable.ic_share,
+                    Modifier
+                        .padding(end = 8.dp)
+                        .size(30.dp),
+                    colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+                )
                 SnuttIcon(
                     R.drawable.ic_alarm_default,
-                    modifier = Modifier.padding(end = 12.dp).size(30.dp),
+                    modifier = Modifier
+                        .padding(end = 12.dp)
+                        .size(30.dp),
                     colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                 )
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/embedmap/FoldableEmbedMap.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/embedmap/FoldableEmbedMap.kt
@@ -17,11 +17,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Building
-import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
@@ -63,7 +63,7 @@ fun FoldableEmbedMap(
                         style = SNUTTTypography.body1.copy(color = SNUTTColors.DarkGray),
                         modifier = Modifier.padding(start = 8.dp, end = 4.dp),
                     )
-                    ArrowDownIcon(modifier = Modifier.size(24.dp))
+                    SnuttIcon(R.drawable.ic_arrow_down, modifier = Modifier.size(24.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
                 }
             }
             AnimatedVisibility(visible = embedMapFolded.not()) {
@@ -98,10 +98,12 @@ fun FoldableEmbedMap(
                             style = SNUTTTypography.body1.copy(color = SNUTTColors.DarkGray),
                             modifier = Modifier.padding(start = 8.dp, end = 4.dp),
                         )
-                        ArrowDownIcon(
+                        SnuttIcon(
+                            R.drawable.ic_arrow_down,
                             modifier = Modifier
                                 .size(24.dp)
                                 .rotate(180f),
+                            colorFilter = ColorFilter.tint(SNUTTColors.Black900),
                         )
                     }
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/embedmap/FoldableEmbedMap.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/embedmap/FoldableEmbedMap.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.Building
 import com.wafflestudio.snutt2.ui.components.compose.ArrowDownIcon
-import com.wafflestudio.snutt2.ui.components.compose.MapIcon
+import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
@@ -54,7 +54,8 @@ fun FoldableEmbedMap(
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    MapIcon(
+                    SnuttIcon(
+                        R.drawable.ic_map,
                         modifier = Modifier.size(17.dp, 19.dp),
                     )
                     Text(


### PR DESCRIPTION
## Summary
- 71개 Icon wrapper (DrawerIcon, ShareIcon, SearchIcon …) 를 모두 폐기하고 호출부에서 `SnuttIcon(R.drawable.xxx, modifier, colorFilter, contentDescription)` 직접 호출로 전환.
- `Icon.kt` 1126줄 → **23줄** (SnuttIcon 정의만), 비-아이콘 (RedDot, IconWithAlertDot 등) 은 `RedDot.kt` 로 분리.
- 호출부의 의도가 wrapper 이름 뒤에 숨던 것을 `R.drawable.xxx` + 명시적 `colorFilter`/`size` 로 드러냄. 후속 정책 변경 (다크모드 tint 등) 의 단일 진입점도 `SnuttIcon` 으로 확보.

## 변경 흐름 (commit 별로 끊어 진행)

1. `SnuttIcon` 공통 컴포넌트 도입 + 71개 wrapper 내부 치환 (호출부 변경 0)
2. SearchIcon 중복 정의 (ambiguous overload) 정리, ChevronIcon → RightArrowIcon 통합
3. 비-아이콘은 RedDot.kt 로 분리, 미사용 wrapper 8개 제거
4. preview 에서만 쓰이던 ListIcon 제거
5. 단순 wrapper 33개 인라인화 (size/분기/특수 contentDescription 없는 것들)
6. colorFilter `Black900` tint 기본값 wrapper 10개 인라인화 (호출부에서 colorFilter 명시)
7. size 강제 wrapper 9개 인라인화 (호출부 modifier 에 .size(30.dp) chain)
8. drawable 분기 wrapper 8개 인라인화 (isSelected/marked/filled → if/else 노출)
9. `.size(X).{...}.size(30)` dup 제거
10. 자동화 잔재 정리 (literal `if (true)` 분기 단순화, 빈 줄 정리), 시각 회귀 1건 수정

## 보존 정책 메모
- 모든 인라인화는 **시각 동작 보존** 우선. wrapper 가 강제하던 `.size(30.dp)` chain 은 호출부 modifier 끝에 그대로 추가했고, 호출자가 이미 size 명시한 경우 Compose modifier chain 동작 (outer 우선) 으로 호출자 의도가 적용됨. dup 케이스만 cleanup 으로 정리.
- 다크모드에 부적합한 `Black900` tint 가 호출부에 명시적으로 노출되어, 추후 다크모드 정책 정리 시 변경 지점이 명확해짐 (별도 PR 권장).

## 보류 항목
- `NotificationVacancyIcon` / `NotificationFriendIcon` 가 동일 res (`ic_ringing_alarm_notification`) 사용. 호출부에서 의미 분리 (Vacancy/Friend) 가 표현되던 부분은 인라인화로 같은 res 가 노출됨 → 디자인 의도 확인 후 별도 정리 가능.

## Test plan
- [ ] `./gradlew ktlintFormat compileStagingDebugUnitTestKotlin compileStagingDebugScreenshotTestKotlin` (로컬 통과)
- [ ] CI 통과 확인
- [ ] 시각 회귀 sanity check — 시간표 메뉴 (TimetableDropdownMenu), BottomNavigation 탭, NotificationScreen, Settings, Friend, LectureDetail TopBar 등 주요 화면의 아이콘 크기/색
- [ ] 특히 `TimetableDropdownMenu` 의 검색 메뉴 아이콘 크기 (22.dp) 가 그대로인지 확인 — 작업 중 1건 회귀 발견하여 수정함