### PR TITLE
chore: MeilCli/slack-upload-file v3 -> v5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,7 +89,7 @@ jobs:
         env:
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID_STAGING }}
       - name: Slack Upload APK
-        uses: MeilCli/slack-upload-file@v3
+        uses: MeilCli/slack-upload-file@v5
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}
           channel_id: ${{ secrets.SLACK_DEPLOY_CHANNEL_ID }}

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -84,7 +84,7 @@ jobs:
           SLACK_USERNAME: BuildNoti
       - name: Slack Upload APK (Live)
         if: ${{ github.event.inputs.slack == 'true' && github.event.inputs.variant == 'live' }}
-        uses: MeilCli/slack-upload-file@v3
+        uses: MeilCli/slack-upload-file@v5
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}
           channel_id: ${{ secrets.SLACK_DEPLOY_CHANNEL_ID }}
@@ -94,7 +94,7 @@ jobs:
           initial_comment: 'live-release APK'
       - name: Slack Upload APK (Staging)
         if: ${{ github.event.inputs.slack == 'true' && github.event.inputs.variant == 'staging' }}
-        uses: MeilCli/slack-upload-file@v3
+        uses: MeilCli/slack-upload-file@v5
         with:
           slack_token: ${{ secrets.SLACK_READ_WRITE_TOKEN }}
           channel_id: ${{ secrets.SLACK_DEPLOY_CHANNEL_ID }}


### PR DESCRIPTION
## Summary
- GitHub Actions 의 Node.js 20 deprecation 워닝 ("Node.js 20 actions are deprecated ...") 대응
- `MeilCli/slack-upload-file@v3` (Node 20) 을 `@v5` (v5.0.2, Node 24) 로 일괄 업그레이드
- 적용 위치: `.github/workflows/cd.yml`, `.github/workflows/manual_deploy.yml` (총 3곳)

## Why v5
- v3 → v4 breaking change: Node 16 → Node 20 (런타임만)
- v4 → v5 breaking change: Node 20 → Node 24, pnpm/esm 전환 (런타임만, 입력 스키마 동일)
- 현재 사용 중인 입력값 (`slack_token`, `channel_id`, `file_path`, `file_name`, `file_type`, `initial_comment`) 은 v5.0.2 의 `action.yml` 에서도 모두 그대로 정의되어 있음

## Test plan
- [ ] `manual_deploy` 워크플로우를 `slack=true` 로 한 번 트리거하여 APK 업로드가 정상 동작하는지 확인
- [ ] 다음 `cd` (develop merge) 실행 시 Slack 채널에 staging APK 가 정상 업로드되는지 확인
- [ ] 실행 로그에 Node 20 deprecation 워닝이 사라졌는지 확인