### PR TITLE
fix: 알림 외부 링크 deeplink 가 외부 앱으로 열리지 않던 문제 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationScreen.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snutt2.feature.notifications
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -26,6 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.wafflestudio.snutt2.R
@@ -52,6 +54,7 @@ fun NotificationRoute(
     onNavigateToBookmarkLectureDetail: (lectureId: String, year: Long, semester: Long) -> Unit,
     onNavigateToFriends: () -> Unit,
 ) {
+    val context = LocalContext.current
     val notificationList = viewModel.notificationList.collectAsLazyPagingItems()
     val notificationUiState = notificationList.notificationUiState()
 
@@ -72,6 +75,11 @@ fun NotificationRoute(
 
                 is NotificationUiEvent.NavigateToFriends ->
                     onNavigateToFriends()
+
+                is NotificationUiEvent.OpenExternalLink ->
+                    runCatching {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, event.url.toUri()))
+                    }
             }
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/notifications/NotificationsViewModel.kt
@@ -70,6 +70,10 @@ class NotificationsViewModel @Inject constructor(
                 is DeeplinkAction.Friends -> {
                     _uiEvent.emit(NotificationUiEvent.NavigateToFriends)
                 }
+
+                is DeeplinkAction.External -> {
+                    _uiEvent.emit(NotificationUiEvent.OpenExternalLink(action.url))
+                }
             }
         }
     }
@@ -88,4 +92,6 @@ sealed interface NotificationUiEvent {
     ) : NotificationUiEvent
 
     data object NavigateToFriends : NotificationUiEvent
+
+    data class OpenExternalLink(val url: String) : NotificationUiEvent
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/navigation/DeeplinkParser.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/navigation/DeeplinkParser.kt
@@ -18,6 +18,8 @@ sealed interface DeeplinkAction {
     ) : DeeplinkAction
 
     data object Friends : DeeplinkAction
+
+    data class External(val url: String) : DeeplinkAction
 }
 
 @Singleton
@@ -25,7 +27,7 @@ class DeeplinkParser @Inject constructor(
     @param:Named("AppScheme") private val appScheme: String,
 ) {
     fun parse(deeplink: String): DeeplinkAction? {
-        if (!deeplink.startsWith(appScheme)) return null
+        if (!deeplink.startsWith(appScheme)) return DeeplinkAction.External(deeplink)
         val uri = deeplink.toUri()
 
         return when (uri.host) {

--- a/app/src/test/java/com/wafflestudio/snutt2/feature/notifications/NotificationsViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/feature/notifications/NotificationsViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.wafflestudio.snutt2.feature.notifications
 
+import app.cash.turbine.test
+import com.wafflestudio.snutt2.domain.model.Notification
+import com.wafflestudio.snutt2.domain.model.NotificationType
 import com.wafflestudio.snutt2.fake.FakeNotificationRepository
 import com.wafflestudio.snutt2.navigation.DeeplinkParser
 import kotlinx.coroutines.Dispatchers
@@ -12,6 +15,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import java.time.LocalDateTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationsViewModelTest {
@@ -66,4 +70,30 @@ class NotificationsViewModelTest {
     }
 
     // endregion
+
+    // region onNotificationClick
+
+    @Test
+    fun `snutt 스킴이 아닌 deeplink 클릭 시 OpenExternalLink 이벤트가 발생한다`() = runTest {
+        viewModel = createViewModel()
+        val notification = createNotification(deeplink = "https://snutt.kr/notice")
+
+        viewModel.uiEvent.test {
+            viewModel.onNotificationClick(notification)
+            assertEquals(
+                NotificationUiEvent.OpenExternalLink("https://snutt.kr/notice"),
+                awaitItem(),
+            )
+        }
+    }
+
+    // endregion
+
+    private fun createNotification(deeplink: String?) = Notification(
+        title = "제목",
+        message = "내용",
+        createdAt = LocalDateTime.of(2026, 1, 1, 0, 0),
+        type = NotificationType.Megaphone,
+        deeplink = deeplink,
+    )
 }


### PR DESCRIPTION
## Summary

- #540 (DeeplinkExecutor 전체 삭제) 이후 새 DeeplinkParser 기반 구조로 옮겨오면서, `snutt://` 가 아닌 deeplink(http/https 등 외부 링크)가 silently 무시되던 회귀를 수정.
- 이전 `DeeplinkExecutor` 의 `if (uri.scheme?.contains(\"snutt\") == true) { 내부 } else { startActivity(ACTION_VIEW) }` 분기와 동치인 동작을 `DeeplinkAction.External` 로 추상화.
- Route 에서 `Intent.ACTION_VIEW` 로 외부 앱에 위임 (`runCatching` 으로 외부 앱 부재 시 안전하게 무시 — 기존 동작 보존).

## Background

- 외부 링크 처리는 #405 (2025-03-15) 에서 추가됐다가, #540 (2026-03-28) 의 "미사용 코드 제거" 에서 `DeeplinkExecutor.kt` 가 삭제되며 함께 유실됨.
- 같은 시기 #538 에서 도입된 새 `DeeplinkParser` 기반 구조에는 외부 링크 분기가 옮겨오지 않았음.

## Changes

- `DeeplinkParser` — `DeeplinkAction.External(url)` 케이스 추가. `appScheme` 으로 시작하지 않는 deeplink 는 `External` 로 반환.
- `NotificationsViewModel` — `DeeplinkAction.External` → `NotificationUiEvent.OpenExternalLink(url)` emit.
- `NotificationRoute` — `OpenExternalLink` 수신 시 `LocalContext` 로 `Intent.ACTION_VIEW` 실행.
- `NotificationsViewModelTest` — `snutt://` 가 아닌 deeplink 클릭 시 `OpenExternalLink` emit 되는지 회귀 테스트 추가.

## Test plan

- [x] `./gradlew ktlintFormat compileStagingDebugUnitTestKotlin compileStagingDebugScreenshotTestKotlin` 통과
- [x] `./gradlew :app:testStagingDebugUnitTest --tests "*.NotificationsViewModelTest"` 통과
- [ ] 실기기/에뮬레이터에서 외부 링크 deeplink (예: `https://snutt.kr/...`) 가 포함된 알림 클릭 시 브라우저(또는 매칭되는 외부 앱) 로 이동하는지 수동 확인
- [ ] 내부 deeplink (`snutt://` TimetableLecture / Bookmark / Friends) 가 기존대로 동작하는지 회귀 확인