### PR TITLE
refactor: DTO/도메인 경계 잔여 정리

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
@@ -2,21 +2,22 @@ package com.wafflestudio.snutt2.data.lecturesearch
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.wafflestudio.snutt2.data.mapper.toDto
+import com.wafflestudio.snutt2.domain.model.SearchTag
+import com.wafflestudio.snutt2.domain.model.SearchTime
 import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.dto.LectureDto
 import com.wafflestudio.snutt2.network.dto.PostSearchQueryParams
-import com.wafflestudio.snutt2.network.dto.SearchTimeDto
-import com.wafflestudio.snutt2.network.dto.TagDto
 
 class LectureSearchPagingSource(
     private val api: SNUTTRestApi,
     year: Long,
     semester: Long,
     title: String,
-    tags: List<TagDto>,
-    times: List<SearchTimeDto>?,
-    timesToExclude: List<SearchTimeDto>?,
+    tags: List<SearchTag>,
+    times: List<SearchTime>?,
+    timesToExclude: List<SearchTime>?,
 ) : PagingSource<Long, LectureDto>() {
 
     private val queryParam: PostSearchQueryParams = PostSearchQueryParams(
@@ -29,12 +30,12 @@ class LectureSearchPagingSource(
         department = tags.extractTagString(TagType.DEPARTMENT),
         category = tags.extractTagString(TagType.CATEGORY),
         categoryPre2025 = tags.extractTagString(TagType.CATEGORY_PRE2025),
-        times = times,
-        timesToExclude = timesToExclude,
+        times = times?.map { it.toDto() },
+        timesToExclude = timesToExclude?.map { it.toDto() },
         etc = tags.mapNotNull {
             when (it) {
-                TagDto.ETC_ENG -> "E"
-                TagDto.ETC_MILITARY -> "MO"
+                SearchTag.EtcEng -> "E"
+                SearchTag.EtcMilitary -> "MO"
                 else -> null
             }
         }.ifEmpty { null },
@@ -67,7 +68,7 @@ class LectureSearchPagingSource(
             ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
     }
 
-    private fun List<TagDto>.extractTagString(type: TagType): List<String> = filter { it.type == type }.map { it.name }
+    private fun List<SearchTag>.extractTagString(type: TagType): List<String> = filterIsInstance<SearchTag.Regular>().filter { it.type == type }.map { it.name }
 
     // FIXME: 서버 인터페이스 수정 필요, 클라단에서 불필요한 컨버팅으로 보임
     private fun String.toCreditNumber(): Long = substring(0, length - 2).toLong()

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
@@ -4,7 +4,6 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
-import com.wafflestudio.snutt2.data.mapper.toDto
 import com.wafflestudio.snutt2.data.mapper.toSearchedLecture
 import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.SearchTag
@@ -48,9 +47,9 @@ class LectureSearchRepositoryImpl @Inject constructor(
                 year = courseBook.year,
                 semester = courseBook.semester,
                 title = title,
-                tags = tags.map { it.toDto() },
-                times = times?.map { it.toDto() },
-                timesToExclude = timesToExclude?.map { it.toDto() },
+                tags = tags,
+                times = times,
+                timesToExclude = timesToExclude,
             )
         },
     ).flow.map { pagingData -> pagingData.map { it.toSearchedLecture() } }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/mapper/SearchMappers.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/mapper/SearchMappers.kt
@@ -1,17 +1,7 @@
 package com.wafflestudio.snutt2.data.mapper
 
-import com.wafflestudio.snutt2.domain.model.SearchTag
 import com.wafflestudio.snutt2.domain.model.SearchTime
 import com.wafflestudio.snutt2.network.dto.SearchTimeDto
-import com.wafflestudio.snutt2.network.dto.TagDto
-
-fun SearchTag.toDto(): TagDto = when (this) {
-    is SearchTag.Regular -> TagDto(type, name)
-    SearchTag.TimeEmpty -> TagDto.TIME_EMPTY
-    SearchTag.TimeSelect -> TagDto.TIME_SELECT
-    SearchTag.EtcEng -> TagDto.ETC_ENG
-    SearchTag.EtcMilitary -> TagDto.ETC_MILITARY
-}
 
 fun SearchTime.toDto(): SearchTimeDto = SearchTimeDto(
     // NOTE: DayOfWeek는 1이 월요일이고, 서버는 0이 월요일이다

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepository.kt
@@ -3,8 +3,8 @@ package com.wafflestudio.snutt2.data.user
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.domain.model.PushPreferences
 import com.wafflestudio.snutt2.domain.model.SocialProviders
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.domain.model.User
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.StateFlow
 
 interface UserRepository {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.wafflestudio.snutt2.data.mapper.toLocalEntity
 import com.wafflestudio.snutt2.domain.Unknown
 import com.wafflestudio.snutt2.domain.model.PushPreferences
 import com.wafflestudio.snutt2.domain.model.SocialProviders
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.domain.model.User
 import com.wafflestudio.snutt2.lib.map
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
@@ -38,7 +39,6 @@ import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.model.toLocalEntity
 import com.wafflestudio.snutt2.storage.model.toOptional
 import com.wafflestudio.snutt2.storage.model.unwrap
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/model/ThemeMode.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/model/ThemeMode.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.snutt2.domain.model
+
+enum class ThemeMode {
+    DARK,
+    LIGHT,
+    AUTO,
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ColorModeSelectViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ColorModeSelectViewModel.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.snutt2.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/PersonalInformationPolicyPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/PersonalInformationPolicyPage.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 
 @Composable
 fun PersonalInformationPolicyPage(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/RootViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/RootViewModel.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.snutt2.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ServiceInfoPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ServiceInfoPage.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 
 @Composable
 fun ServiceInfoPage(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
@@ -22,6 +22,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.wafflestudio.snutt2.BuildConfig
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.config.FeatureFlag
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
@@ -31,7 +32,6 @@ import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 
 @Composable
 fun SettingsRoute(
@@ -184,7 +184,13 @@ fun SettingsScreen(
                     onClick = onClickThemeModeSelect,
                 ) {
                     Text(
-                        text = stringResource(uiState.themeMode.labelResId),
+                        text = stringResource(
+                            when (uiState.themeMode) {
+                                ThemeMode.DARK -> R.string.theme_mode_dark
+                                ThemeMode.LIGHT -> R.string.theme_mode_light
+                                ThemeMode.AUTO -> R.string.theme_mode_auto
+                            },
+                        ),
                         style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
                     )
                 }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsViewModel.kt
@@ -7,9 +7,9 @@ import com.wafflestudio.snutt2.config.RemoteConfig
 import com.wafflestudio.snutt2.data.onFailure
 import com.wafflestudio.snutt2.data.onSuccess
 import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.logging.AnalyticsLogger
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsWebPageViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsWebPageViewModel.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.snutt2.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.user.UserRepository
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/TeamInfoPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/TeamInfoPage.kt
@@ -14,10 +14,10 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 
 @Composable
 fun TeamInfoPage(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ThemeModeSelectPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/ThemeModeSelectPage.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.components.compose.SimpleTopBar
@@ -24,7 +25,6 @@ import com.wafflestudio.snutt2.ui.components.compose.SnuttIcon
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 
 @Composable
 fun ThemeModeSelectPage(

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/TagDto.kt
@@ -7,11 +7,4 @@ import com.wafflestudio.snutt2.domain.model.TagType
 data class TagDto(
     val type: TagType,
     val name: String,
-) {
-    companion object {
-        val TIME_EMPTY: TagDto = TagDto(TagType.TIME, "빈 시간대로 검색")
-        val TIME_SELECT: TagDto = TagDto(TagType.TIME, "시간대 직접 선택")
-        val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
-        val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
-    }
-}
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/TagDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/TagDto.kt
@@ -14,6 +14,4 @@ data class TagDto(
         val ETC_ENG: TagDto = TagDto(TagType.ETC, "영어진행 강의")
         val ETC_MILITARY: TagDto = TagDto(TagType.ETC, "군휴학 원격수업")
     }
-
-    fun toItemKey(): String = type.toString() + name
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 
 enum class ThemeModeLocalEntity {
     DARK,

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/theme/Theme.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt2.ui.theme
 
 import android.content.Context
 import android.content.res.Configuration
-import androidx.annotation.StringRes
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
@@ -11,7 +10,7 @@ import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
-import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 
 private val LightThemeColors @Composable get() = lightColors(
     primary = SNUTTColors.White,
@@ -41,12 +40,6 @@ private val DarkThemeColors @Composable get() = darkColors(
 
 val Colors.onSurfaceVariant: Color
     get() = if (isLight) SNUTTColors.DarkerGray else SNUTTColors.Gray30
-
-enum class ThemeMode(@param:StringRes val labelResId: Int) {
-    DARK(R.string.theme_mode_dark),
-    LIGHT(R.string.theme_mode_light),
-    AUTO(R.string.theme_mode_auto),
-}
 
 val LocalThemeState = compositionLocalOf { ThemeMode.AUTO }
 

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeUserRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeUserRepository.kt
@@ -4,8 +4,8 @@ import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.model.PushPreferences
 import com.wafflestudio.snutt2.domain.model.SocialProviders
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.domain.model.User
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeUserRepository : UserRepository {

--- a/app/src/test/java/com/wafflestudio/snutt2/feature/settings/ColorModeSelectViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/feature/settings/ColorModeSelectViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.snutt2.feature.settings
 
+import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.fake.FakeUserRepository
-import com.wafflestudio.snutt2.ui.theme.ThemeMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher


### PR DESCRIPTION
PR #601 (SNUTTStorage 직렬화 모델 분리) 본문에 "이번 PR 범위 밖" 으로 적어둔 follow-up 3 가지 정리.

## Summary

- DTO 에 박혀있던 미사용 도메인 헬퍼 제거
- 도메인 모델(`ThemeMode`)이 UI 패키지에 있어 storage / data 가 ui 패키지를 import 하던 어색함 해소
- 데이터 레이어 내부에서 호출처가 도메인 → DTO 미리 변환해서 PagingSource 에게 넘기던 패턴을 PagingSource 가 캡슐화하도록 정리

## 변경

### 1. `refactor: 미사용 TagDto.toItemKey() 제거`
- 도메인 측 `SearchTag.toItemKey()` 가 이미 유일 사용처(`SearchResultList`) 를 cover 하고 있어 `TagDto.toItemKey()` 는 dead code 였음 → 단순 삭제로 "DTO 에 박힌 도메인 로직" 어색함 해소.

### 2. `refactor: ThemeMode 를 domain/model 로 이동, UI 의존 분리`
- `ui/theme/Theme.kt` 의 `ThemeMode` 를 `domain/model/ThemeMode` 로 이동 (순수 enum, `labelResId` 제거).
- 유일한 `labelResId` 사용처(`SettingsPage`) 는 그 자리에서 `when` 분기로 `stringResource` 직접 호출. 1회용 매핑이라 별도 확장 추출은 premature abstraction 이라 판단.
- storage / data / feature / test 13개 파일 import 일괄 갱신.

### 3. `refactor: LectureSearchPagingSource 의 input 파라미터를 도메인 모델로 변경`
- `LectureSearchPagingSource` constructor: `tags: List<TagDto>` → `List<SearchTag>`, `times/timesToExclude: List<SearchTimeDto>?` → `List<SearchTime>?`.
- 도메인 → DTO 변환을 PagingSource 가 내부에서 수행. 호출처(Repository) 는 도메인만 다루도록.
- `etc` 분기를 `TagDto.ETC_ENG/ETC_MILITARY` → `SearchTag.EtcEng/EtcMilitary` 로, `extractTagString` 확장을 `List<SearchTag>` 기반으로 재작성 (`SearchTag.Regular` 만 필터링).
- 사용처 0 가 된 `SearchTag.toDto()` 매퍼, `TagDto.TIME_EMPTY/TIME_SELECT/ETC_ENG/ETC_MILITARY` 정적 상수 제거 → `TagDto` 가 순수 데이터 클래스로 단순화.

## 의도적으로 남긴 부분

- **`LectureDto`** 는 `PagingSource<Long, LectureDto>` 의 output 자리. Paging 라이브러리 관점에서 PagingSource 는 data source 에 가까운 raw 자리고, DTO → 도메인 매핑은 Repository 의 `pagingData.map { it.toSearchedLecture() }` 로 처리. 라이브러리 표준 흐름과 맞아 그대로 유지.

## Test plan

- [x] 매 commit 단위로 `./gradlew ktlintFormat compileStagingDebugUnitTestKotlin compileStagingDebugScreenshotTestKotlin` 통과
- [x] 영향 받는 `ColorModeSelectViewModelTest` / `ThemeModeLocalEntitySerializationTest` 실행 통과
- [ ] CI 통과 확인