### PR TITLE
chore: createComposeRule import 을 v2 로 마이그레이션

### DIFF
--- a/app/src/test/java/com/wafflestudio/snutt2/compose/stability/HomeDrawerUiStateSkipTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/compose/stability/HomeDrawerUiStateSkipTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import com.wafflestudio.snutt2.feature.home.drawer.HomeDrawerUiState
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/test/java/com/wafflestudio/snutt2/compose/stability/LectureSessionsSkipTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/compose/stability/LectureSessionsSkipTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import com.wafflestudio.snutt2.domain.model.LectureSession
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/test/java/com/wafflestudio/snutt2/compose/stability/StrongSkippingSmokeTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/compose/stability/StrongSkippingSmokeTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
## Summary
- Compose 1.11 부터 `androidx.compose.ui.test.junit4.createComposeRule` (v1) 이 deprecated 됨. 프로젝트의 BOM `2026.05.00` 은 `ui-test-junit4 1.11.1` 을 가져오므로 v2 API 사용 가능.
- `app/src/test/java/.../compose/stability/` 의 3개 Robolectric 테스트가 v1 import 를 쓰고 있었음. import 만 `androidx.compose.ui.test.junit4.v2.createComposeRule` 로 교체.
- 세 테스트 모두 `@get:Rule` + `waitForIdle()` 패턴만 사용하고 `LaunchedEffect`/`runTest` 등이 없어, v2 의 dispatcher 변경(`UnconfinedTestDispatcher` → `StandardTestDispatcher`)에 의한 동작 차이가 없음. 따라서 가장 보수적인 변경만 적용함. `runComposeUiTest` 함수형 API 전환은 본 PR 범위 밖.

참고: [Migrate to v2 testing APIs](https://developer.android.com/develop/ui/compose/testing/migrate-v2)

## Test plan
- [x] `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과
- [x] `./gradlew :app:testDevDebugUnitTest --tests "com.wafflestudio.snutt2.compose.stability.*"` 통과 (실제 실행으로 dispatcher 변경 영향 없음 확인)