### PR TITLE
fix: PagingSource 의 LoadResult.Page key 계산 및 예외 처리 정정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
@@ -9,6 +9,7 @@ import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.dto.LectureDto
 import com.wafflestudio.snutt2.network.dto.PostSearchQueryParams
+import kotlinx.coroutines.CancellationException
 
 class LectureSearchPagingSource(
     private val api: SNUTTRestApi,
@@ -55,18 +56,17 @@ class LectureSearchPagingSource(
             )
             LoadResult.Page(
                 data = response,
-                prevKey = if (offset == LECTURE_SEARCH_STARTING_PAGE_INDEX) null else offset - params.loadSize,
-                nextKey = if (response.isEmpty()) null else offset + params.loadSize,
+                prevKey = null,
+                nextKey = if (response.size < params.loadSize) null else offset + response.size,
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LoadResult.Error(e)
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Long, LectureDto>): Long? = state.anchorPosition?.let { anchorPosition ->
-        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
-            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
-    }
+    override fun getRefreshKey(state: PagingState<Long, LectureDto>): Long? = null
 
     private fun List<SearchTag>.extractTagString(type: TagType): List<String> = filterIsInstance<SearchTag.Regular>().filter { it.type == type }.map { it.name }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/data/notifications/NotificationPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/notifications/NotificationPagingSource.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.dto.NotificationDto
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 class NotificationPagingSource @Inject constructor(
@@ -20,18 +21,17 @@ class NotificationPagingSource @Inject constructor(
             )
             LoadResult.Page(
                 data = response,
-                prevKey = if (offset == NOTIFICATION_STARTING_PAGE_INDEX) null else offset - params.loadSize,
-                nextKey = if (response.isEmpty()) null else offset + params.loadSize,
+                prevKey = null,
+                nextKey = if (response.size < params.loadSize) null else offset + response.size,
             )
-        } catch (exception: Exception) {
-            LoadResult.Error(exception)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LoadResult.Error(e)
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Int, NotificationDto>): Int? = state.anchorPosition?.let { anchorPosition ->
-        state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
-            ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
-    }
+    override fun getRefreshKey(state: PagingState<Int, NotificationDto>): Int? = null
 
     companion object {
         const val NOTIFICATION_STARTING_PAGE_INDEX = 0


### PR DESCRIPTION
`LectureSearchPagingSource` / `NotificationPagingSource` 가 동일한 템플릿에서 복사된 채로 가지고 있던 어긋남 네 가지를 정리합니다. 사용자 체감 버그라기보다는 Paging 라이브러리 사용 정합성 정정에 가깝습니다.

## 변경

| 항목 | Before | After |
|---|---|---|
| `getRefreshKey` | `prevKey?.plus(1) ?: nextKey?.minus(1)` (페이지 번호 기반 패턴) | `null` (항상 첫 페이지부터 다시 로드) |
| `prevKey` | `offset - params.loadSize` | `null` |
| `nextKey` | `if (response.isEmpty()) null else offset + params.loadSize` | `if (response.size < params.loadSize) null else offset + response.size` |
| 예외 처리 | `catch (e: Exception)` 만 | `CancellationException` rethrow 후 `Exception` catch |

## 왜

### 1. `getRefreshKey` 가 offset 기반 페이징에 맞지 않았음

`prevKey?.plus(1) ?: nextKey?.minus(1)` 패턴은 Android 공식 문서의 **페이지 번호 기반(1, 2, 3…)** 예제에서 가져온 모양인데, 이 두 PagingSource 는 **offset 기반(0, 30, 60…)** 으로 동작합니다. `+1`/`-1` 로는 anchor 위치와 거의 무관한 key 가 나와 새로고침 시 의도와 다른 지점부터 다시 로드됐습니다.

검색 결과/알림 모두 사실상 forward-only 사용(처음 페이지부터 단조 증가) 이므로 `null` 반환 (= 매번 첫 페이지부터 다시 로드) 으로 단순화했습니다.

### 2. `prevKey` 가 페이지 경계와 어긋남

`PagingConfig` 가 `pageSize = 30` 만 명시하고 `initialLoadSize` 는 기본값(`= pageSize * 3 = 90`) 을 따르고 있어, 첫 호출은 `params.loadSize = 90`, 이후는 `30` 입니다. `prevKey = offset - params.loadSize` 는 이 경계와 어긋납니다(예: offset=90 에서 prevKey=60 이 나오지만 실제 직전 페이지는 offset=0).

forward-only 전제 하에 `null` 로 고정합니다. `getRefreshKey` 가 항상 `null` 을 반환하므로 prepend 가 트리거될 일이 없습니다.

### 3. `nextKey` 종료 조건이 한 번 더 호출하게 만들었음

`response.isEmpty()` 만 보면 마지막 페이지 뒤에 **빈 응답을 한 번 더 받아야** 멈춥니다. `response.size < params.loadSize` 로 바꿔 불필요한 마지막 호출을 제거하고, offset 누적도 `params.loadSize` 가 아닌 `response.size` 기준으로 정확하게 맞췄습니다.

### 4. `CancellationException` 까지 삼키고 있었음

`catch (e: Exception)` 이 `CancellationException` 까지 잡아 `LoadResult.Error(e)` 로 감쌌습니다. 코루틴 표준대로 `CancellationException` 만 먼저 rethrow 하고 나머지 `Exception` 만 `LoadResult.Error` 로 변환합니다. 코드베이스의 `ExceptionMapper.toDomainError()` 도 `CancellationException` 을 별도로 처리하므로 컨벤션과도 부합합니다.

## 의도적으로 남긴 부분

- `LectureDto` / `NotificationDto` 가 `PagingSource<_, Dto>` 의 output 자리에 있는 건 그대로 유지. PR #603 에서 명시한 라이브러리 표준 흐름(DTO → 도메인 매핑은 Repository 의 `pagingData.map` 으로) 을 따릅니다.

## Test plan

- [x] `./gradlew ktlintFormat compileStagingDebugUnitTestKotlin compileStagingDebugScreenshotTestKotlin` 통과
- [x] CI 통과 확인
- [x] (수동) 강의 검색 결과 무한 스크롤 정상 동작 확인
- [ ] (수동) 알림 리스트 무한 스크롤 정상 동작 확인