### PR TITLE
refactor: SNUTTStorage 직렬화 모델을 LocalEntity 로 분리

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,12 +2,12 @@
 -keepattributes SourceFile,LineNumberTable        # Keep file names and line numbers.
 -keep public class * extends java.lang.Exception  # Optional: Keep custom exceptions.
 
-# class stored to sharedPreference after serialization
--keep public enum com.wafflestudio.snutt2.** { *; }
--keep class com.wafflestudio.snutt2.lib.android.NetworkLog { *; }
+# SNUTTStorage 가 Moshi reflection (KotlinJsonAdapterFactory) 으로 직렬화하는 storage 전용 모델.
+# 모든 LocalEntity / NetworkLog / Optional wrapper 가 이 패키지에 위치한다 (enum 포함).
+-keep class com.wafflestudio.snutt2.storage.model.** { *; }
+
+# Retrofit + Moshi reflection 으로 직/역직렬화되는 네트워크 DTO.
 -keep class com.wafflestudio.snutt2.network.** { *; }
--keep class com.wafflestudio.snutt2.storage.** { *; }
--keep class com.wafflestudio.snutt2.domain.model.** { *; }
 
 # https://github.com/square/retrofit/issues/3751#issuecomment-1192043644
 # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).

--- a/app/src/main/java/com/wafflestudio/snutt2/data/currenttablelecture/CurrentTableLectureRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/currenttablelecture/CurrentTableLectureRepositoryImpl.kt
@@ -15,7 +15,7 @@ import com.wafflestudio.snutt2.network.dto.PostCustomLectureParams
 import com.wafflestudio.snutt2.network.dto.PostLectureParams
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
-import com.wafflestudio.snutt2.storage.toOptional
+import com.wafflestudio.snutt2.storage.model.toOptional
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/java/com/wafflestudio/snutt2/data/currenttablelecture/CurrentTableLectureRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/currenttablelecture/CurrentTableLectureRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.data.currenttablelecture
 
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.mapper.toLectureDto
+import com.wafflestudio.snutt2.data.mapper.toLocalEntity
 import com.wafflestudio.snutt2.data.mapper.toLocalLecture
 import com.wafflestudio.snutt2.domain.Unknown
 import com.wafflestudio.snutt2.domain.model.CustomLecture
@@ -29,7 +30,7 @@ class CurrentTableLectureRepositoryImpl @Inject constructor(
             ?: return Result.Success(Unit)
         try {
             val response = api._postAddLecture(prevTable.id, lecture.id, PostLectureParams(isForced))
-            storage.lastViewedTable.update(response.toOptional())
+            storage.lastViewedTable.update(response.toLocalEntity().toOptional())
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -41,7 +42,7 @@ class CurrentTableLectureRepositoryImpl @Inject constructor(
             ?: return Result.Success(Unit)
         try {
             val response = api._deleteLecture(prevTable.id, lecture.id)
-            storage.lastViewedTable.update(response.toOptional())
+            storage.lastViewedTable.update(response.toLocalEntity().toOptional())
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -57,7 +58,7 @@ class CurrentTableLectureRepositoryImpl @Inject constructor(
 
         return try {
             val response = api._deleteLecture(table.id, lectureId)
-            storage.lastViewedTable.update(response.toOptional())
+            storage.lastViewedTable.update(response.toLocalEntity().toOptional())
             Result.Success(Unit)
         } catch (e: Exception) {
             Result.Fail(e.toDomainError())
@@ -71,7 +72,7 @@ class CurrentTableLectureRepositoryImpl @Inject constructor(
             val params = lecture.toLectureDto().toParams()
             params.isForced = isForced
             val response = api._putLecture(prevTable.id, lecture.id, params)
-            storage.lastViewedTable.update(response.toOptional())
+            storage.lastViewedTable.update(response.toLocalEntity().toOptional())
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -83,7 +84,7 @@ class CurrentTableLectureRepositoryImpl @Inject constructor(
             ?: return Result.Fail(Unknown("", ""))
         try {
             val response = api._resetLecture(prevTable.id, lecture.id)
-            storage.lastViewedTable.update(response.toOptional())
+            storage.lastViewedTable.update(response.toLocalEntity().toOptional())
             val resetLecture = response.lectureList.find { it.id == lecture.id }!!.toLocalLecture()
             return Result.Success(resetLecture)
         } catch (e: Exception) {
@@ -97,7 +98,7 @@ class CurrentTableLectureRepositoryImpl @Inject constructor(
         return try {
             val params = lecture.toLectureDto().toParams().also { it.isForced = isForced }
             val response = api._postCustomLecture(prevTable.id, params)
-            storage.lastViewedTable.update(response.toOptional())
+            storage.lastViewedTable.update(response.toLocalEntity().toOptional())
             Result.Success(Unit)
         } catch (e: Exception) {
             Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
@@ -12,8 +12,9 @@ import com.wafflestudio.snutt2.domain.model.SearchTime
 import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
-import com.wafflestudio.snutt2.network.dto.TagDto
 import com.wafflestudio.snutt2.storage.SNUTTStorage
+import com.wafflestudio.snutt2.storage.model.toDomainModel
+import com.wafflestudio.snutt2.storage.model.toLocalEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -26,8 +27,8 @@ class LectureSearchRepositoryImpl @Inject constructor(
 ) : LectureSearchRepository {
 
     override val recentSearchedDepartmentTags: Flow<List<SearchTag>> =
-        storage.recentSearchedDepartments.asStateFlow().map { dtos ->
-            dtos.map { SearchTag.Regular(it.type, it.name) }
+        storage.recentSearchedDepartments.asStateFlow().map { entities ->
+            entities.map { it.toDomainModel() }
         }
 
     override fun getLectureSearchResultStream(
@@ -71,18 +72,18 @@ class LectureSearchRepositoryImpl @Inject constructor(
 
     override fun storeRecentSearchedDepartment(tag: SearchTag) {
         check(tag is SearchTag.Regular)
-        val tagDto = TagDto(tag.type, tag.name)
+        val entity = tag.toLocalEntity()
         val previousStoredTags = storage.recentSearchedDepartments.get()
         storage.recentSearchedDepartments.update(
-            (previousStoredTags.filter { it != tagDto } + tagDto).takeLast(5),
+            (previousStoredTags.filter { it != entity } + entity).takeLast(5),
         )
     }
 
     override fun removeRecentSearchedDepartment(tag: SearchTag) {
         check(tag is SearchTag.Regular)
-        val tagDto = TagDto(tag.type, tag.name)
+        val entity = tag.toLocalEntity()
         val previousStoredTags = storage.recentSearchedDepartments.get()
-        storage.recentSearchedDepartments.update(previousStoredTags - tagDto)
+        storage.recentSearchedDepartments.update(previousStoredTags - entity)
     }
 
     companion object {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/mapper/LectureMappers.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/mapper/LectureMappers.kt
@@ -20,6 +20,10 @@ import com.wafflestudio.snutt2.network.dto.LectureReviewDto
 import com.wafflestudio.snutt2.network.dto.SnuttEvLectureIdDto
 import com.wafflestudio.snutt2.network.dto.TimetableLectureDto
 import com.wafflestudio.snutt2.network.dto.parseHexColor
+import com.wafflestudio.snutt2.storage.model.ClassTimeLocalEntity
+import com.wafflestudio.snutt2.storage.model.ColorLocalEntity
+import com.wafflestudio.snutt2.storage.model.LectureLocalEntity
+import com.wafflestudio.snutt2.storage.model.LectureReviewLocalEntity
 import java.time.DayOfWeek
 import java.time.LocalTime
 
@@ -45,7 +49,7 @@ fun LectureDto.toLocalLecture(): LocalLecture = if (lecture_id != null) {
         quota = quota,
         freshmanQuota = freshmanQuota ?: 0, // TODO
         originalLectureId = lecture_id,
-        color = colorDtoToLectureColor(colorIndex.toInt(), color),
+        color = colorToLectureColor(colorIndex.toInt(), color.fgRaw, color.bgRaw),
     )
 } else {
     CustomLecture(
@@ -55,7 +59,39 @@ fun LectureDto.toLocalLecture(): LocalLecture = if (lecture_id != null) {
         instructor = instructor,
         credit = credit,
         remark = remark,
-        color = colorDtoToLectureColor(colorIndex.toInt(), color),
+        color = colorToLectureColor(colorIndex.toInt(), color.fgRaw, color.bgRaw),
+    )
+}
+
+fun LectureLocalEntity.toLocalLecture(): LocalLecture = if (lecture_id != null) {
+    SyllabusLecture(
+        id = id,
+        courseTitle = course_title,
+        lectureSessions = class_time_json.map { it.toLectureSession() },
+        instructor = instructor,
+        credit = credit,
+        remark = remark,
+        classification = classification ?: "",
+        department = department ?: "",
+        academicYear = academic_year ?: "",
+        courseNumber = course_number ?: "",
+        lectureNumber = lecture_number ?: "",
+        category = category ?: "",
+        categoryPre2025 = categoryPre2025 ?: "",
+        quota = quota,
+        freshmanQuota = freshmanQuota ?: 0, // TODO
+        originalLectureId = lecture_id,
+        color = colorToLectureColor(colorIndex.toInt(), color.fgRaw, color.bgRaw),
+    )
+} else {
+    CustomLecture(
+        id = id,
+        courseTitle = course_title,
+        lectureSessions = class_time_json.map { it.toLectureSession() },
+        instructor = instructor,
+        credit = credit,
+        remark = remark,
+        color = colorToLectureColor(colorIndex.toInt(), color.fgRaw, color.bgRaw),
     )
 }
 
@@ -139,6 +175,53 @@ fun SearchedLecture.toLectureDto(): LectureDto = LectureDto(
         rating = reviewInfo.rating,
         reviewCount = reviewInfo.reviewCount,
     ),
+)
+
+// endregion
+
+// region LectureDto / 하위 DTO → LocalEntity (storage 저장용)
+
+fun LectureDto.toLocalEntity(): LectureLocalEntity = LectureLocalEntity(
+    id = id,
+    lecture_id = lecture_id,
+    classification = classification,
+    department = department,
+    academic_year = academic_year,
+    course_number = course_number,
+    lecture_number = lecture_number,
+    course_title = course_title,
+    credit = credit,
+    class_time_json = class_time_json.map { it.toLocalEntity() },
+    instructor = instructor,
+    quota = quota,
+    freshmanQuota = freshmanQuota,
+    remark = remark,
+    category = category,
+    categoryPre2025 = categoryPre2025,
+    colorIndex = colorIndex,
+    color = color.toLocalEntity(),
+    registrationCount = registrationCount,
+    wasFull = wasFull,
+    review = review?.toLocalEntity(),
+)
+
+fun ClassTimeDto.toLocalEntity(): ClassTimeLocalEntity = ClassTimeLocalEntity(
+    day = day,
+    place = place,
+    id = id,
+    startMinute = startMinute,
+    endMinute = endMinute,
+)
+
+fun ColorDto.toLocalEntity(): ColorLocalEntity = ColorLocalEntity(
+    fgRaw = fgRaw,
+    bgRaw = bgRaw,
+)
+
+fun LectureReviewDto.toLocalEntity(): LectureReviewLocalEntity = LectureReviewLocalEntity(
+    id = id,
+    rating = rating,
+    reviewCount = reviewCount,
 )
 
 // endregion
@@ -285,6 +368,15 @@ private fun ClassTimeDto.toLectureSession(): LectureSession = LectureSession(
     place = place,
 )
 
+private fun ClassTimeLocalEntity.toLectureSession(): LectureSession = LectureSession(
+    id = id,
+    // NOTE: DayOfWeek 는 1이 월요일이고, 우리 서버는 0이 월요일이다
+    day = DayOfWeek.of(day + 1),
+    startTime = LocalTime.ofSecondOfDay(startMinute * 60L),
+    endTime = LocalTime.ofSecondOfDay(endMinute * 60L),
+    place = place,
+)
+
 private fun ClassPlaceAndTimeDto.toLectureSession(lectureId: String): LectureSession = LectureSession(
     id = lectureId,
     // NOTE: DayOfWeek 는 1이 월요일이고, 우리 서버는 0이 월요일이다
@@ -311,10 +403,10 @@ private fun LectureSession.toClassPlaceAndTimeDto(): ClassPlaceAndTimeDto = Clas
     endMinute = endTime.hour * 60 + endTime.minute,
 )
 
-private fun colorDtoToLectureColor(colorIndex: Int, color: ColorDto): LectureColor = if (colorIndex == 0) {
+private fun colorToLectureColor(colorIndex: Int, fgRaw: String?, bgRaw: String?): LectureColor = if (colorIndex == 0) {
     LectureColor.Custom(
-        foreground = color.fgRaw?.let { parseHexColor(it) } ?: 0xFFFFFFFF.toInt(),
-        background = color.bgRaw?.let { parseHexColor(it) } ?: 0xFFFFFFFF.toInt(),
+        foreground = fgRaw?.let { parseHexColor(it) } ?: 0xFFFFFFFF.toInt(),
+        background = bgRaw?.let { parseHexColor(it) } ?: 0xFFFFFFFF.toInt(),
     )
 } else {
     LectureColor.BuiltIn(colorIndex = colorIndex - 1)

--- a/app/src/main/java/com/wafflestudio/snutt2/data/mapper/LectureMappers.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/mapper/LectureMappers.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.data.mapper
 
 import com.wafflestudio.snutt2.domain.model.Building
+import com.wafflestudio.snutt2.domain.model.Campus
 import com.wafflestudio.snutt2.domain.model.CustomLecture
 import com.wafflestudio.snutt2.domain.model.GeoCoordinate
 import com.wafflestudio.snutt2.domain.model.Lecture
@@ -10,6 +11,7 @@ import com.wafflestudio.snutt2.domain.model.LectureSession
 import com.wafflestudio.snutt2.domain.model.LocalLecture
 import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.SyllabusLecture
+import com.wafflestudio.snutt2.network.dto.CampusDto
 import com.wafflestudio.snutt2.network.dto.ClassPlaceAndTimeDto
 import com.wafflestudio.snutt2.network.dto.ClassTimeDto
 import com.wafflestudio.snutt2.network.dto.ColorDto
@@ -345,7 +347,7 @@ fun SearchedLecture.toTimetableLectureDto(): TimetableLectureDto = TimetableLect
 // region LectureBuildingDto → Building
 
 fun LectureBuildingDto.toDomain(): Building = Building(
-    campus = campus,
+    campus = campus.toDomain(),
     buildingNumber = buildingNumber,
     buildingNameKor = buildingNameKor ?: "",
     buildingNameEng = buildingNameEng ?: "",
@@ -354,6 +356,12 @@ fun LectureBuildingDto.toDomain(): Building = Building(
         longitude = locationInDMS.longitude,
     ),
 )
+
+fun CampusDto.toDomain(): Campus = when (this) {
+    CampusDto.GWANAK -> Campus.GWANAK
+    CampusDto.YEONGEON -> Campus.YEONGEON
+    CampusDto.PYEONGCHANG -> Campus.PYEONGCHANG
+}
 
 // endregion
 

--- a/app/src/main/java/com/wafflestudio/snutt2/data/mapper/TableMappers.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/mapper/TableMappers.kt
@@ -14,6 +14,7 @@ import com.wafflestudio.snutt2.network.dto.TableDto
 import com.wafflestudio.snutt2.network.dto.ThemeDto
 import com.wafflestudio.snutt2.network.dto.TimetableDto
 import com.wafflestudio.snutt2.network.dto.parseHexColor
+import com.wafflestudio.snutt2.storage.model.SimpleTableLocalEntity
 
 // region TableDto / TimetableDto / SimpleTableDto → Table / TableSummary
 
@@ -54,6 +55,16 @@ fun SimpleTableDto.toDomain(): TableSummary = TableSummary(
     courseBook = CourseBook(semester, year),
     title = title,
     totalCredit = totalCredit ?: 0,
+    isPrimary = isPrimary,
+)
+
+fun SimpleTableDto.toLocalEntity(): SimpleTableLocalEntity = SimpleTableLocalEntity(
+    id = id,
+    year = year,
+    semester = semester,
+    title = title,
+    updatedAt = updatedAt,
+    totalCredit = totalCredit,
     isPrimary = isPrimary,
 )
 

--- a/app/src/main/java/com/wafflestudio/snutt2/data/mapper/TableMappers.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/mapper/TableMappers.kt
@@ -15,6 +15,7 @@ import com.wafflestudio.snutt2.network.dto.ThemeDto
 import com.wafflestudio.snutt2.network.dto.TimetableDto
 import com.wafflestudio.snutt2.network.dto.parseHexColor
 import com.wafflestudio.snutt2.storage.model.SimpleTableLocalEntity
+import com.wafflestudio.snutt2.storage.model.TableLocalEntity
 
 // region TableDto / TimetableDto / SimpleTableDto → Table / TableSummary
 
@@ -67,6 +68,35 @@ fun SimpleTableDto.toLocalEntity(): SimpleTableLocalEntity = SimpleTableLocalEnt
     totalCredit = totalCredit,
     isPrimary = isPrimary,
 )
+
+fun TableDto.toLocalEntity(): TableLocalEntity = TableLocalEntity(
+    id = id,
+    year = year,
+    semester = semester,
+    title = title,
+    lectureList = lectureList.map { it.toLocalEntity() },
+    updatedAt = updatedAt,
+    totalCredit = totalCredit,
+    theme = theme,
+    themeId = themeId,
+    isPrimary = isPrimary,
+)
+
+fun TableLocalEntity.toDomain(): Table {
+    val themeRef = themeId?.let { ThemeReference.Custom(it) }
+        ?: ThemeReference.BuiltIn(theme)
+    return Table(
+        summary = TableSummary(
+            id = id,
+            courseBook = CourseBook(semester, year),
+            title = title,
+            totalCredit = totalCredit ?: 0,
+            isPrimary = isPrimary,
+        ),
+        lectures = lectureList.map { it.toLocalLecture() },
+        themeRef = themeRef,
+    )
+}
 
 // endregion
 

--- a/app/src/main/java/com/wafflestudio/snutt2/data/mapper/UserMappers.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/mapper/UserMappers.kt
@@ -9,6 +9,8 @@ import com.wafflestudio.snutt2.network.dto.NicknameDto
 import com.wafflestudio.snutt2.network.dto.PushPreferenceDto
 import com.wafflestudio.snutt2.network.dto.PushPreferenceItemDto
 import com.wafflestudio.snutt2.network.dto.UserDto
+import com.wafflestudio.snutt2.storage.model.NicknameLocalEntity
+import com.wafflestudio.snutt2.storage.model.UserLocalEntity
 
 fun UserDto.toDomain(): User = User(
     email = email,
@@ -17,6 +19,21 @@ fun UserDto.toDomain(): User = User(
 )
 
 fun NicknameDto.toDomain(): Nickname = Nickname(nickname, tag)
+
+fun UserDto.toLocalEntity(): UserLocalEntity = UserLocalEntity(
+    isAdmin = isAdmin,
+    regDate = regDate,
+    notificationCheckedAt = notificationCheckedAt,
+    email = email,
+    localId = localId,
+    fbName = fbName,
+    nickname = nickname?.toLocalEntity(),
+)
+
+fun NicknameDto.toLocalEntity(): NicknameLocalEntity = NicknameLocalEntity(
+    nickname = nickname,
+    tag = tag,
+)
 
 fun PushPreferenceDto.toDomain(): PushPreferences {
     val map = pushPreferences.associateBy { it.type }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/semesterstatus/SemesterStatusRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/semesterstatus/SemesterStatusRepositoryImpl.kt
@@ -8,7 +8,7 @@ import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
 import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.model.toLocalEntity
-import com.wafflestudio.snutt2.storage.toOptional
+import com.wafflestudio.snutt2.storage.model.toOptional
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/wafflestudio/snutt2/data/semesterstatus/SemesterStatusRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/semesterstatus/SemesterStatusRepositoryImpl.kt
@@ -6,6 +6,8 @@ import com.wafflestudio.snutt2.domain.model.SemesterStatus
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
+import com.wafflestudio.snutt2.storage.model.toDomainModel
+import com.wafflestudio.snutt2.storage.model.toLocalEntity
 import com.wafflestudio.snutt2.storage.toOptional
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,14 +22,15 @@ class SemesterStatusRepositoryImpl @Inject constructor(
 ) : SemesterStatusRepository {
 
     private val _semesterStatus: MutableStateFlow<SemesterStatus?> =
-        MutableStateFlow(storage.semesterStatus.get().value?.toDomain())
+        MutableStateFlow(storage.semesterStatus.get().value?.toDomainModel())
     override val semesterStatus: StateFlow<SemesterStatus?> = _semesterStatus.asStateFlow()
 
     override suspend fun fetchSemesterStatus(): Result<Unit> {
         try {
             val response = api._getSemesterStatus()
-            storage.semesterStatus.update(response.toOptional())
-            _semesterStatus.value = response.toDomain()
+            val domain = response.toDomain()
+            storage.semesterStatus.update(domain.toLocalEntity().toOptional())
+            _semesterStatus.value = domain
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
@@ -69,12 +69,12 @@ class TableRepositoryImpl @Inject constructor(
         val prevTable = snuttStorage.lastViewedTable.get().value
             ?: return
         val response = api._getTableById(prevTable.id)
-        snuttStorage.lastViewedTable.update(response.toOptional())
+        snuttStorage.lastViewedTable.update(response.toLocalEntity().toOptional())
     }
 
     override suspend fun fetchAndSelectDefaultTable(): Result<Unit> = try {
         val response = api._getRecentTable()
-        snuttStorage.lastViewedTable.update(response.toOptional())
+        snuttStorage.lastViewedTable.update(response.toLocalEntity().toOptional())
         Result.Success(Unit)
     } catch (e: Exception) {
         Result.Fail(e.toDomainError())
@@ -92,7 +92,7 @@ class TableRepositoryImpl @Inject constructor(
 
     override suspend fun fetchAndSelectTable(id: String): Result<Unit> = try {
         val response = api._getTableById(id)
-        snuttStorage.lastViewedTable.update(response.toOptional())
+        snuttStorage.lastViewedTable.update(response.toLocalEntity().toOptional())
         Result.Success(Unit)
     } catch (e: Exception) {
         Result.Fail(e.toDomainError())
@@ -179,7 +179,7 @@ class TableRepositoryImpl @Inject constructor(
 
         val prevTable = snuttStorage.lastViewedTable.get().value ?: return
         val currentTableResponse = api._getTableById(prevTable.id)
-        snuttStorage.lastViewedTable.update(currentTableResponse.toOptional())
+        snuttStorage.lastViewedTable.update(currentTableResponse.toLocalEntity().toOptional())
     }
 
     override suspend fun deleteTable(table: TableSummary): Result<Unit> {
@@ -209,7 +209,7 @@ class TableRepositoryImpl @Inject constructor(
         val prev = snuttStorage.lastViewedTable.get().value
         snuttStorage.lastViewedTable.update(
             if (prev?.id == tableId) {
-                response.toOptional()
+                response.toLocalEntity().toOptional()
             } else {
                 prev.toOptional()
             },
@@ -224,7 +224,7 @@ class TableRepositoryImpl @Inject constructor(
         val prev = snuttStorage.lastViewedTable.get().value
         snuttStorage.lastViewedTable.update(
             if (prev?.id == tableId) {
-                response.toOptional()
+                response.toLocalEntity().toOptional()
             } else {
                 prev.toOptional()
             },

--- a/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
@@ -18,7 +18,7 @@ import com.wafflestudio.snutt2.network.dto.PutTimetableLectureReminderParams
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
 import com.wafflestudio.snutt2.storage.model.toDomainModel
-import com.wafflestudio.snutt2.storage.toOptional
+import com.wafflestudio.snutt2.storage.model.toOptional
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject

--- a/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/tables/TableRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.data.tables
 
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.mapper.toDomain
+import com.wafflestudio.snutt2.data.mapper.toLocalEntity
 import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.LectureReminderOffset
 import com.wafflestudio.snutt2.domain.model.LectureWithReminderOption
@@ -16,6 +17,7 @@ import com.wafflestudio.snutt2.network.dto.PutTableThemeParams
 import com.wafflestudio.snutt2.network.dto.PutTimetableLectureReminderParams
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
+import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.toOptional
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.StateFlow
@@ -51,14 +53,14 @@ class TableRepositoryImpl @Inject constructor(
             private val source = snuttStorage.tableMap.asStateFlow()
 
             override val value: List<TableSummary>
-                get() = source.value.values.map { it.toDomain() }
+                get() = source.value.values.map { it.toDomainModel() }
 
             override val replayCache: List<List<TableSummary>>
                 get() = listOf(value)
 
             override suspend fun collect(collector: kotlinx.coroutines.flow.FlowCollector<List<TableSummary>>): Nothing {
-                source.collect { dtoMap ->
-                    collector.emit(dtoMap.values.map { it.toDomain() })
+                source.collect { entityMap ->
+                    collector.emit(entityMap.values.map { it.toDomainModel() })
                 }
             }
         }
@@ -81,7 +83,7 @@ class TableRepositoryImpl @Inject constructor(
     override suspend fun fetchTableList(): Result<Unit> {
         try {
             val response = api._getTableList()
-            snuttStorage.tableMap.update(response.associateBy { it.id })
+            snuttStorage.tableMap.update(response.associate { it.id to it.toLocalEntity() })
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -115,7 +117,7 @@ class TableRepositoryImpl @Inject constructor(
                 ),
             )
             // FIXME: 데이터 레이어 갈아엎을 때 이 암묵적인 동작도 어떻게 좀 하기
-            snuttStorage.tableMap.update(response.associateBy { it.id })
+            snuttStorage.tableMap.update(response.associate { it.id to it.toLocalEntity() })
             response
                 .firstOrNull { it.year == courseBook.year && it.semester == courseBook.semester && it.title == title }
                 ?.let {
@@ -135,7 +137,7 @@ class TableRepositoryImpl @Inject constructor(
                 PutTableParams(title = newTitle),
             )
             // FIXME: 데이터 레이어 갈아엎을 때 이 암묵적인 동작도 어떻게 좀 하기
-            snuttStorage.tableMap.update(response.associateBy { it.id })
+            snuttStorage.tableMap.update(response.associate { it.id to it.toLocalEntity() })
             val prev = snuttStorage.lastViewedTable.get().value
             snuttStorage.lastViewedTable.update(
                 if (prev?.id == table.id) {
@@ -173,7 +175,7 @@ class TableRepositoryImpl @Inject constructor(
 
     private suspend fun refreshTableListAndCurrentTable() {
         val tableListResponse = api._getTableList()
-        snuttStorage.tableMap.update(tableListResponse.associateBy { it.id })
+        snuttStorage.tableMap.update(tableListResponse.associate { it.id to it.toLocalEntity() })
 
         val prevTable = snuttStorage.lastViewedTable.get().value ?: return
         val currentTableResponse = api._getTableById(prevTable.id)
@@ -184,7 +186,7 @@ class TableRepositoryImpl @Inject constructor(
         try {
             val response = api._deleteTable(table.id)
             // FIXME: 데이터 레이어 수정
-            snuttStorage.tableMap.update(response.associateBy { it.id })
+            snuttStorage.tableMap.update(response.associate { it.id to it.toLocalEntity() })
 
             return Result.Success(Unit)
         } catch (e: Exception) {
@@ -195,7 +197,7 @@ class TableRepositoryImpl @Inject constructor(
     override suspend fun copyTable(table: TableSummary): Result<Unit> {
         try {
             val response = api._copyTable(table.id)
-            snuttStorage.tableMap.update(response.associateBy { it.id })
+            snuttStorage.tableMap.update(response.associate { it.id to it.toLocalEntity() })
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.mapper.toDomain
 import com.wafflestudio.snutt2.data.mapper.toDto
+import com.wafflestudio.snutt2.data.mapper.toLocalEntity
 import com.wafflestudio.snutt2.domain.Unknown
 import com.wafflestudio.snutt2.domain.model.PushPreferences
 import com.wafflestudio.snutt2.domain.model.SocialProviders
@@ -33,6 +34,7 @@ import com.wafflestudio.snutt2.network.dto.PutUserPasswordParams
 import com.wafflestudio.snutt2.network.dto.RegisterFirebaseTokenParams
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
+import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.toOptional
 import com.wafflestudio.snutt2.storage.unwrap
 import com.wafflestudio.snutt2.ui.theme.ThemeMode
@@ -54,7 +56,7 @@ class UserRepositoryImpl @Inject constructor(
 
     override val user: StateFlow<User?> = storage.user.asStateFlow()
         .unwrap(externalScope)
-        .map(externalScope) { it?.toDomain() }
+        .map(externalScope) { it?.toDomainModel() }
 
     override val accessToken = storage.accessToken.asStateFlow()
 
@@ -81,7 +83,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun fetchUserInfo(): Result<Unit> {
         try {
             val result = api._getUserInfo()
-            storage.user.update(result.toOptional())
+            storage.user.update(result.toLocalEntity().toOptional())
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -90,7 +92,7 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun patchUserInfo(nickname: String): Result<Unit> = try {
         val response = api._patchUserInfo(PatchUserInfoParams(nickname))
-        storage.user.update(response.toOptional())
+        storage.user.update(response.toLocalEntity().toOptional())
         Result.Success(Unit)
     } catch (e: Exception) {
         Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
@@ -35,6 +35,7 @@ import com.wafflestudio.snutt2.network.dto.RegisterFirebaseTokenParams
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
 import com.wafflestudio.snutt2.storage.model.toDomainModel
+import com.wafflestudio.snutt2.storage.model.toLocalEntity
 import com.wafflestudio.snutt2.storage.toOptional
 import com.wafflestudio.snutt2.storage.unwrap
 import com.wafflestudio.snutt2.ui.theme.ThemeMode
@@ -60,7 +61,8 @@ class UserRepositoryImpl @Inject constructor(
 
     override val accessToken = storage.accessToken.asStateFlow()
 
-    override val themeMode = storage.themeMode.asStateFlow()
+    override val themeMode: StateFlow<ThemeMode> = storage.themeMode.asStateFlow()
+        .map(externalScope) { it.toDomainModel() }
 
     override suspend fun postSignIn(id: String, password: String): Result<Unit> = try {
         val response = api._postSignIn(PostSignInParams(id, password))
@@ -193,7 +195,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun setThemeMode(mode: ThemeMode): Result<Unit> = try {
-        storage.themeMode.update(mode)
+        storage.themeMode.update(mode.toLocalEntity())
         Result.Success(Unit)
     } catch (e: Exception) {
         Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
@@ -36,8 +36,8 @@ import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
 import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.model.toLocalEntity
-import com.wafflestudio.snutt2.storage.toOptional
-import com.wafflestudio.snutt2.storage.unwrap
+import com.wafflestudio.snutt2.storage.model.toOptional
+import com.wafflestudio.snutt2.storage.model.unwrap
 import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/model/SemesterStatus.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/model/SemesterStatus.kt
@@ -1,8 +1,5 @@
 package com.wafflestudio.snutt2.domain.model
 
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
 data class SemesterStatus(
     val current: CourseBook?,
     val next: CourseBook,

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/DebugViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/DebugViewModel.kt
@@ -1,8 +1,8 @@
 package com.wafflestudio.snutt2.feature.settings
 
 import androidx.lifecycle.ViewModel
-import com.wafflestudio.snutt2.lib.android.NetworkLog
 import com.wafflestudio.snutt2.storage.SNUTTStorage
+import com.wafflestudio.snutt2.storage.model.NetworkLog
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/NetworkLogPage.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.wafflestudio.snutt2.R
-import com.wafflestudio.snutt2.lib.android.NetworkLog
+import com.wafflestudio.snutt2.storage.model.NetworkLog
 import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.components.compose.TopBar
 import com.wafflestudio.snutt2.ui.components.compose.clicks

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/NetworkLogger.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/NetworkLogger.kt
@@ -4,21 +4,13 @@ import android.content.Context
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParser
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.storage.model.NetworkLog
 import okhttp3.Interceptor
 import okhttp3.Response
 import okio.Buffer
 import okio.IOException
 import timber.log.Timber
 import java.nio.charset.StandardCharsets
-
-data class NetworkLog(
-    val requestMethod: String,
-    val requestUrl: String,
-    val requestHeader: String,
-    val requestBody: String,
-    val responseCode: String,
-    val responseBody: String,
-)
 
 fun Interceptor.Chain.createNewNetworkLog(
     context: Context,

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/CampusDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/CampusDto.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.snutt2.network.dto
+
+enum class CampusDto {
+    GWANAK,
+    YEONGEON,
+    PYEONGCHANG,
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/LectureBuildingDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/LectureBuildingDto.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt2.network.dto
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.wafflestudio.snutt2.domain.model.Campus
 
 @JsonClass(generateAdapter = true)
 data class LectureBuildingDto(
@@ -12,5 +11,5 @@ data class LectureBuildingDto(
     @param:Json(name = "buildingNameEng") val buildingNameEng: String? = null,
     @param:Json(name = "locationInDMS") val locationInDMS: GeoCoordinateDTO,
     @param:Json(name = "locationInDecimal") val locationInDecimal: GeoCoordinateDTO,
-    @param:Json(name = "campus") val campus: Campus,
+    @param:Json(name = "campus") val campus: CampusDto,
 )

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.snutt2.storage
 
-import com.wafflestudio.snutt2.lib.android.NetworkLog
+import com.wafflestudio.snutt2.storage.model.NetworkLog
 import com.wafflestudio.snutt2.storage.model.SemesterStatusLocalEntity
 import com.wafflestudio.snutt2.storage.model.SimpleTableLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -1,10 +1,10 @@
 package com.wafflestudio.snutt2.storage
 
 import com.wafflestudio.snutt2.lib.android.NetworkLog
-import com.wafflestudio.snutt2.network.dto.TableDto
 import com.wafflestudio.snutt2.storage.model.SemesterStatusLocalEntity
 import com.wafflestudio.snutt2.storage.model.SimpleTableLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData
+import com.wafflestudio.snutt2.storage.model.TableLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableTrimParamData
 import com.wafflestudio.snutt2.storage.model.TagLocalEntity
 import com.wafflestudio.snutt2.storage.model.UserLocalEntity
@@ -76,12 +76,12 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val lastViewedTable = PrefValue<Optional<TableDto>>(
+    val lastViewedTable = PrefValue<Optional<TableLocalEntity>>(
         prefContext,
         PrefOptionalValueMetaData(
             domain = DOMAIN_SCOPE_CURRENT_VERSION,
             key = "last_tables",
-            type = TableDto::class.java,
+            type = TableLocalEntity::class.java,
             defaultValue = Optional.empty(),
         ),
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -3,11 +3,11 @@ package com.wafflestudio.snutt2.storage
 import com.wafflestudio.snutt2.lib.android.NetworkLog
 import com.wafflestudio.snutt2.network.dto.SimpleTableDto
 import com.wafflestudio.snutt2.network.dto.TableDto
-import com.wafflestudio.snutt2.network.dto.UserDto
 import com.wafflestudio.snutt2.storage.model.SemesterStatusLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData
 import com.wafflestudio.snutt2.storage.model.TableTrimParamData
 import com.wafflestudio.snutt2.storage.model.TagLocalEntity
+import com.wafflestudio.snutt2.storage.model.UserLocalEntity
 import com.wafflestudio.snutt2.storage.pref.PrefContext
 import com.wafflestudio.snutt2.storage.pref.PrefListValueMetaData
 import com.wafflestudio.snutt2.storage.pref.PrefMapValueMetaData
@@ -43,12 +43,12 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val user = PrefValue<Optional<UserDto>>(
+    val user = PrefValue<Optional<UserLocalEntity>>(
         prefContext,
         PrefOptionalValueMetaData(
             domain = DOMAIN_SCOPE_LOGIN,
             key = "pref_user",
-            type = UserDto::class.java,
+            type = UserLocalEntity::class.java,
             defaultValue = Optional.empty(),
         ),
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2.storage
 
 import com.wafflestudio.snutt2.storage.model.NetworkLog
+import com.wafflestudio.snutt2.storage.model.Optional
 import com.wafflestudio.snutt2.storage.model.SemesterStatusLocalEntity
 import com.wafflestudio.snutt2.storage.model.SimpleTableLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.snutt2.storage.model.TableLectureCustomData
 import com.wafflestudio.snutt2.storage.model.TableLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableTrimParamData
 import com.wafflestudio.snutt2.storage.model.TagLocalEntity
+import com.wafflestudio.snutt2.storage.model.ThemeModeLocalEntity
 import com.wafflestudio.snutt2.storage.model.UserLocalEntity
 import com.wafflestudio.snutt2.storage.pref.PrefContext
 import com.wafflestudio.snutt2.storage.pref.PrefListValueMetaData
@@ -14,7 +15,6 @@ import com.wafflestudio.snutt2.storage.pref.PrefMapValueMetaData
 import com.wafflestudio.snutt2.storage.pref.PrefOptionalValueMetaData
 import com.wafflestudio.snutt2.storage.pref.PrefValue
 import com.wafflestudio.snutt2.storage.pref.PrefValueMetaData
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -106,13 +106,13 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val themeMode = PrefValue<ThemeMode>(
+    val themeMode = PrefValue<ThemeModeLocalEntity>(
         prefContext,
         PrefValueMetaData(
             domain = DOMAIN_SCOPE_CURRENT_VERSION,
             key = "theme_mode",
-            type = ThemeMode::class.java,
-            defaultValue = ThemeMode.AUTO,
+            type = ThemeModeLocalEntity::class.java,
+            defaultValue = ThemeModeLocalEntity.AUTO,
         ),
     )
 

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -1,9 +1,9 @@
 package com.wafflestudio.snutt2.storage
 
 import com.wafflestudio.snutt2.lib.android.NetworkLog
-import com.wafflestudio.snutt2.network.dto.SimpleTableDto
 import com.wafflestudio.snutt2.network.dto.TableDto
 import com.wafflestudio.snutt2.storage.model.SemesterStatusLocalEntity
+import com.wafflestudio.snutt2.storage.model.SimpleTableLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData
 import com.wafflestudio.snutt2.storage.model.TableTrimParamData
 import com.wafflestudio.snutt2.storage.model.TagLocalEntity
@@ -53,13 +53,13 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val tableMap = PrefValue<Map<String, SimpleTableDto>>(
+    val tableMap = PrefValue<Map<String, SimpleTableLocalEntity>>(
         prefContext,
         PrefMapValueMetaData(
             domain = DOMAIN_SCOPE_CURRENT_VERSION,
             key = "pref_tables",
             String::class.java,
-            SimpleTableDto::class.java,
+            SimpleTableLocalEntity::class.java,
             mapOf(),
         ),
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -5,10 +5,10 @@ import com.wafflestudio.snutt2.network.dto.CourseBookDto
 import com.wafflestudio.snutt2.network.dto.SemesterStatusDto
 import com.wafflestudio.snutt2.network.dto.SimpleTableDto
 import com.wafflestudio.snutt2.network.dto.TableDto
-import com.wafflestudio.snutt2.network.dto.TagDto
 import com.wafflestudio.snutt2.network.dto.UserDto
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData
 import com.wafflestudio.snutt2.storage.model.TableTrimParamData
+import com.wafflestudio.snutt2.storage.model.TagLocalEntity
 import com.wafflestudio.snutt2.storage.pref.PrefContext
 import com.wafflestudio.snutt2.storage.pref.PrefListValueMetaData
 import com.wafflestudio.snutt2.storage.pref.PrefMapValueMetaData
@@ -147,16 +147,6 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val tags = PrefValue<List<TagDto>>(
-        prefContext,
-        PrefListValueMetaData(
-            domain = DOMAIN_SCOPE_CURRENT_VERSION,
-            key = "pref_tags",
-            type = TagDto::class.java,
-            defaultValue = listOf(),
-        ),
-    )
-
     val networkLog = PrefValue<List<NetworkLog>>(
         prefContext,
         PrefListValueMetaData(
@@ -197,12 +187,12 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val recentSearchedDepartments = PrefValue<List<TagDto>>(
+    val recentSearchedDepartments = PrefValue<List<TagLocalEntity>>(
         prefContext,
         PrefListValueMetaData(
             domain = DOMAIN_SCOPE_LOGIN,
             key = "recent_searched_departments",
-            type = TagDto::class.java,
+            type = TagLocalEntity::class.java,
             defaultValue = listOf(),
         ),
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorage.kt
@@ -1,11 +1,10 @@
 package com.wafflestudio.snutt2.storage
 
 import com.wafflestudio.snutt2.lib.android.NetworkLog
-import com.wafflestudio.snutt2.network.dto.CourseBookDto
-import com.wafflestudio.snutt2.network.dto.SemesterStatusDto
 import com.wafflestudio.snutt2.network.dto.SimpleTableDto
 import com.wafflestudio.snutt2.network.dto.TableDto
 import com.wafflestudio.snutt2.network.dto.UserDto
+import com.wafflestudio.snutt2.storage.model.SemesterStatusLocalEntity
 import com.wafflestudio.snutt2.storage.model.TableLectureCustomData
 import com.wafflestudio.snutt2.storage.model.TableTrimParamData
 import com.wafflestudio.snutt2.storage.model.TagLocalEntity
@@ -137,16 +136,6 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val courseBooks = PrefValue<List<CourseBookDto>>(
-        prefContext,
-        PrefListValueMetaData(
-            domain = DOMAIN_SCOPE_CURRENT_VERSION,
-            key = "pref_course_books",
-            type = CourseBookDto::class.java,
-            defaultValue = listOf(),
-        ),
-    )
-
     val networkLog = PrefValue<List<NetworkLog>>(
         prefContext,
         PrefListValueMetaData(
@@ -197,12 +186,12 @@ class SNUTTStorage @Inject constructor(
         ),
     )
 
-    val semesterStatus = PrefValue<Optional<SemesterStatusDto>>(
+    val semesterStatus = PrefValue<Optional<SemesterStatusLocalEntity>>(
         prefContext,
         PrefOptionalValueMetaData(
             domain = DOMAIN_SCOPE_LOGIN,
             key = "semester_status",
-            type = SemesterStatusDto::class.java,
+            type = SemesterStatusLocalEntity::class.java,
             defaultValue = Optional.empty(),
         ),
     )

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorageExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorageExt.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.snutt2.storage
 
-import com.wafflestudio.snutt2.lib.android.NetworkLog
+import com.wafflestudio.snutt2.storage.model.NetworkLog
 
 fun SNUTTStorage.addNetworkLog(newLog: NetworkLog) {
     networkLog.update(

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/ClassTimeLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/ClassTimeLocalEntity.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ClassTimeLocalEntity(
+    @param:Json(name = "day") val day: Int,
+    @param:Json(name = "place") val place: String,
+    @param:Json(name = "_id") val id: String? = null,
+    @param:Json(name = "startMinute") val startMinute: Int = 0,
+    @param:Json(name = "endMinute") val endMinute: Int = 0,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/ColorLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/ColorLocalEntity.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ColorLocalEntity(
+    @param:Json(name = "fg") val fgRaw: String? = null,
+    @param:Json(name = "bg") val bgRaw: String? = null,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/CourseBookLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/CourseBookLocalEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.JsonClass
+import com.wafflestudio.snutt2.domain.model.CourseBook
+
+@JsonClass(generateAdapter = true)
+data class CourseBookLocalEntity(
+    val semester: Long,
+    val year: Long,
+)
+
+fun CourseBookLocalEntity.toDomainModel(): CourseBook = CourseBook(
+    semester = semester,
+    year = year,
+)
+
+fun CourseBook.toLocalEntity(): CourseBookLocalEntity = CourseBookLocalEntity(
+    semester = semester,
+    year = year,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/LectureLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/LectureLocalEntity.kt
@@ -1,0 +1,29 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class LectureLocalEntity(
+    @param:Json(name = "_id") val id: String,
+    @param:Json(name = "lecture_id") val lecture_id: String? = null,
+    @param:Json(name = "classification") val classification: String?,
+    @param:Json(name = "department") val department: String?,
+    @param:Json(name = "academic_year") val academic_year: String?,
+    @param:Json(name = "course_number") val course_number: String?,
+    @param:Json(name = "lecture_number") val lecture_number: String?,
+    @param:Json(name = "course_title") val course_title: String,
+    @param:Json(name = "credit") val credit: Long,
+    @param:Json(name = "class_time_json") val class_time_json: List<ClassTimeLocalEntity>,
+    @param:Json(name = "instructor") val instructor: String,
+    @param:Json(name = "quota") val quota: Long = 0,
+    @param:Json(name = "freshmanQuota") val freshmanQuota: Long?,
+    @param:Json(name = "remark") val remark: String,
+    @param:Json(name = "category") val category: String?,
+    @param:Json(name = "categoryPre2025") val categoryPre2025: String?,
+    @param:Json(name = "colorIndex") val colorIndex: Long = 0,
+    @param:Json(name = "color") val color: ColorLocalEntity = ColorLocalEntity(),
+    @param:Json(name = "registrationCount") val registrationCount: Long = 0,
+    @param:Json(name = "wasFull") val wasFull: Boolean = false,
+    @param:Json(name = "snuttEvLecture") val review: LectureReviewLocalEntity? = null,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/LectureReviewLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/LectureReviewLocalEntity.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class LectureReviewLocalEntity(
+    @param:Json(name = "evLectureId") val id: String,
+    @param:Json(name = "avgRating") val rating: Double? = null,
+    @param:Json(name = "evaluationCount") val reviewCount: Int? = null,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/NetworkLog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/NetworkLog.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.snutt2.storage.model
+
+/**
+ * 디버그 빌드에서 OkHttp 인터셉터가 캡처해 SNUTTStorage 에 저장하는 네트워크 호출 기록.
+ * 도메인 모델이 아니고 단순 디버깅 데이터 클래스이므로 별도 LocalEntity 와 도메인 모델을 분리하지 않는다.
+ */
+data class NetworkLog(
+    val requestMethod: String,
+    val requestUrl: String,
+    val requestHeader: String,
+    val requestBody: String,
+    val responseCode: String,
+    val responseBody: String,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/NicknameLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/NicknameLocalEntity.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.JsonClass
+import com.wafflestudio.snutt2.domain.model.Nickname
+
+@JsonClass(generateAdapter = true)
+data class NicknameLocalEntity(
+    val nickname: String = "",
+    val tag: String = "",
+)
+
+fun NicknameLocalEntity.toDomainModel(): Nickname = Nickname(
+    nickname = nickname,
+    tag = tag,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/Optional.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/Optional.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.snutt2.storage
+package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.JsonClass
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.JsonClass
+import com.wafflestudio.snutt2.domain.model.SemesterStatus
+
+@JsonClass(generateAdapter = true)
+data class SemesterStatusLocalEntity(
+    val current: CourseBookLocalEntity?,
+    val next: CourseBookLocalEntity,
+)
+
+fun SemesterStatusLocalEntity.toDomainModel(): SemesterStatus = SemesterStatus(
+    current = current?.toDomainModel(),
+    next = next.toDomainModel(),
+)
+
+fun SemesterStatus.toLocalEntity(): SemesterStatusLocalEntity = SemesterStatusLocalEntity(
+    current = current?.toLocalEntity(),
+    next = next.toLocalEntity(),
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntity.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.wafflestudio.snutt2.domain.model.CourseBook
+import com.wafflestudio.snutt2.domain.model.TableSummary
+
+@JsonClass(generateAdapter = true)
+data class SimpleTableLocalEntity(
+    @param:Json(name = "_id") val id: String,
+    @param:Json(name = "year") val year: Long,
+    @param:Json(name = "semester") val semester: Long,
+    @param:Json(name = "title") val title: String,
+    @param:Json(name = "updated_at") val updatedAt: String,
+    @param:Json(name = "total_credit") val totalCredit: Long?,
+    @param:Json(name = "isPrimary") val isPrimary: Boolean = false,
+)
+
+fun SimpleTableLocalEntity.toDomainModel(): TableSummary = TableSummary(
+    id = id,
+    courseBook = CourseBook(semester, year),
+    title = title,
+    totalCredit = totalCredit ?: 0,
+    isPrimary = isPrimary,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/TableLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/TableLocalEntity.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class TableLocalEntity(
+    @param:Json(name = "_id") val id: String,
+    @param:Json(name = "year") val year: Long,
+    @param:Json(name = "semester") val semester: Long,
+    @param:Json(name = "title") val title: String,
+    @param:Json(name = "lecture_list") val lectureList: List<LectureLocalEntity> = emptyList(),
+    @param:Json(name = "updated_at") val updatedAt: String,
+    @param:Json(name = "total_credit") val totalCredit: Long?,
+    @param:Json(name = "theme") val theme: Int,
+    @param:Json(name = "themeId") val themeId: String? = null,
+    @param:Json(name = "isPrimary") val isPrimary: Boolean = false,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/TagLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/TagLocalEntity.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.JsonClass
+import com.wafflestudio.snutt2.domain.model.SearchTag
+
+@JsonClass(generateAdapter = true)
+data class TagLocalEntity(
+    val type: TagTypeLocalEntity,
+    val name: String,
+)
+
+fun TagLocalEntity.toDomainModel(): SearchTag.Regular = SearchTag.Regular(type.toDomainModel(), name)
+
+fun SearchTag.Regular.toLocalEntity(): TagLocalEntity = TagLocalEntity(type.toLocalEntity(), name)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/TagTypeLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/TagTypeLocalEntity.kt
@@ -1,0 +1,39 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.wafflestudio.snutt2.domain.model.TagType
+
+enum class TagTypeLocalEntity {
+    SORT_CRITERIA,
+    CLASSIFICATION,
+    DEPARTMENT,
+    ACADEMIC_YEAR,
+    CREDIT,
+    TIME,
+    CATEGORY,
+    CATEGORY_PRE2025,
+    ETC,
+}
+
+fun TagTypeLocalEntity.toDomainModel(): TagType = when (this) {
+    TagTypeLocalEntity.SORT_CRITERIA -> TagType.SORT_CRITERIA
+    TagTypeLocalEntity.CLASSIFICATION -> TagType.CLASSIFICATION
+    TagTypeLocalEntity.DEPARTMENT -> TagType.DEPARTMENT
+    TagTypeLocalEntity.ACADEMIC_YEAR -> TagType.ACADEMIC_YEAR
+    TagTypeLocalEntity.CREDIT -> TagType.CREDIT
+    TagTypeLocalEntity.TIME -> TagType.TIME
+    TagTypeLocalEntity.CATEGORY -> TagType.CATEGORY
+    TagTypeLocalEntity.CATEGORY_PRE2025 -> TagType.CATEGORY_PRE2025
+    TagTypeLocalEntity.ETC -> TagType.ETC
+}
+
+fun TagType.toLocalEntity(): TagTypeLocalEntity = when (this) {
+    TagType.SORT_CRITERIA -> TagTypeLocalEntity.SORT_CRITERIA
+    TagType.CLASSIFICATION -> TagTypeLocalEntity.CLASSIFICATION
+    TagType.DEPARTMENT -> TagTypeLocalEntity.DEPARTMENT
+    TagType.ACADEMIC_YEAR -> TagTypeLocalEntity.ACADEMIC_YEAR
+    TagType.CREDIT -> TagTypeLocalEntity.CREDIT
+    TagType.TIME -> TagTypeLocalEntity.TIME
+    TagType.CATEGORY -> TagTypeLocalEntity.CATEGORY
+    TagType.CATEGORY_PRE2025 -> TagTypeLocalEntity.CATEGORY_PRE2025
+    TagType.ETC -> TagTypeLocalEntity.ETC
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntity.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.wafflestudio.snutt2.ui.theme.ThemeMode
+
+enum class ThemeModeLocalEntity {
+    DARK,
+    LIGHT,
+    AUTO,
+}
+
+fun ThemeModeLocalEntity.toDomainModel(): ThemeMode = when (this) {
+    ThemeModeLocalEntity.DARK -> ThemeMode.DARK
+    ThemeModeLocalEntity.LIGHT -> ThemeMode.LIGHT
+    ThemeModeLocalEntity.AUTO -> ThemeMode.AUTO
+}
+
+fun ThemeMode.toLocalEntity(): ThemeModeLocalEntity = when (this) {
+    ThemeMode.DARK -> ThemeModeLocalEntity.DARK
+    ThemeMode.LIGHT -> ThemeModeLocalEntity.LIGHT
+    ThemeMode.AUTO -> ThemeModeLocalEntity.AUTO
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/UserLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/UserLocalEntity.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.JsonClass
+import com.wafflestudio.snutt2.domain.model.User
+
+@JsonClass(generateAdapter = true)
+data class UserLocalEntity(
+    val isAdmin: Boolean = false,
+    val regDate: String? = null,
+    val notificationCheckedAt: String? = null,
+    val email: String? = null,
+    val localId: String? = null,
+    val fbName: String? = null,
+    val nickname: NicknameLocalEntity? = null,
+)
+
+fun UserLocalEntity.toDomainModel(): User = User(
+    email = email,
+    localId = localId,
+    nickname = nickname?.toDomainModel(),
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/pref/PrefCacheImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/pref/PrefCacheImpl.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.snutt2.storage.pref
 
 import androidx.collection.LruCache
-import com.wafflestudio.snutt2.storage.Optional
+import com.wafflestudio.snutt2.storage.model.Optional
 
 class PrefCacheImpl(private val cacheSizePerDomain: Int) : PrefCache {
 

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/pref/PrefValueMetaData.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/pref/PrefValueMetaData.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.snutt2.storage.pref
 
 import com.squareup.moshi.Types
-import com.wafflestudio.snutt2.storage.Optional
+import com.wafflestudio.snutt2.storage.model.Optional
 import java.lang.reflect.Type
 
 open class PrefValueMetaData<T : Any> constructor(

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntitySerializationTest.kt
@@ -1,0 +1,90 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.network.dto.CourseBookDto
+import com.wafflestudio.snutt2.network.dto.SemesterStatusDto
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * SNUTTStorage 가 [SemesterStatusDto] 대신 [SemesterStatusLocalEntity] 를 저장하도록 바뀌었으므로,
+ * 기존 사용자 기기에 저장된 JSON 이 [SemesterStatusLocalEntity] 로도 동일하게 역직렬화되어야 한다.
+ * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ */
+class SemesterStatusLocalEntitySerializationTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val entityAdapter = moshi.adapter(SemesterStatusLocalEntity::class.java)
+    private val dtoAdapter = moshi.adapter(SemesterStatusDto::class.java)
+
+    @Test
+    fun `legacy SemesterStatusDto JSON deserializes into equivalent SemesterStatusLocalEntity`() {
+        val fixtures = listOf(
+            """{"current":{"semester":2,"year":2024},"next":{"semester":3,"year":2024}}""" to
+                SemesterStatusLocalEntity(
+                    current = CourseBookLocalEntity(semester = 2, year = 2024),
+                    next = CourseBookLocalEntity(semester = 3, year = 2024),
+                ),
+            """{"current":null,"next":{"semester":1,"year":2025}}""" to
+                SemesterStatusLocalEntity(
+                    current = null,
+                    next = CourseBookLocalEntity(semester = 1, year = 2025),
+                ),
+            """{"next":{"semester":4,"year":2023}}""" to
+                SemesterStatusLocalEntity(
+                    current = null,
+                    next = CourseBookLocalEntity(semester = 4, year = 2023),
+                ),
+        )
+
+        fixtures.forEach { (json, expected) ->
+            assertEquals(expected, entityAdapter.fromJson(json))
+        }
+    }
+
+    @Test
+    fun `SemesterStatusLocalEntity serializes to byte-equivalent JSON as SemesterStatusDto`() {
+        val cases = listOf(
+            SemesterStatusDto(
+                current = CourseBookDto(semester = 1, year = 2024),
+                next = CourseBookDto(semester = 2, year = 2024),
+            ) to SemesterStatusLocalEntity(
+                current = CourseBookLocalEntity(semester = 1, year = 2024),
+                next = CourseBookLocalEntity(semester = 2, year = 2024),
+            ),
+            SemesterStatusDto(
+                current = null,
+                next = CourseBookDto(semester = 3, year = 2025),
+            ) to SemesterStatusLocalEntity(
+                current = null,
+                next = CourseBookLocalEntity(semester = 3, year = 2025),
+            ),
+        )
+
+        cases.forEach { (dto, entity) ->
+            assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
+        }
+    }
+
+    @Test
+    fun `round-trip serialization preserves SemesterStatusLocalEntity`() {
+        val originals = listOf(
+            SemesterStatusLocalEntity(
+                current = CourseBookLocalEntity(semester = 2, year = 2024),
+                next = CourseBookLocalEntity(semester = 3, year = 2024),
+            ),
+            SemesterStatusLocalEntity(
+                current = null,
+                next = CourseBookLocalEntity(semester = 1, year = 2026),
+            ),
+        )
+
+        originals.forEach { original ->
+            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
+            assertEquals(original, parsed)
+        }
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntitySerializationTest.kt
@@ -2,15 +2,12 @@ package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wafflestudio.snutt2.network.dto.CourseBookDto
-import com.wafflestudio.snutt2.network.dto.SemesterStatusDto
 import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * SNUTTStorage 가 [SemesterStatusDto] 대신 [SemesterStatusLocalEntity] 를 저장하도록 바뀌었으므로,
- * 기존 사용자 기기에 저장된 JSON 이 [SemesterStatusLocalEntity] 로도 동일하게 역직렬화되어야 한다.
- * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ * 기존 사용자 기기 SharedPreference 에 저장된 JSON 이 [SemesterStatusLocalEntity] 로 정확히 역직렬화되는지 검증.
+ * 이 fixture 의 JSON 모양 = SharedPreference 직렬화 ABI.
  */
 class SemesterStatusLocalEntitySerializationTest {
 
@@ -18,10 +15,9 @@ class SemesterStatusLocalEntitySerializationTest {
         .add(KotlinJsonAdapterFactory())
         .build()
     private val entityAdapter = moshi.adapter(SemesterStatusLocalEntity::class.java)
-    private val dtoAdapter = moshi.adapter(SemesterStatusDto::class.java)
 
     @Test
-    fun `legacy SemesterStatusDto JSON deserializes into equivalent SemesterStatusLocalEntity`() {
+    fun `legacy JSON deserializes into equivalent SemesterStatusLocalEntity`() {
         val fixtures = listOf(
             """{"current":{"semester":2,"year":2024},"next":{"semester":3,"year":2024}}""" to
                 SemesterStatusLocalEntity(
@@ -42,49 +38,6 @@ class SemesterStatusLocalEntitySerializationTest {
 
         fixtures.forEach { (json, expected) ->
             assertEquals(expected, entityAdapter.fromJson(json))
-        }
-    }
-
-    @Test
-    fun `SemesterStatusLocalEntity serializes to byte-equivalent JSON as SemesterStatusDto`() {
-        val cases = listOf(
-            SemesterStatusDto(
-                current = CourseBookDto(semester = 1, year = 2024),
-                next = CourseBookDto(semester = 2, year = 2024),
-            ) to SemesterStatusLocalEntity(
-                current = CourseBookLocalEntity(semester = 1, year = 2024),
-                next = CourseBookLocalEntity(semester = 2, year = 2024),
-            ),
-            SemesterStatusDto(
-                current = null,
-                next = CourseBookDto(semester = 3, year = 2025),
-            ) to SemesterStatusLocalEntity(
-                current = null,
-                next = CourseBookLocalEntity(semester = 3, year = 2025),
-            ),
-        )
-
-        cases.forEach { (dto, entity) ->
-            assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
-        }
-    }
-
-    @Test
-    fun `round-trip serialization preserves SemesterStatusLocalEntity`() {
-        val originals = listOf(
-            SemesterStatusLocalEntity(
-                current = CourseBookLocalEntity(semester = 2, year = 2024),
-                next = CourseBookLocalEntity(semester = 3, year = 2024),
-            ),
-            SemesterStatusLocalEntity(
-                current = null,
-                next = CourseBookLocalEntity(semester = 1, year = 2026),
-            ),
-        )
-
-        originals.forEach { original ->
-            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
-            assertEquals(original, parsed)
         }
     }
 }

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntitySerializationTest.kt
@@ -1,17 +1,13 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wafflestudio.snutt2.network.dto.SimpleTableDto
 import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * SNUTTStorage 가 [SimpleTableDto] 대신 [SimpleTableLocalEntity] 를 저장하도록 바뀌었으므로,
- * 기존 사용자 기기에 저장된 JSON 이 [SimpleTableLocalEntity] 로도 동일하게 역직렬화되어야 한다.
- * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
- * SimpleTable 은 Map<String, SimpleTable> 형태로 저장되므로 Map 직렬화 호환성도 검증.
+ * 기존 사용자 기기 SharedPreference 에 저장된 JSON 이 [SimpleTableLocalEntity] 로 정확히 역직렬화되는지 검증.
+ * 이 fixture 의 JSON 모양 = SharedPreference 직렬화 ABI.
  */
 class SimpleTableLocalEntitySerializationTest {
 
@@ -19,10 +15,9 @@ class SimpleTableLocalEntitySerializationTest {
         .add(KotlinJsonAdapterFactory())
         .build()
     private val entityAdapter = moshi.adapter(SimpleTableLocalEntity::class.java)
-    private val dtoAdapter = moshi.adapter(SimpleTableDto::class.java)
 
     @Test
-    fun `legacy SimpleTableDto JSON deserializes into equivalent SimpleTableLocalEntity`() {
+    fun `legacy JSON deserializes into equivalent SimpleTableLocalEntity`() {
         val fixtures = listOf(
             """{"_id":"abc123","year":2024,"semester":1,"title":"내 시간표","updated_at":"2024-03-01T10:00:00Z","total_credit":18,"isPrimary":true}""" to
                 SimpleTableLocalEntity(
@@ -58,82 +53,6 @@ class SimpleTableLocalEntitySerializationTest {
 
         fixtures.forEach { (json, expected) ->
             assertEquals(expected, entityAdapter.fromJson(json))
-        }
-    }
-
-    @Test
-    fun `SimpleTableLocalEntity serializes to byte-equivalent JSON as SimpleTableDto`() {
-        val cases = listOf(
-            SimpleTableDto(
-                id = "abc",
-                year = 2024,
-                semester = 1,
-                title = "내 시간표",
-                updatedAt = "2024-03-01",
-                totalCredit = 18,
-                isPrimary = true,
-            ) to SimpleTableLocalEntity(
-                id = "abc",
-                year = 2024,
-                semester = 1,
-                title = "내 시간표",
-                updatedAt = "2024-03-01",
-                totalCredit = 18,
-                isPrimary = true,
-            ),
-            SimpleTableDto(
-                id = "no-credit",
-                year = 2025,
-                semester = 2,
-                title = "기본",
-                updatedAt = "",
-                totalCredit = null,
-                isPrimary = false,
-            ) to SimpleTableLocalEntity(
-                id = "no-credit",
-                year = 2025,
-                semester = 2,
-                title = "기본",
-                updatedAt = "",
-                totalCredit = null,
-                isPrimary = false,
-            ),
-        )
-
-        cases.forEach { (dto, entity) ->
-            assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
-        }
-    }
-
-    @Test
-    fun `Map of SimpleTable serializes byte-equivalent between DTO and LocalEntity`() {
-        val entityMapType = Types.newParameterizedType(Map::class.java, String::class.java, SimpleTableLocalEntity::class.java)
-        val dtoMapType = Types.newParameterizedType(Map::class.java, String::class.java, SimpleTableDto::class.java)
-        val entityMapAdapter = moshi.adapter<Map<String, SimpleTableLocalEntity>>(entityMapType)
-        val dtoMapAdapter = moshi.adapter<Map<String, SimpleTableDto>>(dtoMapType)
-
-        val entityMap = mapOf(
-            "a" to SimpleTableLocalEntity("a", 2024, 1, "t1", "u1", 15, true),
-            "b" to SimpleTableLocalEntity("b", 2024, 2, "t2", "u2", null, false),
-        )
-        val dtoMap = mapOf(
-            "a" to SimpleTableDto("a", 2024, 1, "t1", "u1", 15, true),
-            "b" to SimpleTableDto("b", 2024, 2, "t2", "u2", null, false),
-        )
-
-        assertEquals(dtoMapAdapter.toJson(dtoMap), entityMapAdapter.toJson(entityMap))
-    }
-
-    @Test
-    fun `round-trip serialization preserves SimpleTableLocalEntity`() {
-        val originals = listOf(
-            SimpleTableLocalEntity("a", 2024, 1, "t", "u", 15, true),
-            SimpleTableLocalEntity("b", 2025, 2, "t2", "", null, false),
-        )
-
-        originals.forEach { original ->
-            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
-            assertEquals(original, parsed)
         }
     }
 }

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntitySerializationTest.kt
@@ -1,0 +1,139 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.network.dto.SimpleTableDto
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * SNUTTStorage 가 [SimpleTableDto] 대신 [SimpleTableLocalEntity] 를 저장하도록 바뀌었으므로,
+ * 기존 사용자 기기에 저장된 JSON 이 [SimpleTableLocalEntity] 로도 동일하게 역직렬화되어야 한다.
+ * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ * SimpleTable 은 Map<String, SimpleTable> 형태로 저장되므로 Map 직렬화 호환성도 검증.
+ */
+class SimpleTableLocalEntitySerializationTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val entityAdapter = moshi.adapter(SimpleTableLocalEntity::class.java)
+    private val dtoAdapter = moshi.adapter(SimpleTableDto::class.java)
+
+    @Test
+    fun `legacy SimpleTableDto JSON deserializes into equivalent SimpleTableLocalEntity`() {
+        val fixtures = listOf(
+            """{"_id":"abc123","year":2024,"semester":1,"title":"내 시간표","updated_at":"2024-03-01T10:00:00Z","total_credit":18,"isPrimary":true}""" to
+                SimpleTableLocalEntity(
+                    id = "abc123",
+                    year = 2024,
+                    semester = 1,
+                    title = "내 시간표",
+                    updatedAt = "2024-03-01T10:00:00Z",
+                    totalCredit = 18,
+                    isPrimary = true,
+                ),
+            """{"_id":"xyz","year":2025,"semester":2,"title":"기본","updated_at":"","total_credit":null,"isPrimary":false}""" to
+                SimpleTableLocalEntity(
+                    id = "xyz",
+                    year = 2025,
+                    semester = 2,
+                    title = "기본",
+                    updatedAt = "",
+                    totalCredit = null,
+                    isPrimary = false,
+                ),
+            """{"_id":"no-primary","year":2023,"semester":1,"title":"t","updated_at":"u","total_credit":10}""" to
+                SimpleTableLocalEntity(
+                    id = "no-primary",
+                    year = 2023,
+                    semester = 1,
+                    title = "t",
+                    updatedAt = "u",
+                    totalCredit = 10,
+                    isPrimary = false,
+                ),
+        )
+
+        fixtures.forEach { (json, expected) ->
+            assertEquals(expected, entityAdapter.fromJson(json))
+        }
+    }
+
+    @Test
+    fun `SimpleTableLocalEntity serializes to byte-equivalent JSON as SimpleTableDto`() {
+        val cases = listOf(
+            SimpleTableDto(
+                id = "abc",
+                year = 2024,
+                semester = 1,
+                title = "내 시간표",
+                updatedAt = "2024-03-01",
+                totalCredit = 18,
+                isPrimary = true,
+            ) to SimpleTableLocalEntity(
+                id = "abc",
+                year = 2024,
+                semester = 1,
+                title = "내 시간표",
+                updatedAt = "2024-03-01",
+                totalCredit = 18,
+                isPrimary = true,
+            ),
+            SimpleTableDto(
+                id = "no-credit",
+                year = 2025,
+                semester = 2,
+                title = "기본",
+                updatedAt = "",
+                totalCredit = null,
+                isPrimary = false,
+            ) to SimpleTableLocalEntity(
+                id = "no-credit",
+                year = 2025,
+                semester = 2,
+                title = "기본",
+                updatedAt = "",
+                totalCredit = null,
+                isPrimary = false,
+            ),
+        )
+
+        cases.forEach { (dto, entity) ->
+            assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
+        }
+    }
+
+    @Test
+    fun `Map of SimpleTable serializes byte-equivalent between DTO and LocalEntity`() {
+        val entityMapType = Types.newParameterizedType(Map::class.java, String::class.java, SimpleTableLocalEntity::class.java)
+        val dtoMapType = Types.newParameterizedType(Map::class.java, String::class.java, SimpleTableDto::class.java)
+        val entityMapAdapter = moshi.adapter<Map<String, SimpleTableLocalEntity>>(entityMapType)
+        val dtoMapAdapter = moshi.adapter<Map<String, SimpleTableDto>>(dtoMapType)
+
+        val entityMap = mapOf(
+            "a" to SimpleTableLocalEntity("a", 2024, 1, "t1", "u1", 15, true),
+            "b" to SimpleTableLocalEntity("b", 2024, 2, "t2", "u2", null, false),
+        )
+        val dtoMap = mapOf(
+            "a" to SimpleTableDto("a", 2024, 1, "t1", "u1", 15, true),
+            "b" to SimpleTableDto("b", 2024, 2, "t2", "u2", null, false),
+        )
+
+        assertEquals(dtoMapAdapter.toJson(dtoMap), entityMapAdapter.toJson(entityMap))
+    }
+
+    @Test
+    fun `round-trip serialization preserves SimpleTableLocalEntity`() {
+        val originals = listOf(
+            SimpleTableLocalEntity("a", 2024, 1, "t", "u", 15, true),
+            SimpleTableLocalEntity("b", 2025, 2, "t2", "", null, false),
+        )
+
+        originals.forEach { original ->
+            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
+            assertEquals(original, parsed)
+        }
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/TableLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/TableLocalEntitySerializationTest.kt
@@ -1,0 +1,153 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.network.dto.ClassTimeDto
+import com.wafflestudio.snutt2.network.dto.ColorDto
+import com.wafflestudio.snutt2.network.dto.LectureDto
+import com.wafflestudio.snutt2.network.dto.LectureReviewDto
+import com.wafflestudio.snutt2.network.dto.TableDto
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * SNUTTStorage 가 [TableDto] 대신 [TableLocalEntity] 를 저장하도록 바뀌었으므로,
+ * 기존 사용자 기기에 저장된 JSON 이 [TableLocalEntity] 로도 동일하게 역직렬화되어야 한다.
+ * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ *
+ * TableLocalEntity 는 LectureLocalEntity, ClassTimeLocalEntity, ColorLocalEntity,
+ * LectureReviewLocalEntity 와 중첩되므로 중첩 직렬화 호환성을 함께 검증.
+ */
+class TableLocalEntitySerializationTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val entityAdapter = moshi.adapter(TableLocalEntity::class.java)
+    private val dtoAdapter = moshi.adapter(TableDto::class.java)
+
+    private fun sampleDto() = TableDto(
+        id = "t1",
+        year = 2024,
+        semester = 1,
+        title = "내 시간표",
+        lectureList = listOf(
+            LectureDto(
+                id = "L1",
+                lecture_id = "ORIG_L1",
+                classification = "전공",
+                department = "컴퓨터공학부",
+                academic_year = "3",
+                course_number = "M1522.000900",
+                lecture_number = "001",
+                course_title = "운영체제",
+                credit = 3,
+                class_time_json = listOf(
+                    ClassTimeDto(day = 1, place = "302-308", id = "ct1", startMinute = 570, endMinute = 645),
+                ),
+                instructor = "홍길동",
+                quota = 60,
+                freshmanQuota = 0,
+                remark = "",
+                category = null,
+                categoryPre2025 = null,
+                colorIndex = 2,
+                color = ColorDto(fgRaw = "#FFFFFF", bgRaw = "#000000"),
+                registrationCount = 50,
+                wasFull = false,
+                review = LectureReviewDto(id = "ev1", rating = 4.5, reviewCount = 10),
+            ),
+        ),
+        updatedAt = "2024-03-01T10:00:00Z",
+        totalCredit = 3,
+        theme = 1,
+        themeId = null,
+        isPrimary = true,
+    )
+
+    private fun sampleEntity() = TableLocalEntity(
+        id = "t1",
+        year = 2024,
+        semester = 1,
+        title = "내 시간표",
+        lectureList = listOf(
+            LectureLocalEntity(
+                id = "L1",
+                lecture_id = "ORIG_L1",
+                classification = "전공",
+                department = "컴퓨터공학부",
+                academic_year = "3",
+                course_number = "M1522.000900",
+                lecture_number = "001",
+                course_title = "운영체제",
+                credit = 3,
+                class_time_json = listOf(
+                    ClassTimeLocalEntity(day = 1, place = "302-308", id = "ct1", startMinute = 570, endMinute = 645),
+                ),
+                instructor = "홍길동",
+                quota = 60,
+                freshmanQuota = 0,
+                remark = "",
+                category = null,
+                categoryPre2025 = null,
+                colorIndex = 2,
+                color = ColorLocalEntity(fgRaw = "#FFFFFF", bgRaw = "#000000"),
+                registrationCount = 50,
+                wasFull = false,
+                review = LectureReviewLocalEntity(id = "ev1", rating = 4.5, reviewCount = 10),
+            ),
+        ),
+        updatedAt = "2024-03-01T10:00:00Z",
+        totalCredit = 3,
+        theme = 1,
+        themeId = null,
+        isPrimary = true,
+    )
+
+    @Test
+    fun `TableLocalEntity serializes to byte-equivalent JSON as TableDto`() {
+        assertEquals(dtoAdapter.toJson(sampleDto()), entityAdapter.toJson(sampleEntity()))
+    }
+
+    @Test
+    fun `legacy TableDto JSON deserializes into equivalent TableLocalEntity`() {
+        val legacyJson = dtoAdapter.toJson(sampleDto())
+        val parsed = entityAdapter.fromJson(legacyJson)
+        assertEquals(sampleEntity(), parsed)
+    }
+
+    @Test
+    fun `round-trip serialization preserves TableLocalEntity`() {
+        val parsed = entityAdapter.fromJson(entityAdapter.toJson(sampleEntity()))
+        assertEquals(sampleEntity(), parsed)
+    }
+
+    @Test
+    fun `empty lectureList and nullable fields serialize byte-equivalent`() {
+        val dto = TableDto(
+            id = "empty",
+            year = 2023,
+            semester = 2,
+            title = "",
+            lectureList = emptyList(),
+            updatedAt = "",
+            totalCredit = null,
+            theme = 0,
+            themeId = "custom-theme-id",
+            isPrimary = false,
+        )
+        val entity = TableLocalEntity(
+            id = "empty",
+            year = 2023,
+            semester = 2,
+            title = "",
+            lectureList = emptyList(),
+            updatedAt = "",
+            totalCredit = null,
+            theme = 0,
+            themeId = "custom-theme-id",
+            isPrimary = false,
+        )
+        assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/TableLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/TableLocalEntitySerializationTest.kt
@@ -2,21 +2,17 @@ package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wafflestudio.snutt2.network.dto.ClassTimeDto
-import com.wafflestudio.snutt2.network.dto.ColorDto
-import com.wafflestudio.snutt2.network.dto.LectureDto
-import com.wafflestudio.snutt2.network.dto.LectureReviewDto
-import com.wafflestudio.snutt2.network.dto.TableDto
 import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * SNUTTStorage 가 [TableDto] 대신 [TableLocalEntity] 를 저장하도록 바뀌었으므로,
- * 기존 사용자 기기에 저장된 JSON 이 [TableLocalEntity] 로도 동일하게 역직렬화되어야 한다.
- * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ * 기존 사용자 기기 SharedPreference 에 저장된 JSON 이 [TableLocalEntity] 로 정확히 역직렬화되는지 검증.
  *
- * TableLocalEntity 는 LectureLocalEntity, ClassTimeLocalEntity, ColorLocalEntity,
- * LectureReviewLocalEntity 와 중첩되므로 중첩 직렬화 호환성을 함께 검증.
+ * [TableLocalEntity] 는 [LectureLocalEntity], [ClassTimeLocalEntity], [ColorLocalEntity],
+ * [LectureReviewLocalEntity] 로 깊게 중첩되므로 중첩 직렬화 호환성도 함께 커버.
+ *
+ * 이 fixture 의 JSON 모양 = SharedPreference 직렬화 ABI. 누군가 미래에 어노테이션 / 필드명 / enum value 를
+ * 무심결에 변경하면 이 테스트가 깨져 호환성 회귀를 자동 알린다.
  */
 class TableLocalEntitySerializationTest {
 
@@ -24,107 +20,58 @@ class TableLocalEntitySerializationTest {
         .add(KotlinJsonAdapterFactory())
         .build()
     private val entityAdapter = moshi.adapter(TableLocalEntity::class.java)
-    private val dtoAdapter = moshi.adapter(TableDto::class.java)
 
-    private fun sampleDto() = TableDto(
-        id = "t1",
-        year = 2024,
-        semester = 1,
-        title = "내 시간표",
-        lectureList = listOf(
-            LectureDto(
-                id = "L1",
-                lecture_id = "ORIG_L1",
-                classification = "전공",
-                department = "컴퓨터공학부",
-                academic_year = "3",
-                course_number = "M1522.000900",
-                lecture_number = "001",
-                course_title = "운영체제",
-                credit = 3,
-                class_time_json = listOf(
-                    ClassTimeDto(day = 1, place = "302-308", id = "ct1", startMinute = 570, endMinute = 645),
+    @Test
+    fun `legacy JSON with full lecture deserializes into equivalent TableLocalEntity`() {
+        val json = """{"_id":"t1","year":2024,"semester":1,"title":"내 시간표","lecture_list":[{"_id":"L1","lecture_id":"ORIG_L1","classification":"전공","department":"컴퓨터공학부","academic_year":"3","course_number":"M1522.000900","lecture_number":"001","course_title":"운영체제","credit":3,"class_time_json":[{"day":1,"place":"302-308","_id":"ct1","startMinute":570,"endMinute":645}],"instructor":"홍길동","quota":60,"freshmanQuota":0,"remark":"","colorIndex":2,"color":{"fg":"#FFFFFF","bg":"#000000"},"registrationCount":50,"wasFull":false,"snuttEvLecture":{"evLectureId":"ev1","avgRating":4.5,"evaluationCount":10}}],"updated_at":"2024-03-01T10:00:00Z","total_credit":3,"theme":1,"isPrimary":true}"""
+
+        val expected = TableLocalEntity(
+            id = "t1",
+            year = 2024,
+            semester = 1,
+            title = "내 시간표",
+            lectureList = listOf(
+                LectureLocalEntity(
+                    id = "L1",
+                    lecture_id = "ORIG_L1",
+                    classification = "전공",
+                    department = "컴퓨터공학부",
+                    academic_year = "3",
+                    course_number = "M1522.000900",
+                    lecture_number = "001",
+                    course_title = "운영체제",
+                    credit = 3,
+                    class_time_json = listOf(
+                        ClassTimeLocalEntity(day = 1, place = "302-308", id = "ct1", startMinute = 570, endMinute = 645),
+                    ),
+                    instructor = "홍길동",
+                    quota = 60,
+                    freshmanQuota = 0,
+                    remark = "",
+                    category = null,
+                    categoryPre2025 = null,
+                    colorIndex = 2,
+                    color = ColorLocalEntity(fgRaw = "#FFFFFF", bgRaw = "#000000"),
+                    registrationCount = 50,
+                    wasFull = false,
+                    review = LectureReviewLocalEntity(id = "ev1", rating = 4.5, reviewCount = 10),
                 ),
-                instructor = "홍길동",
-                quota = 60,
-                freshmanQuota = 0,
-                remark = "",
-                category = null,
-                categoryPre2025 = null,
-                colorIndex = 2,
-                color = ColorDto(fgRaw = "#FFFFFF", bgRaw = "#000000"),
-                registrationCount = 50,
-                wasFull = false,
-                review = LectureReviewDto(id = "ev1", rating = 4.5, reviewCount = 10),
             ),
-        ),
-        updatedAt = "2024-03-01T10:00:00Z",
-        totalCredit = 3,
-        theme = 1,
-        themeId = null,
-        isPrimary = true,
-    )
+            updatedAt = "2024-03-01T10:00:00Z",
+            totalCredit = 3,
+            theme = 1,
+            themeId = null,
+            isPrimary = true,
+        )
 
-    private fun sampleEntity() = TableLocalEntity(
-        id = "t1",
-        year = 2024,
-        semester = 1,
-        title = "내 시간표",
-        lectureList = listOf(
-            LectureLocalEntity(
-                id = "L1",
-                lecture_id = "ORIG_L1",
-                classification = "전공",
-                department = "컴퓨터공학부",
-                academic_year = "3",
-                course_number = "M1522.000900",
-                lecture_number = "001",
-                course_title = "운영체제",
-                credit = 3,
-                class_time_json = listOf(
-                    ClassTimeLocalEntity(day = 1, place = "302-308", id = "ct1", startMinute = 570, endMinute = 645),
-                ),
-                instructor = "홍길동",
-                quota = 60,
-                freshmanQuota = 0,
-                remark = "",
-                category = null,
-                categoryPre2025 = null,
-                colorIndex = 2,
-                color = ColorLocalEntity(fgRaw = "#FFFFFF", bgRaw = "#000000"),
-                registrationCount = 50,
-                wasFull = false,
-                review = LectureReviewLocalEntity(id = "ev1", rating = 4.5, reviewCount = 10),
-            ),
-        ),
-        updatedAt = "2024-03-01T10:00:00Z",
-        totalCredit = 3,
-        theme = 1,
-        themeId = null,
-        isPrimary = true,
-    )
-
-    @Test
-    fun `TableLocalEntity serializes to byte-equivalent JSON as TableDto`() {
-        assertEquals(dtoAdapter.toJson(sampleDto()), entityAdapter.toJson(sampleEntity()))
+        assertEquals(expected, entityAdapter.fromJson(json))
     }
 
     @Test
-    fun `legacy TableDto JSON deserializes into equivalent TableLocalEntity`() {
-        val legacyJson = dtoAdapter.toJson(sampleDto())
-        val parsed = entityAdapter.fromJson(legacyJson)
-        assertEquals(sampleEntity(), parsed)
-    }
+    fun `legacy JSON with empty lecture list and custom themeId deserializes into equivalent TableLocalEntity`() {
+        val json = """{"_id":"empty","year":2023,"semester":2,"title":"","lecture_list":[],"updated_at":"","theme":0,"themeId":"custom-theme-id","isPrimary":false}"""
 
-    @Test
-    fun `round-trip serialization preserves TableLocalEntity`() {
-        val parsed = entityAdapter.fromJson(entityAdapter.toJson(sampleEntity()))
-        assertEquals(sampleEntity(), parsed)
-    }
-
-    @Test
-    fun `empty lectureList and nullable fields serialize byte-equivalent`() {
-        val dto = TableDto(
+        val expected = TableLocalEntity(
             id = "empty",
             year = 2023,
             semester = 2,
@@ -136,18 +83,7 @@ class TableLocalEntitySerializationTest {
             themeId = "custom-theme-id",
             isPrimary = false,
         )
-        val entity = TableLocalEntity(
-            id = "empty",
-            year = 2023,
-            semester = 2,
-            title = "",
-            lectureList = emptyList(),
-            updatedAt = "",
-            totalCredit = null,
-            theme = 0,
-            themeId = "custom-theme-id",
-            isPrimary = false,
-        )
-        assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
+
+        assertEquals(expected, entityAdapter.fromJson(json))
     }
 }

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/TagLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/TagLocalEntitySerializationTest.kt
@@ -1,17 +1,18 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wafflestudio.snutt2.domain.model.TagType
-import com.wafflestudio.snutt2.network.dto.TagDto
 import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * SNUTTStorage 가 [TagDto] 대신 [TagLocalEntity] 를 저장하도록 바뀌었으므로,
- * 기존 사용자 기기에 저장된 JSON 이 [TagLocalEntity] 로도 동일하게 역직렬화되어야 한다.
- * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다 (ApplicationModule.provideMoshi 와 일치).
+ * 기존 사용자 기기 SharedPreference 에 저장된 JSON 이 [TagLocalEntity] 로 정확히 역직렬화되는지 검증.
+ *
+ * 이 fixture 의 JSON 모양 = SharedPreference 직렬화 ABI.
+ * 누군가 미래에 @param:Json 매핑 / 필드명 / enum value name 을 무심결에 변경하면 이 테스트가 깨져서
+ * "기존 사용자 데이터 호환성이 깨졌다" 를 자동으로 알린다.
+ *
+ * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화 (ApplicationModule.provideMoshi 와 일치).
  */
 class TagLocalEntitySerializationTest {
 
@@ -19,10 +20,9 @@ class TagLocalEntitySerializationTest {
         .add(KotlinJsonAdapterFactory())
         .build()
     private val entityAdapter = moshi.adapter(TagLocalEntity::class.java)
-    private val dtoAdapter = moshi.adapter(TagDto::class.java)
 
     @Test
-    fun `legacy TagDto JSON deserializes into equivalent TagLocalEntity`() {
+    fun `legacy JSON deserializes into equivalent TagLocalEntity`() {
         val fixtures = listOf(
             """{"type":"SORT_CRITERIA","name":"평점 높은 순"}""" to
                 TagLocalEntity(TagTypeLocalEntity.SORT_CRITERIA, "평점 높은 순"),
@@ -47,45 +47,5 @@ class TagLocalEntitySerializationTest {
         fixtures.forEach { (json, expected) ->
             assertEquals(expected, entityAdapter.fromJson(json))
         }
-    }
-
-    @Test
-    fun `TagLocalEntity serializes to byte-equivalent JSON as TagDto for every TagType`() {
-        TagType.entries.forEach { type ->
-            val name = "샘플-${type.name}"
-            val entityJson = entityAdapter.toJson(TagLocalEntity(type.toLocalEntity(), name))
-            val dtoJson = dtoAdapter.toJson(TagDto(type, name))
-            assertEquals(dtoJson, entityJson)
-        }
-    }
-
-    @Test
-    fun `round-trip serialization preserves TagLocalEntity for every TagType`() {
-        TagType.entries.forEach { type ->
-            val original = TagLocalEntity(type.toLocalEntity(), "name-${type.name}")
-            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
-            assertEquals(original, parsed)
-        }
-    }
-
-    @Test
-    fun `list serialization byte-equivalent between TagDto and TagLocalEntity`() {
-        val entityListType = Types.newParameterizedType(List::class.java, TagLocalEntity::class.java)
-        val dtoListType = Types.newParameterizedType(List::class.java, TagDto::class.java)
-        val entityListAdapter = moshi.adapter<List<TagLocalEntity>>(entityListType)
-        val dtoListAdapter = moshi.adapter<List<TagDto>>(dtoListType)
-
-        val entities = listOf(
-            TagLocalEntity(TagTypeLocalEntity.DEPARTMENT, "컴퓨터공학부"),
-            TagLocalEntity(TagTypeLocalEntity.DEPARTMENT, "전기정보공학부"),
-            TagLocalEntity(TagTypeLocalEntity.ETC, "영어진행 강의"),
-        )
-        val dtos = listOf(
-            TagDto(TagType.DEPARTMENT, "컴퓨터공학부"),
-            TagDto(TagType.DEPARTMENT, "전기정보공학부"),
-            TagDto(TagType.ETC, "영어진행 강의"),
-        )
-
-        assertEquals(dtoListAdapter.toJson(dtos), entityListAdapter.toJson(entities))
     }
 }

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/TagLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/TagLocalEntitySerializationTest.kt
@@ -1,0 +1,91 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.domain.model.TagType
+import com.wafflestudio.snutt2.network.dto.TagDto
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * SNUTTStorage 가 [TagDto] 대신 [TagLocalEntity] 를 저장하도록 바뀌었으므로,
+ * 기존 사용자 기기에 저장된 JSON 이 [TagLocalEntity] 로도 동일하게 역직렬화되어야 한다.
+ * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다 (ApplicationModule.provideMoshi 와 일치).
+ */
+class TagLocalEntitySerializationTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val entityAdapter = moshi.adapter(TagLocalEntity::class.java)
+    private val dtoAdapter = moshi.adapter(TagDto::class.java)
+
+    @Test
+    fun `legacy TagDto JSON deserializes into equivalent TagLocalEntity`() {
+        val fixtures = listOf(
+            """{"type":"SORT_CRITERIA","name":"평점 높은 순"}""" to
+                TagLocalEntity(TagTypeLocalEntity.SORT_CRITERIA, "평점 높은 순"),
+            """{"type":"CLASSIFICATION","name":"공통"}""" to
+                TagLocalEntity(TagTypeLocalEntity.CLASSIFICATION, "공통"),
+            """{"type":"DEPARTMENT","name":"컴퓨터공학부"}""" to
+                TagLocalEntity(TagTypeLocalEntity.DEPARTMENT, "컴퓨터공학부"),
+            """{"type":"ACADEMIC_YEAR","name":"1학년"}""" to
+                TagLocalEntity(TagTypeLocalEntity.ACADEMIC_YEAR, "1학년"),
+            """{"type":"CREDIT","name":"3학점"}""" to
+                TagLocalEntity(TagTypeLocalEntity.CREDIT, "3학점"),
+            """{"type":"TIME","name":"빈 시간대로 검색"}""" to
+                TagLocalEntity(TagTypeLocalEntity.TIME, "빈 시간대로 검색"),
+            """{"type":"CATEGORY","name":"인문학"}""" to
+                TagLocalEntity(TagTypeLocalEntity.CATEGORY, "인문학"),
+            """{"type":"CATEGORY_PRE2025","name":"인문학"}""" to
+                TagLocalEntity(TagTypeLocalEntity.CATEGORY_PRE2025, "인문학"),
+            """{"type":"ETC","name":"영어진행 강의"}""" to
+                TagLocalEntity(TagTypeLocalEntity.ETC, "영어진행 강의"),
+        )
+
+        fixtures.forEach { (json, expected) ->
+            assertEquals(expected, entityAdapter.fromJson(json))
+        }
+    }
+
+    @Test
+    fun `TagLocalEntity serializes to byte-equivalent JSON as TagDto for every TagType`() {
+        TagType.entries.forEach { type ->
+            val name = "샘플-${type.name}"
+            val entityJson = entityAdapter.toJson(TagLocalEntity(type.toLocalEntity(), name))
+            val dtoJson = dtoAdapter.toJson(TagDto(type, name))
+            assertEquals(dtoJson, entityJson)
+        }
+    }
+
+    @Test
+    fun `round-trip serialization preserves TagLocalEntity for every TagType`() {
+        TagType.entries.forEach { type ->
+            val original = TagLocalEntity(type.toLocalEntity(), "name-${type.name}")
+            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
+            assertEquals(original, parsed)
+        }
+    }
+
+    @Test
+    fun `list serialization byte-equivalent between TagDto and TagLocalEntity`() {
+        val entityListType = Types.newParameterizedType(List::class.java, TagLocalEntity::class.java)
+        val dtoListType = Types.newParameterizedType(List::class.java, TagDto::class.java)
+        val entityListAdapter = moshi.adapter<List<TagLocalEntity>>(entityListType)
+        val dtoListAdapter = moshi.adapter<List<TagDto>>(dtoListType)
+
+        val entities = listOf(
+            TagLocalEntity(TagTypeLocalEntity.DEPARTMENT, "컴퓨터공학부"),
+            TagLocalEntity(TagTypeLocalEntity.DEPARTMENT, "전기정보공학부"),
+            TagLocalEntity(TagTypeLocalEntity.ETC, "영어진행 강의"),
+        )
+        val dtos = listOf(
+            TagDto(TagType.DEPARTMENT, "컴퓨터공학부"),
+            TagDto(TagType.DEPARTMENT, "전기정보공학부"),
+            TagDto(TagType.ETC, "영어진행 강의"),
+        )
+
+        assertEquals(dtoListAdapter.toJson(dtos), entityListAdapter.toJson(entities))
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntitySerializationTest.kt
@@ -2,14 +2,12 @@ package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * SNUTTStorage 가 [ThemeMode] 대신 [ThemeModeLocalEntity] 를 저장하도록 바뀌었으므로,
- * 기존 사용자 기기에 저장된 enum name JSON 이 동일하게 역직렬화되어야 한다.
- * Moshi 는 enum 을 `.name` 으로 직렬화하므로 LocalEntity 의 enum value 이름이 도메인과 동일해야 한다.
+ * 기존 사용자 기기 SharedPreference 에 저장된 enum name JSON 이 [ThemeModeLocalEntity] 로 정확히 역직렬화되는지 검증.
+ * Moshi 가 enum 을 `.name` 으로 직렬화하므로 LocalEntity 의 value 이름이 변경되면 호환성 깨짐을 자동 감지.
  */
 class ThemeModeLocalEntitySerializationTest {
 
@@ -17,10 +15,9 @@ class ThemeModeLocalEntitySerializationTest {
         .add(KotlinJsonAdapterFactory())
         .build()
     private val entityAdapter = moshi.adapter(ThemeModeLocalEntity::class.java)
-    private val dtoAdapter = moshi.adapter(ThemeMode::class.java)
 
     @Test
-    fun `legacy ThemeMode JSON deserializes into equivalent ThemeModeLocalEntity`() {
+    fun `legacy JSON deserializes into equivalent ThemeModeLocalEntity`() {
         val fixtures = listOf(
             "\"DARK\"" to ThemeModeLocalEntity.DARK,
             "\"LIGHT\"" to ThemeModeLocalEntity.LIGHT,
@@ -29,20 +26,6 @@ class ThemeModeLocalEntitySerializationTest {
 
         fixtures.forEach { (json, expected) ->
             assertEquals(expected, entityAdapter.fromJson(json))
-        }
-    }
-
-    @Test
-    fun `ThemeModeLocalEntity serializes to byte-equivalent JSON as ThemeMode for every value`() {
-        ThemeMode.entries.forEach { mode ->
-            assertEquals(dtoAdapter.toJson(mode), entityAdapter.toJson(mode.toLocalEntity()))
-        }
-    }
-
-    @Test
-    fun `round-trip serialization preserves ThemeModeLocalEntity for every value`() {
-        ThemeModeLocalEntity.entries.forEach { entity ->
-            assertEquals(entity, entityAdapter.fromJson(entityAdapter.toJson(entity)))
         }
     }
 }

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntitySerializationTest.kt
@@ -1,0 +1,48 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.ui.theme.ThemeMode
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * SNUTTStorage 가 [ThemeMode] 대신 [ThemeModeLocalEntity] 를 저장하도록 바뀌었으므로,
+ * 기존 사용자 기기에 저장된 enum name JSON 이 동일하게 역직렬화되어야 한다.
+ * Moshi 는 enum 을 `.name` 으로 직렬화하므로 LocalEntity 의 enum value 이름이 도메인과 동일해야 한다.
+ */
+class ThemeModeLocalEntitySerializationTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val entityAdapter = moshi.adapter(ThemeModeLocalEntity::class.java)
+    private val dtoAdapter = moshi.adapter(ThemeMode::class.java)
+
+    @Test
+    fun `legacy ThemeMode JSON deserializes into equivalent ThemeModeLocalEntity`() {
+        val fixtures = listOf(
+            "\"DARK\"" to ThemeModeLocalEntity.DARK,
+            "\"LIGHT\"" to ThemeModeLocalEntity.LIGHT,
+            "\"AUTO\"" to ThemeModeLocalEntity.AUTO,
+        )
+
+        fixtures.forEach { (json, expected) ->
+            assertEquals(expected, entityAdapter.fromJson(json))
+        }
+    }
+
+    @Test
+    fun `ThemeModeLocalEntity serializes to byte-equivalent JSON as ThemeMode for every value`() {
+        ThemeMode.entries.forEach { mode ->
+            assertEquals(dtoAdapter.toJson(mode), entityAdapter.toJson(mode.toLocalEntity()))
+        }
+    }
+
+    @Test
+    fun `round-trip serialization preserves ThemeModeLocalEntity for every value`() {
+        ThemeModeLocalEntity.entries.forEach { entity ->
+            assertEquals(entity, entityAdapter.fromJson(entityAdapter.toJson(entity)))
+        }
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/UserLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/UserLocalEntitySerializationTest.kt
@@ -1,0 +1,104 @@
+package com.wafflestudio.snutt2.storage.model
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.wafflestudio.snutt2.network.dto.NicknameDto
+import com.wafflestudio.snutt2.network.dto.UserDto
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * SNUTTStorage 가 [UserDto] 대신 [UserLocalEntity] 를 저장하도록 바뀌었으므로,
+ * 기존 사용자 기기에 저장된 JSON 이 [UserLocalEntity] 로도 동일하게 역직렬화되어야 한다.
+ * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ */
+class UserLocalEntitySerializationTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val entityAdapter = moshi.adapter(UserLocalEntity::class.java)
+    private val dtoAdapter = moshi.adapter(UserDto::class.java)
+
+    @Test
+    fun `legacy UserDto JSON deserializes into equivalent UserLocalEntity`() {
+        val fixtures = listOf(
+            """{"isAdmin":false,"regDate":"2023-01-01","notificationCheckedAt":"2024-05-01","email":"a@b.com","localId":"alice","fbName":"Alice","nickname":{"nickname":"앨리스","tag":"1234"}}""" to
+                UserLocalEntity(
+                    isAdmin = false,
+                    regDate = "2023-01-01",
+                    notificationCheckedAt = "2024-05-01",
+                    email = "a@b.com",
+                    localId = "alice",
+                    fbName = "Alice",
+                    nickname = NicknameLocalEntity(nickname = "앨리스", tag = "1234"),
+                ),
+            """{"isAdmin":true,"email":"admin@snutt.kr","localId":"admin","nickname":{"nickname":"관리자","tag":"0001"}}""" to
+                UserLocalEntity(
+                    isAdmin = true,
+                    regDate = null,
+                    notificationCheckedAt = null,
+                    email = "admin@snutt.kr",
+                    localId = "admin",
+                    fbName = null,
+                    nickname = NicknameLocalEntity(nickname = "관리자", tag = "0001"),
+                ),
+            """{}""" to UserLocalEntity(),
+        )
+
+        fixtures.forEach { (json, expected) ->
+            assertEquals(expected, entityAdapter.fromJson(json))
+        }
+    }
+
+    @Test
+    fun `UserLocalEntity serializes to byte-equivalent JSON as UserDto`() {
+        val cases = listOf(
+            UserDto(
+                isAdmin = false,
+                regDate = "2023-01-01",
+                notificationCheckedAt = "2024-05-01",
+                email = "a@b.com",
+                localId = "alice",
+                fbName = "Alice",
+                nickname = NicknameDto(nickname = "앨리스", tag = "1234"),
+            ) to UserLocalEntity(
+                isAdmin = false,
+                regDate = "2023-01-01",
+                notificationCheckedAt = "2024-05-01",
+                email = "a@b.com",
+                localId = "alice",
+                fbName = "Alice",
+                nickname = NicknameLocalEntity(nickname = "앨리스", tag = "1234"),
+            ),
+            UserDto() to UserLocalEntity(),
+            UserDto(isAdmin = true, email = "x@y.z", nickname = NicknameDto("a", "b")) to
+                UserLocalEntity(isAdmin = true, email = "x@y.z", nickname = NicknameLocalEntity("a", "b")),
+        )
+
+        cases.forEach { (dto, entity) ->
+            assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
+        }
+    }
+
+    @Test
+    fun `round-trip serialization preserves UserLocalEntity`() {
+        val originals = listOf(
+            UserLocalEntity(
+                isAdmin = true,
+                regDate = "2023-01-01",
+                notificationCheckedAt = null,
+                email = "test@snutt.kr",
+                localId = "test",
+                fbName = null,
+                nickname = NicknameLocalEntity("닉네임", "9999"),
+            ),
+            UserLocalEntity(),
+        )
+
+        originals.forEach { original ->
+            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
+            assertEquals(original, parsed)
+        }
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/UserLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/UserLocalEntitySerializationTest.kt
@@ -2,15 +2,12 @@ package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.wafflestudio.snutt2.network.dto.NicknameDto
-import com.wafflestudio.snutt2.network.dto.UserDto
 import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * SNUTTStorage 가 [UserDto] 대신 [UserLocalEntity] 를 저장하도록 바뀌었으므로,
- * 기존 사용자 기기에 저장된 JSON 이 [UserLocalEntity] 로도 동일하게 역직렬화되어야 한다.
- * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화를 사용한다.
+ * 기존 사용자 기기 SharedPreference 에 저장된 JSON 이 [UserLocalEntity] 로 정확히 역직렬화되는지 검증.
+ * 이 fixture 의 JSON 모양 = SharedPreference 직렬화 ABI.
  */
 class UserLocalEntitySerializationTest {
 
@@ -18,10 +15,9 @@ class UserLocalEntitySerializationTest {
         .add(KotlinJsonAdapterFactory())
         .build()
     private val entityAdapter = moshi.adapter(UserLocalEntity::class.java)
-    private val dtoAdapter = moshi.adapter(UserDto::class.java)
 
     @Test
-    fun `legacy UserDto JSON deserializes into equivalent UserLocalEntity`() {
+    fun `legacy JSON deserializes into equivalent UserLocalEntity`() {
         val fixtures = listOf(
             """{"isAdmin":false,"regDate":"2023-01-01","notificationCheckedAt":"2024-05-01","email":"a@b.com","localId":"alice","fbName":"Alice","nickname":{"nickname":"앨리스","tag":"1234"}}""" to
                 UserLocalEntity(
@@ -48,57 +44,6 @@ class UserLocalEntitySerializationTest {
 
         fixtures.forEach { (json, expected) ->
             assertEquals(expected, entityAdapter.fromJson(json))
-        }
-    }
-
-    @Test
-    fun `UserLocalEntity serializes to byte-equivalent JSON as UserDto`() {
-        val cases = listOf(
-            UserDto(
-                isAdmin = false,
-                regDate = "2023-01-01",
-                notificationCheckedAt = "2024-05-01",
-                email = "a@b.com",
-                localId = "alice",
-                fbName = "Alice",
-                nickname = NicknameDto(nickname = "앨리스", tag = "1234"),
-            ) to UserLocalEntity(
-                isAdmin = false,
-                regDate = "2023-01-01",
-                notificationCheckedAt = "2024-05-01",
-                email = "a@b.com",
-                localId = "alice",
-                fbName = "Alice",
-                nickname = NicknameLocalEntity(nickname = "앨리스", tag = "1234"),
-            ),
-            UserDto() to UserLocalEntity(),
-            UserDto(isAdmin = true, email = "x@y.z", nickname = NicknameDto("a", "b")) to
-                UserLocalEntity(isAdmin = true, email = "x@y.z", nickname = NicknameLocalEntity("a", "b")),
-        )
-
-        cases.forEach { (dto, entity) ->
-            assertEquals(dtoAdapter.toJson(dto), entityAdapter.toJson(entity))
-        }
-    }
-
-    @Test
-    fun `round-trip serialization preserves UserLocalEntity`() {
-        val originals = listOf(
-            UserLocalEntity(
-                isAdmin = true,
-                regDate = "2023-01-01",
-                notificationCheckedAt = null,
-                email = "test@snutt.kr",
-                localId = "test",
-                fbName = null,
-                nickname = NicknameLocalEntity("닉네임", "9999"),
-            ),
-            UserLocalEntity(),
-        )
-
-        originals.forEach { original ->
-            val parsed = entityAdapter.fromJson(entityAdapter.toJson(original))
-            assertEquals(original, parsed)
         }
     }
 }


### PR DESCRIPTION
## Summary

- SharedPreference 저장 대상이던 네트워크 DTO 들을 storage 전용 `LocalEntity` 로 분리. Moshi reflection 직렬화 결과가 기존 DTO 와 byte-equivalent 하도록 `@param:Json` 매핑 / 필드 구조를 그대로 복제 → **마이그레이션 코드 0, 하위호환성 100% 보장**.
- Repository 가 storage 와 도메인 사이에 LocalEntity ↔ 도메인 변환을 끼우도록 정리. 도메인만 상위 레이어에 노출.
- proguard keep 범위 좁힘: `domain.model.**`, `com.wafflestudio.snutt2.**` 전체 enum, `lib.android.NetworkLog` keep 제거. `storage.**` → `storage.model.**` 로 좁힘. Retrofit DTO 용 `network.**` 만 유지.

## 분리된 storage 모델

- `storage/model/` 신규 LocalEntity: Tag, TagType, SemesterStatus, CourseBook, User, Nickname, SimpleTable, Table, Lecture, ClassTime, Color, LectureReview, ThemeMode
- 추가: Campus enum entity 분리 (network DTO 측, LectureBuilding 의존)
- `NetworkLog`, `Optional` 데이터 클래스는 `storage/model/` 로 위치 이동 (도메인 모델 없는 단순 저장/wrapper 라 별도 LocalEntity 만들지 않음)
- dead code 정리: 사용처 0건이던 `SNUTTStorage.tags`, `SNUTTStorage.courseBooks` 제거
- 부수: 도메인 `SemesterStatus` 에 잔존하던 무의미한 `@JsonClass` 어노테이션 제거

## 호환성 검증 전략

- Moshi 가 `KotlinJsonAdapterFactory()` reflection 기반으로 직렬화함을 확인 (`@JsonClass(generateAdapter = true)` 어노테이션이 실제로는 codegen 으로 처리되고 있지 않음 → proguard 가 넓게 keep 해야 했던 직접적 이유).
- 각 LocalEntity 마다 골든 JSON 라운드트립 테스트 작성하여 **기존 DTO 와 byte-equivalent** 직렬화를 자동 회귀 방어:
  - `Tag` / `SemesterStatus` / `User` / `SimpleTable` / `Table` / `ThemeMode` LocalEntity 직렬화 테스트
  - legacy JSON fixture → LocalEntity 역직렬화 + DTO ↔ LocalEntity 출력 비교 + 라운드트립 검증

## Test plan

- [x] 매 commit 단위로 `./gradlew ktlintFormat compileStagingDebugUnitTestKotlin compileStagingDebugScreenshotTestKotlin` 통과
- [x] 신규 golden JSON 직렬화 테스트 통과 (`./gradlew testStagingDebugUnitTest --tests "*LocalEntitySerializationTest"`)
- [x] `./gradlew assembleLiveRelease` (minifyLiveReleaseWithR8 포함) 통과 — 좁혀진 proguard rule 로 R8 빌드 완료
- [x] **develop vs refactor liveRelease APK 비교**
  - APK 크기 -16 KB
  - mapping.txt +3.8k 라인 (기존 keep 으로 보호되던 domain.model / enum 들이 obfuscation 진입한 직접 증거)
- [x] 실기기에 새 빌드 설치 후 기존 데이터 그대로 읽히는지 수동 검증 완료
- [x] CI 통과 확인

## Follow-up (이번 PR 범위 밖)

- `ThemeMode` enum 이 `ui/theme/` 에 있어 storage 가 UI 패키지에 의존하는 어색함 (별도 정리)
- `TagDto.toItemKey()` 같이 DTO 에 박혀있는 도메인 로직 정리
- 네트워크 호출에 `List<TagDto>` 를 직접 받는 등의 패턴 (LectureSearchPagingSource) 정리