### PR TITLE
fix: RangeBar 드래그 핸들 스냅/콜백 동작 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/TimetableConfigPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/TimetableConfigPage.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt2.feature.settings
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -29,8 +28,9 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,7 +59,6 @@ import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 import com.wafflestudio.snutt2.ui.theme.isDarkMode
 import com.wafflestudio.snutt2.ui.util.toast
-import kotlinx.coroutines.launch
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -337,10 +336,17 @@ private fun RangeBar(
     }
 
     val tickPx: Float = widthPx / tickNum
+    // 드래그 중에는 Animatable 을 건드리지 않고 dragOffset 만 갱신해 MutatorMutex 경합을 피한다.
+    // 손을 뗀 뒤 단일 코루틴에서 snapTo(드래그 끝 위치로 보정) → animateTo(가까운 tick) 순으로 스냅한다.
     val barStart = remember { Animatable(initStart * tickPx) }
-    val startTick = (barStart.value / tickPx).roundToInt()
     val barEnd = remember { Animatable(initEnd * tickPx) }
-    val endTick = (barEnd.value / tickPx).roundToInt()
+    var startDragOffset by remember { mutableStateOf<Float?>(null) }
+    var endDragOffset by remember { mutableStateOf<Float?>(null) }
+
+    val startDisplay = startDragOffset ?: barStart.value
+    val endDisplay = endDragOffset ?: barEnd.value
+    val startTick = (startDisplay / tickPx).roundToInt()
+    val endTick = (endDisplay / tickPx).roundToInt()
     val black = SNUTTColors.Black600
 
     Canvas(
@@ -359,49 +365,71 @@ private fun RangeBar(
         }
         drawLine(
             color = black,
-            start = Offset(x = barStart.value, y = lineOffset),
-            end = Offset(x = barEnd.value, y = lineOffset),
+            start = Offset(x = startDisplay, y = lineOffset),
+            end = Offset(x = endDisplay, y = lineOffset),
             strokeWidth = 3.dp.toPx(),
         )
         drawCircle(
             color = black,
             radius = 6.dp.toPx(),
-            center = Offset(x = barStart.value, y = lineOffset),
+            center = Offset(x = startDisplay, y = lineOffset),
         )
         drawCircle(
             color = black,
             radius = 6.dp.toPx(),
-            center = Offset(x = barEnd.value, y = lineOffset),
+            center = Offset(x = endDisplay, y = lineOffset),
         )
     }
     Label(
-        offset = barStart,
-        widthPx = widthPx,
-        tickPx = tickPx,
+        displayOffset = startDisplay,
         labelText = labelArray[startTick],
-    ) {
-        onChange(min(startTick, endTick), max(startTick, endTick))
-    }
-    Label(offset = barEnd, widthPx = widthPx, tickPx = tickPx, labelText = labelArray[endTick]) {
-        onChange(min(startTick, endTick), max(startTick, endTick))
-    }
+        onDragDelta = { delta ->
+            val current = startDragOffset ?: barStart.value
+            startDragOffset = (current + delta).coerceIn(0f, widthPx)
+        },
+        onDragStop = {
+            val finalDrag = startDragOffset ?: barStart.value
+            val target = (finalDrag / tickPx).roundToInt() * tickPx
+            barStart.snapTo(finalDrag)
+            startDragOffset = null
+            barStart.animateTo(target)
+            val newStart = (target / tickPx).roundToInt()
+            val currentEnd = (barEnd.value / tickPx).roundToInt()
+            onChange(min(newStart, currentEnd), max(newStart, currentEnd))
+        },
+    )
+    Label(
+        displayOffset = endDisplay,
+        labelText = labelArray[endTick],
+        onDragDelta = { delta ->
+            val current = endDragOffset ?: barEnd.value
+            endDragOffset = (current + delta).coerceIn(0f, widthPx)
+        },
+        onDragStop = {
+            val finalDrag = endDragOffset ?: barEnd.value
+            val target = (finalDrag / tickPx).roundToInt() * tickPx
+            barEnd.snapTo(finalDrag)
+            endDragOffset = null
+            barEnd.animateTo(target)
+            val currentStart = (barStart.value / tickPx).roundToInt()
+            val newEnd = (target / tickPx).roundToInt()
+            onChange(min(currentStart, newEnd), max(currentStart, newEnd))
+        },
+    )
 }
 
 @Composable
 private fun Label(
-    offset: Animatable<Float, AnimationVector1D>,
-    widthPx: Float,
-    tickPx: Float,
+    displayOffset: Float,
     labelText: String,
-    onChange: () -> Unit,
+    onDragDelta: (Float) -> Unit,
+    onDragStop: suspend () -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
-
     Box(
         modifier = Modifier
             .offset {
                 IntOffset(
-                    (offset.value - 13.dp.toPx()).roundToInt(),
+                    (displayOffset - 13.dp.toPx()).roundToInt(),
                     5.dp
                         .toPx()
                         .roundToInt(),
@@ -409,19 +437,8 @@ private fun Label(
             }
             .draggable(
                 orientation = Orientation.Horizontal,
-                state = rememberDraggableState { delta ->
-                    scope.launch {
-                        offset.snapTo(
-                            (offset.value + delta).coerceIn(0f, widthPx),
-                        )
-                    }
-                },
-                onDragStopped = {
-                    offset.animateTo(
-                        (offset.value / tickPx).roundToInt() * tickPx,
-                    )
-                    onChange()
-                },
+                state = rememberDraggableState(onDelta = onDragDelta),
+                onDragStopped = { onDragStop() },
             )
             .clip(CircleShape)
             .width(26.dp)


### PR DESCRIPTION
## Summary

시간표 설정 화면(`TimetableConfigPage`) 의 `RangeBar` 가 릴리즈 빌드 + 실기기 환경에서 두 가지 증상을 보이던 문제를 수정.

- 핸들이 정수 tick 으로 스냅되지 않고 중간 위치에서 멈춤
- `onChange` 콜백이 누락되거나 한 박자 늦게 반영 (예: 월→수 드래그 후에도 월 상태 유지)
- 드래그 중 캔버스의 색칠된 바 영역이 핸들을 따라오지 않음

## 원인

- **MutatorMutex 경합**: 드래그 delta 콜백이 `scope.launch { Animatable.snapTo() }` 로 코루틴을 메인 looper 큐에 적재. 손을 떼는 시점에 남아 있던 stale `snapTo` 가 `onDragStopped` 의 `animateTo` 를 `MutatePriority.Default` 동일 우선순위로 cancel → `animateTo` 가 `CancellationException` 으로 끝나면서 그 뒤의 `onChange()` 도 호출되지 않음. 실기기 + 릴리즈 빌드에서 delta 빈도가 높아 큐 잔여 가능성이 커서 재현이 잦음.
- **stale 캡처**: `onChange` 람다가 RangeBar 의 `startTick`/`endTick` 을 캡처. `snapTo→animateTo` 가 끝나야 RangeBar 가 recompose 되므로 콜백이 직전 composition 의 값을 들고 호출됨 → 한 박자 늦은 반영.
- **Canvas 미동기화**: `Canvas` 가 `Animatable.value` 만 읽음. 드래그 중에는 Animatable 이 갱신되지 않으므로 색칠 영역이 정지.

## 수정

- 드래그 중 위치를 `var dragOffset by mutableStateOf<Float?>(null)` 로 즉시 갱신. 코루틴/Animatable 모두 건드리지 않아 경합 자체가 사라짐.
- `onDragStop` 단일 코루틴 안에서 순차 `snapTo(드래그 끝 위치) → animateTo(가까운 tick)` 수행. 자기 자신을 cancel 할 수 없으므로 안전.
- `dragOffset` 을 `RangeBar` 레벨로 끌어올리고 Canvas/Label 이 모두 `displayOffset = dragOffset ?: animatable.value` 를 사용 → 색칠 영역도 드래그를 따라옴.
- `onChange` 인자는 stale 캡처가 아닌 방금 계산한 target tick 과 반대편 Animatable 현재값으로 직접 생성 → 즉시 반영.
- `Label` 시그니처를 `displayOffset: Float` + `onDragDelta` / `onDragStop` 두 콜백으로 단순화.

## Test plan

- [ ] (수동) 실기기 릴리즈 빌드에서 요일/시간 RangeBar 드래그 → 정수 tick 으로 스냅 확인
- [ ] (수동) 월→수 등 한 번의 드래그로 즉시 반영되는지 확인
- [ ] (수동) 드래그 중 캔버스의 색칠 영역이 핸들과 함께 움직이는지 확인
- [ ] (수동) 두 핸들이 교차하는 케이스(start > end 가 되는 드래그)에서 min/max 정렬 확인