### PR TITLE
chore: AndroidManifest 정리 및 사용하지 않는 google-id 의존성 제거

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -207,7 +207,6 @@ dependencies {
 
     // Authentication
     implementation(libs.google.auth)
-    implementation(libs.google.id)
 
     // Kakao SDK
     implementation(libs.bundles.kakao)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.wafflestudio.snutt2">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -34,10 +33,11 @@
             android:resource="@drawable/ic_notification" />
 
         <activity
-            android:name="com.wafflestudio.snutt2.RootActivity"
+            android:name=".RootActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -74,7 +74,7 @@
         </activity>
 
         <receiver
-            android:name="TimetableWidgetProvider"
+            android:name=".TimetableWidgetProvider"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -94,7 +94,7 @@
                 android:resource="@xml/filepaths" />
         </provider>
         <service
-            android:name="SNUTTFirebaseMessagingService"
+            android:name=".SNUTTFirebaseMessagingService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/main/res/values/secrets_defaults.xml
+++ b/app/src/main/res/values/secrets_defaults.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- flavor(live/dev)의 strings.xml에서 실제 값으로 override됩니다. -->
+<?xml version="1.0" encoding="utf-8"?><!-- flavor(live/dev)의 strings.xml에서 실제 값으로 override됩니다. -->
 <!-- 이 파일은 IDE에서 R.string.* 참조를 인식시키기 위한 더미 기본값입니다. -->
 <resources>
     <string name="app_name" translatable="false">SNUTT</string>
@@ -14,6 +13,6 @@
     <string name="scheme" translatable="false">PLACEHOLDER</string>
     <string name="naver_map_ncp_key_id" translatable="false">PLACEHOLDER</string>
     <string name="kakao_native_app_key" translatable="false">PLACEHOLDER</string>
-    <string name="kakao_native_app_key_kakao" translatable="false">PLACEHOLDER</string>
+    <string name="kakao_native_app_key_kakao" translatable="false">placeholder</string>
     <string name="theme_market_base_url" translatable="false">PLACEHOLDER</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,6 @@ splashscreen = "1.2.0"
 # Authentication
 facebookLogin = "15.0.1"
 googleAuth = "21.5.1"
-googleId = "1.2.0"
 kakaoSDK = "2.23.2"
 
 # Maps
@@ -118,7 +117,6 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 # Authentication
 facebook-login = { module = "com.facebook.android:facebook-login", version.ref = "facebookLogin" }
 google-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "googleAuth" }
-google-id = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleId" }
 kakao-share = { module = "com.kakao.sdk:v2-share", version.ref = "kakaoSDK" }
 kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoSDK" }
 


### PR DESCRIPTION
## Summary
- AGP 8+ 에서 deprecated 된 manifest `package` 속성 제거 (이미 `build.gradle.kts` 의 `namespace` 로 정의됨)
- 컴포넌트 이름 표기 일관성: `RootActivity` / `TimetableWidgetProvider` / `SNUTTFirebaseMessagingService` 를 `.ClassName` 상대 표기로 통일
- `RootActivity` 의 의도적 portrait 고정에 대한 lint 워닝(`DiscouragedApi`, `LockedOrientationActivity`)을 inline `tools:ignore` 로 명시
- 코드 및 git history 전체에서 한 번도 사용된 적 없는 `googleid` 라이브러리(`libs.google.id`) 제거
  - transitive 로 끌려오던 `androidx.credentials:credentials` 도 함께 사라져 `CredentialDependency` lint 자연 해소
- `secrets_defaults.xml` 의 `kakao_native_app_key_kakao` placeholder 값을 소문자로 변경 (`AppLinkUrlError` lint 회피)

## Follow-up
`lint-baseline.xml` 의 다음 항목들은 이번 변경으로 stale 상태가 되므로 baseline cleanup 워크트리에서 같이 정리 예정:
- `LockedOrientationActivity` (inline suppression 으로 대체)
- `DiscouragedApi` (inline suppression 으로 대체)
- `CredentialDependency` (dead dep 제거로 자연 해소)
- `AppLinkUrlError` 2건 (placeholder 소문자화로 해소)

## Test plan
- [x] `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과
- [x] CI lint 통과 확인
- [x] 로컬 실행 시 앱 정상 기동 확인 (manifest 컴포넌트 이름 정규화 영향 확인)
- [x] 위젯 정상 동작 확인 (manifest receiver name 변경 영향 확인)
- [x] 알림(FCM) 수신 확인 (manifest service name 변경 영향 확인)
- [x] 카카오 로그인/공유 정상 동작 확인 (kakao scheme intent-filter 동작 확인)