### PR TITLE
refactor: Moshi 직렬화를 reflection 에서 codegen 으로 전환

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,7 +165,8 @@ dependencies {
     implementation(libs.bundles.kotlin.core)
 
     // Networking
-    implementation(libs.bundles.moshi)
+    implementation(libs.moshi)
+    ksp(libs.moshi.kotlin.codegen)
     implementation(libs.bundles.retrofit)
 
     // Dependency Injection

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,12 +2,29 @@
 -keepattributes SourceFile,LineNumberTable        # Keep file names and line numbers.
 -keep public class * extends java.lang.Exception  # Optional: Keep custom exceptions.
 
-# SNUTTStorage 가 Moshi reflection (KotlinJsonAdapterFactory) 으로 직렬화하는 storage 전용 모델.
-# 모든 LocalEntity / NetworkLog / Optional wrapper 가 이 패키지에 위치한다 (enum 포함).
--keep class com.wafflestudio.snutt2.storage.model.** { *; }
+# Moshi codegen 으로 ${ClassName}JsonAdapter 가 생성되어 reflection-free 로 직/역직렬화한다.
+# Moshi 는 ${ClassName}JsonAdapter 를 reflection 으로 lookup 하므로 DTO 와 generated adapter 의
+# 클래스명이 paired 로 보존되어야 한다. generated adapter 가 DTO 생성자/property 를 직접 호출하므로
+# R8 이 멤버 그래프를 추적할 수 있어 멤버 전체 keep 은 불필요하다.
+-keep @com.squareup.moshi.JsonClass class * {
+    <init>(...);
+}
+-keep class **JsonAdapter { <init>(...); }
 
-# Retrofit + Moshi reflection 으로 직/역직렬화되는 네트워크 DTO.
--keep class com.wafflestudio.snutt2.network.** { *; }
+# SharedPreference 직렬화 ABI: Moshi 가 enum 을 enum.name 으로 직렬화하므로 value 이름이 변하면
+# 기존 사용자 기기에 저장된 JSON 과 매칭이 깨진다. @JsonClass 가 붙은 enum 은 Moshi 번들 룰이
+# 보호하지만 (META-INF/proguard/moshi.pro), 어노테이션 없는 enum 도 명시 보존한다.
+-keepclassmembers enum com.wafflestudio.snutt2.network.dto.** {
+    **[] values();
+    <fields>;
+}
+-keepclassmembers enum com.wafflestudio.snutt2.storage.model.** {
+    **[] values();
+    <fields>;
+}
+
+# Retrofit 이 런타임 동적 proxy 로 구현하는 API 인터페이스.
+-keep interface com.wafflestudio.snutt2.network.api.** { *; }
 
 # https://github.com/square/retrofit/issues/3751#issuecomment-1192043644
 # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).

--- a/app/src/main/java/com/wafflestudio/snutt2/di/ApplicationModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/ApplicationModule.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snutt2.di
 
 import android.content.Context
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.wafflestudio.snutt2.R
 import dagger.Module
 import dagger.Provides
@@ -21,9 +20,7 @@ object ApplicationModule {
 
     @Provides
     @Singleton
-    fun provideMoshi(): Moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    fun provideMoshi(): Moshi = Moshi.Builder().build()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/PushPreferenceDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/PushPreferenceDto.kt
@@ -1,5 +1,8 @@
 package com.wafflestudio.snutt2.network.dto
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class PushPreferenceDto(
     val pushPreferences: List<PushPreferenceItemDto>,
 )

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/PushPreferenceItemDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/PushPreferenceItemDto.kt
@@ -1,5 +1,8 @@
 package com.wafflestudio.snutt2.network.dto
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class PushPreferenceItemDto(
     val type: String,
     val isEnabled: Boolean,

--- a/app/src/main/java/com/wafflestudio/snutt2/network/error/ErrorBodyDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/error/ErrorBodyDto.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.snutt2.network.error
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ErrorBodyDto(
+    @param:Json(name = "errcode") val code: Int,
+    val message: String?,
+    val title: String?,
+    val displayMessage: String?,
+    val ext: Map<String, String>?,
+    val displayTitle: String?,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/network/error/ErrorParsedHttpException.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/error/ErrorParsedHttpException.kt
@@ -1,14 +1,5 @@
 package com.wafflestudio.snutt2.network.error
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
-@JsonClass(generateAdapter = true)
-data class ErrorParsedHttpException(
-    @param:Json(name = "errcode") val code: Int,
-    override val message: String?,
-    val title: String?,
-    val displayMessage: String?,
-    val ext: Map<String, String>?,
-    val displayTitle: String?,
-) : Exception(message)
+class ErrorParsedHttpException(
+    val body: ErrorBodyDto,
+) : Exception(body.message)

--- a/app/src/main/java/com/wafflestudio/snutt2/network/error/ErrorParsingCallAdapter.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/error/ErrorParsingCallAdapter.kt
@@ -54,10 +54,11 @@ private class ErrorParsingCall<T>(
 
         if (errorBody.isNotEmpty()) {
             try {
-                return serializer.deserialize<ErrorParsedHttpException>(
+                val body = serializer.deserialize<ErrorBodyDto>(
                     errorBody,
-                    ErrorParsedHttpException::class.java,
+                    ErrorBodyDto::class.java,
                 )
+                return ErrorParsedHttpException(body)
             } catch (_: Exception) {
                 // 파싱 실패 시 HttpException 으로 fallback
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/network/error/ExceptionMapper.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/error/ExceptionMapper.kt
@@ -32,9 +32,9 @@ fun Exception.toDomainError(): DomainError {
         is IOException -> NetworkDisconnect("", "")
         is CancellationException -> Nothing("", "")
         is ErrorParsedHttpException -> {
-            val displayTitle = this.displayTitle ?: ""
-            val displayMessage = this.displayMessage ?: ""
-            return when (this.code) {
+            val displayTitle = this.body.displayTitle ?: ""
+            val displayMessage = this.body.displayMessage ?: ""
+            return when (this.body.code) {
                 ErrorCode.SERVER_FAULT -> ServerFault(displayTitle, displayMessage)
                 ErrorCode.NO_ADMIN_PRIVILEGE -> NoAdminPrivilege(displayTitle, displayMessage)
                 ErrorCode.WRONG_API_KEY -> WrongApiKey(displayTitle, displayMessage)

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/NetworkLog.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/NetworkLog.kt
@@ -1,9 +1,12 @@
 package com.wafflestudio.snutt2.storage.model
 
+import com.squareup.moshi.JsonClass
+
 /**
  * 디버그 빌드에서 OkHttp 인터셉터가 캡처해 SNUTTStorage 에 저장하는 네트워크 호출 기록.
  * 도메인 모델이 아니고 단순 디버깅 데이터 클래스이므로 별도 LocalEntity 와 도메인 모델을 분리하지 않는다.
  */
+@JsonClass(generateAdapter = true)
 data class NetworkLog(
     val requestMethod: String,
     val requestUrl: String,

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/model/TableLectureCustomData.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/model/TableLectureCustomData.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.snutt2.storage.model
 
+import com.squareup.moshi.JsonClass
 import com.wafflestudio.snutt2.domain.model.TableLectureCustom
 
+@JsonClass(generateAdapter = true)
 data class TableLectureCustomData(
     val title: Boolean,
     val place: Boolean,

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/SemesterStatusLocalEntitySerializationTest.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -11,9 +10,7 @@ import kotlin.test.assertEquals
  */
 class SemesterStatusLocalEntitySerializationTest {
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val entityAdapter = moshi.adapter(SemesterStatusLocalEntity::class.java)
 
     @Test

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/SimpleTableLocalEntitySerializationTest.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -11,9 +10,7 @@ import kotlin.test.assertEquals
  */
 class SimpleTableLocalEntitySerializationTest {
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val entityAdapter = moshi.adapter(SimpleTableLocalEntity::class.java)
 
     @Test

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/TableLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/TableLocalEntitySerializationTest.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -16,9 +15,7 @@ import kotlin.test.assertEquals
  */
 class TableLocalEntitySerializationTest {
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val entityAdapter = moshi.adapter(TableLocalEntity::class.java)
 
     @Test

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/TagLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/TagLocalEntitySerializationTest.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -12,13 +11,11 @@ import kotlin.test.assertEquals
  * 누군가 미래에 @param:Json 매핑 / 필드명 / enum value name 을 무심결에 변경하면 이 테스트가 깨져서
  * "기존 사용자 데이터 호환성이 깨졌다" 를 자동으로 알린다.
  *
- * 앱 본체와 동일하게 [KotlinJsonAdapterFactory] 기반 reflection 직렬화 (ApplicationModule.provideMoshi 와 일치).
+ * 앱 본체와 동일하게 Moshi codegen 기반 직렬화 (ApplicationModule.provideMoshi 와 일치).
  */
 class TagLocalEntitySerializationTest {
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val entityAdapter = moshi.adapter(TagLocalEntity::class.java)
 
     @Test

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/ThemeModeLocalEntitySerializationTest.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -11,9 +10,7 @@ import kotlin.test.assertEquals
  */
 class ThemeModeLocalEntitySerializationTest {
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val entityAdapter = moshi.adapter(ThemeModeLocalEntity::class.java)
 
     @Test

--- a/app/src/test/java/com/wafflestudio/snutt2/storage/model/UserLocalEntitySerializationTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/storage/model/UserLocalEntitySerializationTest.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.storage.model
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -11,9 +10,7 @@ import kotlin.test.assertEquals
  */
 class UserLocalEntitySerializationTest {
 
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val moshi = Moshi.Builder().build()
     private val entityAdapter = moshi.adapter(UserLocalEntity::class.java)
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-intercepto
 
 # JSON
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
+moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
 # Dependency Injection
@@ -166,11 +166,6 @@ retrofit = [
     "retrofit",
     "retrofit-converter-moshi",
     "okhttp-logging-interceptor"
-]
-
-moshi = [
-    "moshi",
-    "moshi-kotlin"
 ]
 
 compose = [


### PR DESCRIPTION
## Summary

`@JsonClass(generateAdapter = true)` 가 코드베이스에 100여 곳 박혀 있었지만 `moshi-kotlin-codegen` 의존성이 빠져 있어 사실상 no-op 였고, 실제 직렬화는 `KotlinJsonAdapterFactory` (reflection) 가 처리하고 있었습니다. 이 PR 에서 어노테이션이 의도대로 동작하도록 codegen 으로 전환하고, 부수적으로 ProGuard 룰을 좁힙니다.

3개 커밋:

1. **`refactor: ErrorParsedHttpException 의 JSON body 를 ErrorBodyDto 로 분리`**
   - JSON 파싱 컨테이너 + Exception 두 역할을 겸하던 클래스를 분리 (codegen 은 `Exception` 상속 data class 처리 불가)
   - `ErrorBodyDto` (data class) + `ErrorParsedHttpException(body: ErrorBodyDto): Exception(body.message)`

2. **`refactor: Moshi 직렬화를 reflection 에서 codegen 으로 전환`**
   - `moshi-kotlin` (reflection) 제거 + `moshi-kotlin-codegen` 을 KSP 로 추가
   - `ApplicationModule.provideMoshi()` 의 `KotlinJsonAdapterFactory` 등록 제거
   - 어노테이션 누락 4개 클래스에 `@JsonClass(generateAdapter = true)` 추가
     (`PushPreferenceDto`, `PushPreferenceItemDto`, `NetworkLog`, `TableLectureCustomData`)
   - SharedPreference 직렬화 ABI 검증 테스트 6종을 본체와 동일 설정으로 정렬

3. **`refactor: ProGuard 룰을 Moshi codegen 환경에 맞게 축소`**
   - 기존: `-keep class .network.** { *; }` / `-keep class .storage.model.** { *; }` (광범위 keep)
   - 신규: codegen `*JsonAdapter` 의 reflection lookup 매칭에 필요한 최소 keep + enum value 이름 보존 (SharedPreference ABI 호환) + Retrofit 인터페이스 keep
   - 효과: stagingRelease classes.dex **9,229,880 → 9,056,700 bytes** (≈169KB / 1.9% 감소)

## 효과

- 런타임 reflection 제거로 시작 시 비용/`kotlin-reflect` 로딩 회피
- generated `*JsonAdapter` 가 reflection-free 코드라 R8 이 그래프를 정확히 추적 가능
- ProGuard 룰 축소 (광범위 keep → 의도 명시적 룰)

## Test plan

- [x] `./gradlew ktlintFormat compileStagingDebugUnitTestKotlin compileStagingDebugScreenshotTestKotlin` 통과
- [x] `:app:testStagingDebugUnitTest --tests "*SerializationTest"` 통과 — codegen adapter 가 기존 SharedPreference fixture 와 호환됨을 확인 (직렬화 ABI 회귀 없음)
- [x] `:app:minifyStagingReleaseWithR8` 통과
- [x] R8 `mapping.txt` 로 검증:
  - DTO 클래스명 보존 (`UserDto → UserDto`, `LectureDto → LectureDto`, `TableDto → TableDto`)
  - enum value 이름 보존 (`CampusDto.GWANAK → GWANAK`, `ThemeModeLocalEntity.AUTO → AUTO` 등) — SharedPreference enum.name 직렬화 ABI 안전
  - enum class 자체는 obfuscate 허용 (`CampusDto → ve0`) — JVM class reference 는 R8 이 일관 변환하므로 무관