### PR TITLE
refactor: SNUTTStorage DataStore 마이그레이션 사전 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,7 @@ node_modules/
 # Kotlin compiler session files (생성 시점에 따라 git status 에 잠시 떴다 사라짐)
 .kotlin/
 
+## claude
+.claude/worktrees/
+
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
@@ -72,17 +72,15 @@ class LectureSearchRepositoryImpl @Inject constructor(
     override fun storeRecentSearchedDepartment(tag: SearchTag) {
         check(tag is SearchTag.Regular)
         val entity = tag.toLocalEntity()
-        val previousStoredTags = storage.recentSearchedDepartments.get()
-        storage.recentSearchedDepartments.update(
-            (previousStoredTags.filter { it != entity } + entity).takeLast(5),
-        )
+        storage.recentSearchedDepartments.update { prev ->
+            (prev.filter { it != entity } + entity).takeLast(5)
+        }
     }
 
     override fun removeRecentSearchedDepartment(tag: SearchTag) {
         check(tag is SearchTag.Regular)
         val entity = tag.toLocalEntity()
-        val previousStoredTags = storage.recentSearchedDepartments.get()
-        storage.recentSearchedDepartments.update(previousStoredTags - entity)
+        storage.recentSearchedDepartments.update { it - entity }
     }
 
     companion object {

--- a/app/src/main/java/com/wafflestudio/snutt2/data/popup/PopupRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/popup/PopupRepositoryImpl.kt
@@ -46,11 +46,9 @@ class PopupRepositoryImpl @Inject constructor(
                 System.currentTimeMillis() + TimeUnit.DAYS.toMillis(hideDays.toLong())
             } ?: INFINITE_LONG_MILLIS
 
-            storage.shownPopupIdsAndTimestamp.update(
-                storage.shownPopupIdsAndTimestamp.get()
-                    .toMutableMap()
-                    .also { it[popup.key] = expiredDay },
-            )
+            storage.shownPopupIdsAndTimestamp.update { prev ->
+                prev.toMutableMap().also { it[popup.key] = expiredDay }
+            }
 
             _popups.value = _popups.value?.drop(1)
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/semesterstatus/SemesterStatusRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/semesterstatus/SemesterStatusRepositoryImpl.kt
@@ -3,15 +3,15 @@ package com.wafflestudio.snutt2.data.semesterstatus
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.mapper.toDomain
 import com.wafflestudio.snutt2.domain.model.SemesterStatus
+import com.wafflestudio.snutt2.lib.map
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.error.toDomainError
 import com.wafflestudio.snutt2.storage.SNUTTStorage
 import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.model.toLocalEntity
 import com.wafflestudio.snutt2.storage.model.toOptional
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -19,21 +19,18 @@ import javax.inject.Singleton
 class SemesterStatusRepositoryImpl @Inject constructor(
     private val api: SNUTTRestApi,
     private val storage: SNUTTStorage,
+    externalScope: CoroutineScope,
 ) : SemesterStatusRepository {
 
-    private val _semesterStatus: MutableStateFlow<SemesterStatus?> =
-        MutableStateFlow(storage.semesterStatus.get().value?.toDomainModel())
-    override val semesterStatus: StateFlow<SemesterStatus?> = _semesterStatus.asStateFlow()
+    override val semesterStatus: StateFlow<SemesterStatus?> =
+        storage.semesterStatus.asStateFlow().map(externalScope) { it.value?.toDomainModel() }
 
-    override suspend fun fetchSemesterStatus(): Result<Unit> {
-        try {
-            val response = api._getSemesterStatus()
-            val domain = response.toDomain()
-            storage.semesterStatus.update(domain.toLocalEntity().toOptional())
-            _semesterStatus.value = domain
-            return Result.Success(Unit)
-        } catch (e: Exception) {
-            return Result.Fail(e.toDomainError())
-        }
+    override suspend fun fetchSemesterStatus(): Result<Unit> = try {
+        val response = api._getSemesterStatus()
+        val domain = response.toDomain()
+        storage.semesterStatus.update(domain.toLocalEntity().toOptional())
+        Result.Success(Unit)
+    } catch (e: Exception) {
+        Result.Fail(e.toDomainError())
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/data/tabledisplay/TableDisplayRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/tabledisplay/TableDisplayRepositoryImpl.kt
@@ -38,16 +38,15 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun toggleForceFit(): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableTrimParam.get()
-            storage.tableTrimParam.update(
+            storage.tableTrimParam.update { prev ->
                 TableTrimParam(
-                    dayOfWeekFrom = prevTrimParam.dayOfWeekFrom,
-                    dayOfWeekTo = prevTrimParam.dayOfWeekTo,
-                    hourFrom = prevTrimParam.hourFrom,
-                    hourTo = prevTrimParam.hourTo,
-                    forceFitLectures = prevTrimParam.forceFitLectures.not(),
-                ).toDataModel(),
-            )
+                    dayOfWeekFrom = prev.dayOfWeekFrom,
+                    dayOfWeekTo = prev.dayOfWeekTo,
+                    hourFrom = prev.hourFrom,
+                    hourTo = prev.hourTo,
+                    forceFitLectures = prev.forceFitLectures.not(),
+                ).toDataModel()
+            }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -56,16 +55,15 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun setDayOfWeekRange(from: Int, to: Int): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableTrimParam.get()
-            storage.tableTrimParam.update(
+            storage.tableTrimParam.update { prev ->
                 TableTrimParam(
                     dayOfWeekFrom = from,
                     dayOfWeekTo = to,
-                    hourFrom = prevTrimParam.hourFrom,
-                    hourTo = prevTrimParam.hourTo,
-                    forceFitLectures = prevTrimParam.forceFitLectures,
-                ).toDataModel(),
-            )
+                    hourFrom = prev.hourFrom,
+                    hourTo = prev.hourTo,
+                    forceFitLectures = prev.forceFitLectures,
+                ).toDataModel()
+            }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -74,16 +72,15 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun setHourRange(from: Int, to: Int): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableTrimParam.get()
-            storage.tableTrimParam.update(
+            storage.tableTrimParam.update { prev ->
                 TableTrimParam(
-                    dayOfWeekFrom = prevTrimParam.dayOfWeekFrom,
-                    dayOfWeekTo = prevTrimParam.dayOfWeekTo,
+                    dayOfWeekFrom = prev.dayOfWeekFrom,
+                    dayOfWeekTo = prev.dayOfWeekTo,
                     hourFrom = from,
                     hourTo = to,
-                    forceFitLectures = prevTrimParam.forceFitLectures,
-                ).toDataModel(),
-            )
+                    forceFitLectures = prev.forceFitLectures,
+                ).toDataModel()
+            }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -92,8 +89,7 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun toggleCompactMode(): Result<Unit> {
         try {
-            val compactMode = storage.compactMode.get()
-            storage.compactMode.update(compactMode.not())
+            storage.compactMode.update { it.not() }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -102,10 +98,7 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun toggleTitleVisible(): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableLectureCustom.get()
-            storage.tableLectureCustom.update(
-                prevTrimParam.copy(title = prevTrimParam.title.not()),
-            )
+            storage.tableLectureCustom.update { it.copy(title = it.title.not()) }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -114,10 +107,7 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun togglePlaceVisible(): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableLectureCustom.get()
-            storage.tableLectureCustom.update(
-                prevTrimParam.copy(place = prevTrimParam.place.not()),
-            )
+            storage.tableLectureCustom.update { it.copy(place = it.place.not()) }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -126,10 +116,7 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun toggleLectureNumberVisible(): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableLectureCustom.get()
-            storage.tableLectureCustom.update(
-                prevTrimParam.copy(lectureNumber = prevTrimParam.lectureNumber.not()),
-            )
+            storage.tableLectureCustom.update { it.copy(lectureNumber = it.lectureNumber.not()) }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())
@@ -138,10 +125,7 @@ class TableDisplayRepositoryImpl @Inject constructor(
 
     override suspend fun toggleInstructorVisible(): Result<Unit> {
         try {
-            val prevTrimParam = storage.tableLectureCustom.get()
-            storage.tableLectureCustom.update(
-                prevTrimParam.copy(instructor = prevTrimParam.instructor.not()),
-            )
+            storage.tableLectureCustom.update { it.copy(instructor = it.instructor.not()) }
             return Result.Success(Unit)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
@@ -12,6 +12,7 @@ import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.lib.android.DisplayMessageResolverImpl
 import com.wafflestudio.snutt2.lib.android.createNewNetworkLog
 import com.wafflestudio.snutt2.lib.serializer.Serializer
+import com.wafflestudio.snutt2.network.AuthInterceptor
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.error.ErrorParsingCallAdapterFactory
 import com.wafflestudio.snutt2.storage.SNUTTStorage
@@ -41,20 +42,12 @@ object NetworkModule {
     fun provideOkHttpClient(
         @ApplicationContext context: Context,
         snuttStorage: SNUTTStorage,
+        authInterceptor: AuthInterceptor,
     ): OkHttpClient {
         val cache = Cache(File(context.cacheDir, "http"), SIZE_OF_CACHE)
         return OkHttpClient.Builder()
             .cache(cache)
-            .addInterceptor { chain ->
-                val token = snuttStorage.accessToken.get()
-                val newRequest = chain.request().newBuilder()
-                    .addHeader(
-                        "x-access-token",
-                        token,
-                    )
-                    .build()
-                chain.proceed(newRequest)
-            }
+            .addInterceptor(authInterceptor)
             .addInterceptor { chain ->
                 val newRequest = chain.request().newBuilder()
                     .addHeader(

--- a/app/src/main/java/com/wafflestudio/snutt2/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/AuthInterceptor.kt
@@ -1,0 +1,34 @@
+package com.wafflestudio.snutt2.network
+
+import com.wafflestudio.snutt2.storage.SNUTTStorage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthInterceptor @Inject constructor(
+    snuttStorage: SNUTTStorage,
+    externalScope: CoroutineScope,
+) : Interceptor {
+
+    private val accessToken = snuttStorage.accessToken.asStateFlow()
+
+    @Volatile
+    private var token: String = accessToken.value
+
+    init {
+        externalScope.launch {
+            accessToken.collect { token = it }
+        }
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val newRequest = chain.request().newBuilder()
+            .addHeader("x-access-token", token)
+            .build()
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorageExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/SNUTTStorageExt.kt
@@ -3,15 +3,7 @@ package com.wafflestudio.snutt2.storage
 import com.wafflestudio.snutt2.storage.model.NetworkLog
 
 fun SNUTTStorage.addNetworkLog(newLog: NetworkLog) {
-    networkLog.update(
-        networkLog.get().toMutableList().apply {
-            add(0, newLog)
-        }.let {
-            if (it.size > 100) {
-                it.subList(0, 100)
-            } else {
-                it
-            }
-        },
-    )
+    networkLog.update { prev ->
+        (listOf(newLog) + prev).take(100)
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/storage/pref/PrefValue.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/storage/pref/PrefValue.kt
@@ -25,6 +25,10 @@ class PrefValue<T : Any> constructor(
         prefContext.putValue(metaData.domain, metaData.key, value, metaData.type)
     }
 
+    fun update(transform: (T) -> T) {
+        update(transform(get()))
+    }
+
     fun clear() {
         prefContext.removeValue(metaData.domain, metaData.key)
     }


### PR DESCRIPTION
## Summary

추후 `SNUTTStorage` 의 backing 을 SharedPreferences → DataStore 로 옮길 때를 대비해, 동기 I/O 와 storage 의존성을 미리 정리한 사전 작업 묶음입니다. 기능 변경 없음.

- **`SemesterStatusRepositoryImpl` seed-pattern 제거** (`11607331`)
  별도 `MutableStateFlow` 를 `storage.semesterStatus.get()` 으로 seed 한 뒤 fetch 시 storage 와 이중 갱신하던 구조를 없애고, `storage.semesterStatus.asStateFlow().map(externalScope)` 로 storage 가 단일 진실 원천이 되도록 변경. 동기 read 1 곳 제거 + 외부 storage 변경 (clearLoginScope 등) 이 반영되지 않을 위험도 해소.

- **`PrefValue.update(transform)` overload 도입 + read-modify-write 호출처 정리** (`b4385f22`)
  `prev = get()` 직후 `update(prev.modify())` 하는 read-modify-write 패턴 12 곳을 `update { prev -> ... }` 한 줄로 통일. DataStore 도입 시 같은 메서드를 suspend + `dataStore.edit { }` atomic 트랜잭션으로 업그레이드할 수 있어 호출처 변경이 최소화됨. 동시에 PrefValue 내부 변수명 `asdf` → `state` 로 정리.
  대상: `TableDisplayRepositoryImpl` 8 / `LectureSearchRepositoryImpl` 2 / `PopupRepositoryImpl` 1 / `SNUTTStorageExt.addNetworkLog` 1.
  순수 read 인 `.get()` 호출처 (TableRepositoryImpl, CurrentTableLectureRepositoryImpl, UserRepositoryImpl 156/172 등) 는 이번 범위 제외.

- **`AuthInterceptor` 분리 및 토큰 in-memory 캐시화** (`9bfe260b`)
  `NetworkModule.provideOkHttpClient` 안 inline 람다로 작성되어 있던 access token 인터셉터를 `AuthInterceptor` 클래스로 분리. application scope 에서 `accessToken.asStateFlow()` 를 구독해 `@Volatile var token` 에 최신값을 유지하고, `intercept()` 는 캐시된 token 만 동기 read. OkHttp Interceptor 의 동기 계약과 DataStore 의 suspend read 사이의 임피던스를 클래스 내부에 가둠.

- **`.gitignore` 에 `.claude/worktrees/` 추가** (`3849e802`)

## 범위 외 (별도 PR 또는 DataStore 본 마이그레이션 PR 에서 처리)

- `NetworkLog` 인터셉터 (`NetworkModule` · `NetworkModuleForGoogle` 양쪽) 의 동기 write. Interceptor 의 동기 계약 안에서 suspend 호출이 불가능해지므로 별도 SharedFlow 버퍼 + async consumer 패턴 등이 필요.
- 순수 read `.get()` 호출처들 (`lastViewedTable.get().value`, `prefKeyUserId.get().value`, `UserRepositoryImpl::getAccessToken` 의 `accessToken.get()` 등). 이건 `get()` 시그니처를 suspend 로 바꾸는 큰 변경이므로 DataStore 본 PR 에서 일괄 처리.

## Test plan

- [ ] 로그인 → 로그아웃 → 재로그인 시 `AuthInterceptor` 의 토큰이 정상적으로 갱신되어 모든 API 가 401 없이 통과
- [ ] 앱 첫 실행 시 토큰 없는 상태에서 로그인 화면이 정상 노출 (캐시 초기값 race 없음)
- [ ] 학기 변경 (semester picker) 후 시간표/검색 화면에 새 학기 정보 반영
- [ ] 로그아웃 (clearLoginScope) 후 `SemesterStatus` 가 `null` 로 떨어지고 UI 가 알맞게 처리
- [ ] 설정 화면에서 `compactMode` / `tableTrimParam` (요일·시간 범위) / `forceFitLectures` / `tableLectureCustom` (title·place·instructor·lectureNumber 보임 토글) 정상 반영
- [ ] 강의 검색에서 최근 학과 태그 추가/삭제 정상 동작 (5 개 한도 유지)
- [ ] 팝업 hide 처리 후 재진입 시 만료 전에는 다시 표시되지 않음
- [ ] Debug build 의 network log 화면이 정상 누적 (Interceptor 변경 회귀 확인)