### PR TITLE
release: 3.12.0 — 강의일기장 출시 / targetSdk 36 / 다국어(영문) 대응

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.11.0
+snuttVersionName=3.12.0-rc.1


### PR DESCRIPTION
## Summary

3.11.0 이후 약 3개월간의 변경사항을 모은 정기 릴리즈입니다.
제품 관점에서 가장 큰 축은 **강의일기장 기능 정식 출시**, **앱 영문 다국어 지원**,
그리고 **타깃 SDK 36 (Android 16) 대응** 세 가지입니다.

### 신규 기능

- **강의일기장 정식 출시** — 작성 플로우 / 푸시 알림 on-off / 홈화면 드롭다운 진입점 /
  분석 이벤트 로그까지 마무리하여 피처 플래그 ON (#500, #519, #520, #561, #598, #599)
- **앱 영문 다국어 지원** — 영어 locale 대응 (#521)
- **시스템 알림 자동 정리** — 앱 내에서 알림을 확인하면 상태표시줄 알림도 함께 제거 (#596)
- **알림함 → 본문 외부 링크 딥링크** 신규 구조로 구현 (#525, 외부 앱 열림 보정 #606)

### 화면 재작성 / 개편
사용자 동작은 동일하지만 내부 구조를 새로 작성한 화면들입니다.

- 홈 화면 (#524) / 검색 페이지 (#523)
- 강의 상세 페이지 (현재 시간표 강의 한정 1차) (#522)
- 강의평 바텀시트 — 최상위 별도 Route 분리 (#546)
- 테마 설정 / 테마 상세 (#529)
- 즐겨찾기 (#528) / 커스텀 강의 추가 (#527)
- 강의 리마인더 페이지 (#595)
- HomeDrawer (#502, #505)

### 시스템 / 호환성

- **targetSdk 36 (Android 16) 대응** (#509)
- Naver Map SDK 마이그레이션 (#594)
- 의존성 일괄 최신화: Paging / AGP 9.1.1 / Gradle 9.4 / Kotlin 2.3.20 등 (#508, #550, #573)

### 버그 수정 (사용자 체감)

- 화면 회전 등 configuration change 시 현재 화면이 초기화되던 문제 (#576)
- 상시강의 상세 진입 후 복귀 시 위로 스크롤이 막히던 문제 (#583)
- 시간대 필터에서 "시간대 직접 선택" x 를 눌러도 검색 시 필터가 남아있던 문제 (#552)
- 학과 탭이 아닌 검색 필터 탭에서도 '최근 찾아본 학과' 가 노출되던 문제 (#577)
- 강의평 rating 이 null 일 때 "n" 으로 표시되던 문제 (#547)
- 커스텀 테마 디폴트 색깔이 검정으로 잡히던 문제 (#515)
- HomeDrawer 다크모드 scrim 색 명시 (#591)
- RangeBar 드래그 핸들 스냅/콜백 동작 (#602)
- 알림 페이징의 page key 계산 / 예외 처리 (#605)

### 내부 개선 (사용자 영향 없음)

폴더 위계 / DTO·도메인 경계 / Repository·ViewModel 정리, Compose stability 정책 도입,
Compose Preview Screenshot Test 도입, ViewModel 테스트 인프라 + 다수 테스트 추가,
CI 정비(Lint baseline · Configuration Cache · GitHub Actions 버전업 등),
Moshi reflection → codegen 전환, SNUTTStorage 직렬화 모델 분리 등.

## Test plan

- [ ] 강의일기장 진입 / 작성 / 푸시 on-off
- [ ] 영문 locale 전반 확인
- [ ] 화면 회전 시 현재 화면 유지
- [ ] 검색 필터 (시간대 / 학과) 동작
- [ ] 강의 상세 / 강의평 바텀시트 진입·뒤로가기
- [ ] 테마 변경 / 커스텀 테마
- [ ] 알림함 내부·외부 딥링크
- [ ] QA 회귀 시나리오 일괄 확인