### PR TITLE
release: 3.12.0 — 강의일기장 출시 / targetSdk 36 / 다국어(영문) 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepository.kt
@@ -1,11 +1,13 @@
 package com.wafflestudio.snutt2.data.lecturediary
 
 import com.wafflestudio.snutt2.data.Result
+import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.diary.CourseBookDiarySubmissions
 import com.wafflestudio.snutt2.domain.model.diary.DiaryAnsweredQuestion
 import com.wafflestudio.snutt2.domain.model.diary.DiaryDailyClassType
 import com.wafflestudio.snutt2.domain.model.diary.DiaryQuestion
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
+import com.wafflestudio.snutt2.domain.model.diary.DiaryTargetLecture
 
 // TODO: Diary 관련해서는 data layer 다 한 repository 로 통일하기
 interface DiaryRepository {
@@ -26,6 +28,8 @@ interface DiaryRepository {
     suspend fun getMyDiarySubmissions(): Result<List<CourseBookDiarySubmissions>>
 
     suspend fun removeDiarySubmission(diary: DiarySummary): Result<Unit>
+
+    suspend fun getDiaryTargetLecture(courseBook: CourseBook): Result<DiaryTargetLecture>
 }
 
 data class DiaryQuestionnaireData(

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepositoryImpl.kt
@@ -2,9 +2,11 @@ package com.wafflestudio.snutt2.data.lecturediary
 
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.mapper.toDomain
+import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.diary.DiaryAnsweredQuestion
 import com.wafflestudio.snutt2.domain.model.diary.DiaryDailyClassType
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
+import com.wafflestudio.snutt2.domain.model.diary.DiaryTargetLecture
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionAnswerDto
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionnaireRequestDto
@@ -84,6 +86,21 @@ class DiaryRepositoryImpl @Inject constructor(
     override suspend fun removeDiarySubmission(diary: DiarySummary): Result<Unit> = try {
         api._removeDiarySubmission(diary.id)
         Result.Success(Unit)
+    } catch (e: Exception) {
+        Result.Fail(e.toDomainError())
+    }
+
+    override suspend fun getDiaryTargetLecture(courseBook: CourseBook): Result<DiaryTargetLecture> = try {
+        val result = api._getDiaryTargetLecture(
+            year = courseBook.year.toInt(),
+            semester = courseBook.semester.toInt(),
+        )
+        Result.Success(
+            DiaryTargetLecture(
+                lectureId = result.lectureId,
+                courseTitle = result.courseTitle,
+            ),
+        )
     } catch (e: Exception) {
         Result.Fail(e.toDomainError())
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/model/diary/DiaryModels.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/model/diary/DiaryModels.kt
@@ -38,3 +38,8 @@ data class CourseBookDiarySubmissions(
     val courseBook: CourseBook,
     val submissions: List<DiarySummary>,
 )
+
+data class DiaryTargetLecture(
+    val lectureId: String,
+    val courseTitle: String,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryDialogs.kt
@@ -5,25 +5,45 @@ import androidx.compose.ui.res.stringResource
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
 import com.wafflestudio.snutt2.ui.components.compose.ConfirmDialog
+import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 
 @Composable
 internal fun DiaryHistoryDialogs(
-    dialogState: DiaryHistoryUiState.DialogState,
-    onDismiss: () -> Unit,
+    uiState: DiaryHistoryUiState,
+    onDismissDialog: () -> Unit,
     onConfirmDeleteDiary: (DiarySummary) -> Unit,
+    onDismissWriteUnavailableDialog: () -> Unit,
 ) {
-    when (dialogState) {
-        DiaryHistoryUiState.DialogState.None -> {}
-        is DiaryHistoryUiState.DialogState.DeleteDiary -> {
-            ConfirmDialog(
-                onDismiss = onDismiss,
-                onConfirm = { onConfirmDeleteDiary(dialogState.diary) },
-                title = stringResource(R.string.diary_delete_confirm_message, dialogState.diary.courseName),
-            )
+    when (uiState) {
+        is DiaryHistoryUiState.Success -> {
+            when (val dialogState = uiState.dialogState) {
+                DiaryHistoryUiState.DialogState.None -> {}
+                is DiaryHistoryUiState.DialogState.DeleteDiary -> {
+                    ConfirmDialog(
+                        onDismiss = onDismissDialog,
+                        onConfirm = { onConfirmDeleteDiary(dialogState.diary) },
+                        title = stringResource(R.string.diary_delete_confirm_message, dialogState.diary.courseName),
+                    )
+                }
+            }
         }
+        is DiaryHistoryUiState.Empty -> {
+            if (uiState.showWriteUnavailableDialog) {
+                CustomDialog(
+                    onDismiss = onDismissWriteUnavailableDialog,
+                    onConfirm = onDismissWriteUnavailableDialog,
+                    title = stringResource(R.string.diary_history_empty_no_target_lecture_dialog_title),
+                    negativeButtonText = null,
+                    content = {},
+                )
+            }
+        }
+        DiaryHistoryUiState.Error,
+        DiaryHistoryUiState.Loading,
+        -> {}
     }
 }
 
@@ -32,11 +52,30 @@ internal fun DiaryHistoryDialogs(
 private fun DiaryHistoryDialogs_DeleteDiary() {
     SnuttPreviewSurface {
         DiaryHistoryDialogs(
-            dialogState = DiaryHistoryUiState.DialogState.DeleteDiary(
-                diary = DiaryPreviewData.sampleDiarySummaryShortComment,
+            uiState = DiaryHistoryUiState.Success(
+                courseBooks = DiaryPreviewData.courseBookList,
+                selectedCourseBook = DiaryPreviewData.courseBookList[0],
+                diarySummariesByCourseBook = emptyMap(),
+                dialogState = DiaryHistoryUiState.DialogState.DeleteDiary(
+                    diary = DiaryPreviewData.sampleDiarySummaryShortComment,
+                ),
             ),
-            onDismiss = {},
+            onDismissDialog = {},
             onConfirmDeleteDiary = {},
+            onDismissWriteUnavailableDialog = {},
+        )
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun DiaryHistoryDialogs_EmptyWriteUnavailable() {
+    SnuttPreviewSurface {
+        DiaryHistoryDialogs(
+            uiState = DiaryHistoryUiState.Empty(showWriteUnavailableDialog = true),
+            onDismissDialog = {},
+            onConfirmDeleteDiary = {},
+            onDismissWriteUnavailableDialog = {},
         )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
@@ -1,14 +1,18 @@
 package com.wafflestudio.snutt2.feature.diary.diaryhistory
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -26,6 +30,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -38,6 +43,7 @@ import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
+import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 import com.wafflestudio.snutt2.ui.util.formatter.toAbbvString
 import com.wafflestudio.snutt2.ui.util.toast
@@ -46,6 +52,7 @@ import java.time.LocalDate
 @Composable
 fun DiaryHistoryRoute(
     onNavigateBack: () -> Unit,
+    onNavigateToDiaryWrite: (lectureId: String, courseTitle: String) -> Unit,
     viewModel: DiaryHistoryViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -60,19 +67,24 @@ fun DiaryHistoryRoute(
                         context.toast(message)
                     }
                 }
+                is DiaryHistoryUiEvent.NavigateToDiaryWrite -> {
+                    onNavigateToDiaryWrite(uiEvent.lectureId, uiEvent.courseTitle)
+                }
             }
         }
     }
 
     DiaryTheme {
         DiaryHistoryScreen(
-            uiState,
-            onNavigateBack,
-            { idx -> viewModel.selectCourseBook(idx) },
-            viewModel::toggleDateExpand,
-            viewModel::openDeleteDiaryDialog,
-            viewModel::dismissDialog,
-            viewModel::confirmDeleteDiary,
+            uiState = uiState,
+            onNavigateBack = onNavigateBack,
+            onClickCourseBook = { idx -> viewModel.selectCourseBook(idx) },
+            onToggleExpandOfDate = viewModel::toggleDateExpand,
+            onDeleteDiary = viewModel::openDeleteDiaryDialog,
+            onDismissDialog = viewModel::dismissDialog,
+            onConfirmDeleteDiary = viewModel::confirmDeleteDiary,
+            onClickWriteFromEmpty = viewModel::requestDiaryWrite,
+            onDismissWriteUnavailableDialog = viewModel::dismissWriteUnavailableDialog,
         )
     }
 }
@@ -86,15 +98,16 @@ fun DiaryHistoryScreen(
     onDeleteDiary: (DiarySummary) -> Unit,
     onDismissDialog: () -> Unit,
     onConfirmDeleteDiary: (DiarySummary) -> Unit,
+    onClickWriteFromEmpty: () -> Unit,
+    onDismissWriteUnavailableDialog: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (uiState is DiaryHistoryUiState.Success) {
-        DiaryHistoryDialogs(
-            dialogState = uiState.dialogState,
-            onDismiss = onDismissDialog,
-            onConfirmDeleteDiary = onConfirmDeleteDiary,
-        )
-    }
+    DiaryHistoryDialogs(
+        uiState = uiState,
+        onDismissDialog = onDismissDialog,
+        onConfirmDeleteDiary = onConfirmDeleteDiary,
+        onDismissWriteUnavailableDialog = onDismissWriteUnavailableDialog,
+    )
 
     Column(
         modifier = modifier
@@ -121,7 +134,9 @@ fun DiaryHistoryScreen(
         )
 
         when (uiState) {
-            DiaryHistoryUiState.Empty -> {}
+            is DiaryHistoryUiState.Empty -> DiaryHistoryEmpty(
+                onClickAction = onClickWriteFromEmpty,
+            )
             DiaryHistoryUiState.Error -> {}
             DiaryHistoryUiState.Loading -> {}
             is DiaryHistoryUiState.Success -> {
@@ -173,6 +188,68 @@ fun DiaryHistoryScreen(
     }
 }
 
+@Composable
+private fun DiaryHistoryEmpty(
+    onClickAction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(DiaryTheme.colors.screenBackground),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            SnuttIcon(
+                id = R.drawable.ic_cat_retry,
+                modifier = Modifier.size(60.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(R.string.diary_history_empty_title),
+                style = SNUTTTypography.h3.copy(fontSize = 15.sp, fontWeight = FontWeight.SemiBold),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.diary_history_empty_subtitle),
+                style = SNUTTTypography.body1.copy(
+                    fontSize = 13.sp,
+                    color = DiaryTheme.colors.textSubtitle,
+                ),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = DiaryTheme.colors.nextActionBorder,
+                        shape = RoundedCornerShape(30.dp),
+                    )
+                    .clicks { onClickAction() }
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.diary_history_empty_action),
+                    style = SNUTTTypography.body1.copy(
+                        fontSize = 15.sp,
+                        color = SNUTTColors.Black900,
+                    ),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                SnuttIcon(
+                    id = R.drawable.ic_arrow_right,
+                    modifier = Modifier.size(20.dp),
+                    colorFilter = ColorFilter.tint(DiaryTheme.colors.iconPrimary),
+                )
+            }
+        }
+    }
+}
+
 @SnuttPreview
 @Composable
 private fun DiaryHistoryScreen_Default() {
@@ -186,11 +263,33 @@ private fun DiaryHistoryScreen_Default() {
                 onDeleteDiary = { _ -> },
                 onDismissDialog = {},
                 onConfirmDeleteDiary = {},
+                onClickWriteFromEmpty = {},
+                onDismissWriteUnavailableDialog = {},
                 uiState = DiaryHistoryUiState.Success(
                     courseBooks = courseBookList,
                     selectedCourseBook = courseBookList[0],
                     diarySummariesByCourseBook = mapOf(courseBookList[0] to DiaryPreviewData.diaryList),
                 ),
+            )
+        }
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun DiaryHistoryScreen_Empty() {
+    SnuttPreviewSurface {
+        DiaryTheme {
+            DiaryHistoryScreen(
+                onNavigateBack = {},
+                onClickCourseBook = {},
+                onToggleExpandOfDate = {},
+                onDeleteDiary = { _ -> },
+                onDismissDialog = {},
+                onConfirmDeleteDiary = {},
+                onClickWriteFromEmpty = {},
+                onDismissWriteUnavailableDialog = {},
+                uiState = DiaryHistoryUiState.Empty(),
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryUiState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryUiState.kt
@@ -22,7 +22,10 @@ sealed interface DiaryHistoryUiState {
 
     data object Error : DiaryHistoryUiState
     data object Loading : DiaryHistoryUiState
-    data object Empty : DiaryHistoryUiState
+
+    data class Empty(
+        val showWriteUnavailableDialog: Boolean = false,
+    ) : DiaryHistoryUiState
 }
 
 // NOTE: 각 날짜 별 expand 상태가 수정 페이지 이동 후 되돌아왔을 때도 유지되기 위해, uiState 에서 관리한다.

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.lecturediary.DiaryRepository
 import com.wafflestudio.snutt2.data.onFailure
 import com.wafflestudio.snutt2.data.onSuccess
+import com.wafflestudio.snutt2.data.semesterstatus.SemesterStatusRepository
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.model.CourseBook
@@ -27,6 +28,7 @@ import javax.inject.Inject
 class DiaryHistoryViewModel @Inject constructor(
     private val diaryRepository: DiaryRepository,
     private val userRepository: UserRepository,
+    private val semesterStatusRepository: SemesterStatusRepository,
     private val displayMessageResolver: DisplayMessageResolver,
 ) : ViewModel() {
 
@@ -41,7 +43,7 @@ class DiaryHistoryViewModel @Inject constructor(
             diaryRepository.getMyDiarySubmissions()
                 .onSuccess { courseBookDiarySubmissionsList ->
                     if (courseBookDiarySubmissionsList.isEmpty()) {
-                        _uiState.update { DiaryHistoryUiState.Empty }
+                        _uiState.update { DiaryHistoryUiState.Empty() }
                         return@onSuccess
                     }
 
@@ -143,6 +145,49 @@ class DiaryHistoryViewModel @Inject constructor(
         }
     }
 
+    fun requestDiaryWrite() {
+        val courseBook = semesterStatusRepository.semesterStatus.value
+            ?.let { it.current ?: it.next }
+
+        if (courseBook == null) {
+            showWriteUnavailableDialog()
+            return
+        }
+
+        viewModelScope.launch {
+            diaryRepository.getDiaryTargetLecture(courseBook)
+                .onSuccess { targetLecture ->
+                    _uiEvent.emit(
+                        DiaryHistoryUiEvent.NavigateToDiaryWrite(
+                            lectureId = targetLecture.lectureId,
+                            courseTitle = targetLecture.courseTitle,
+                        ),
+                    )
+                }
+                .onFailure {
+                    showWriteUnavailableDialog()
+                }
+        }
+    }
+
+    fun dismissWriteUnavailableDialog() {
+        _uiState.update { state ->
+            when (state) {
+                is DiaryHistoryUiState.Empty -> state.copy(showWriteUnavailableDialog = false)
+                else -> state
+            }
+        }
+    }
+
+    private fun showWriteUnavailableDialog() {
+        _uiState.update { state ->
+            when (state) {
+                is DiaryHistoryUiState.Empty -> state.copy(showWriteUnavailableDialog = true)
+                else -> state
+            }
+        }
+    }
+
     fun confirmDeleteDiary(diary: DiarySummary) {
         viewModelScope.launch {
             diaryRepository.removeDiarySubmission(diary)
@@ -180,4 +225,8 @@ class DiaryHistoryViewModel @Inject constructor(
 
 sealed interface DiaryHistoryUiEvent {
     data class ShowToast(val message: String) : DiaryHistoryUiEvent
+    data class NavigateToDiaryWrite(
+        val lectureId: String,
+        val courseTitle: String,
+    ) : DiaryHistoryUiEvent
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/navigation/RootNavGraph.kt
@@ -442,6 +442,11 @@ private fun NavGraphBuilder.settingComposables(
                         navController.popBackStack()
                     }
                 },
+                onNavigateToDiaryWrite = { lectureId, courseTitle ->
+                    navController.navigate(
+                        NavigationDestination.LectureDiaryWrite(lectureId, courseTitle),
+                    )
+                },
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/network/api/SNUTTRestApi.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/api/SNUTTRestApi.kt
@@ -9,6 +9,7 @@ import com.wafflestudio.snutt2.network.dto.DeleteUserAccountResults
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionnaireDto
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionnaireRequestDto
 import com.wafflestudio.snutt2.network.dto.DiarySubmissionRequestDto
+import com.wafflestudio.snutt2.network.dto.DiaryTargetLectureDto
 import com.wafflestudio.snutt2.network.dto.GetBookmarkListResults
 import com.wafflestudio.snutt2.network.dto.GetCoursebookResults
 import com.wafflestudio.snutt2.network.dto.GetCoursebooksOfficialResults
@@ -521,6 +522,12 @@ interface SNUTTRestApi {
 
     @GET("/v1/diary/my")
     suspend fun _getMyDiarySubmissions(): GetMyDiarySubmissionsResults
+
+    @GET("/v1/diary/target")
+    suspend fun _getDiaryTargetLecture(
+        @Query("year") year: Int,
+        @Query("semester") semester: Int,
+    ): DiaryTargetLectureDto
 
     @POST("/v1/diary/questionnaire")
     suspend fun _getQuestionnaireFromActivities(

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/DiaryTargetLectureDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/DiaryTargetLectureDto.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.snutt2.network.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class DiaryTargetLectureDto(
+    @param:Json(name = "lectureId") val lectureId: String,
+    @param:Json(name = "courseTitle") val courseTitle: String,
+)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -445,6 +445,10 @@
     <string name="diary_write_more_text_hint">Briefly write about what you learned or felt in today\'s class.</string>
     <string name="diary_delete_confirm_message">Delete the lecture diary for \'%s\'?</string>
     <string name="diary_summary_more_text_label">Additional Notes</string>
+    <string name="diary_history_empty_title">Your lecture diary is empty.</string>
+    <string name="diary_history_empty_subtitle">Every last class of the week,\nwrite a lecture diary through push notifications!</string>
+    <string name="diary_history_empty_action">Write Lecture Diary</string>
+    <string name="diary_history_empty_no_target_lecture_dialog_title">No lectures available to write a diary.</string>
 
 <!-- Debug -->
     <string name="debug_network_log_title">Network Log</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -627,6 +627,10 @@
     <string name="diary_write_more_text_hint">오늘 수업에서 배운 내용, 느낀 점 등을 간단하게 적어보세요.</string>
     <string name="diary_delete_confirm_message">\'%s\'\n강의일기를 삭제하시겠습니까?</string>
     <string name="diary_summary_more_text_label">남기고 싶은 말</string>
+    <string name="diary_history_empty_title">강의일기장이 비어있어요.</string>
+    <string name="diary_history_empty_subtitle">매주 마지막 수업날,\n푸시알림을 통해 강의일기를 작성해보세요!</string>
+    <string name="diary_history_empty_action">강의일기 작성하기</string>
+    <string name="diary_history_empty_no_target_lecture_dialog_title">강의일기장을 작성할 수 있는 강의가 없습니다.</string>
 
 <!-- Debug -->
     <string name="debug_network_log_title">네트워크 로그</string>

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.12.0-rc.1
+snuttVersionName=3.12.0-rc.2

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.11.0
+snuttVersionName=3.12.0-rc.1

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.12.0-rc.2
+snuttVersionName=3.12.0


### PR DESCRIPTION
> 이전에 잘못된 브랜치명(`release/3.12.0`)으로 열렸던 #614 를 닫고, CD 워크플로우(`release-*`) 컨벤션에 맞춰 `release-3.12.0` 으로 다시 엽니다. 내용은 동일합니다.

## Summary

3.11.0 이후 약 3개월간의 변경사항을 모은 정기 릴리즈입니다.
제품 관점에서 가장 큰 축은 **강의일기장 기능 정식 출시**, **앱 영문 다국어 지원**,
그리고 **타깃 SDK 36 (Android 16) 대응** 세 가지입니다.

### 신규 기능

- **강의일기장 정식 출시** — 작성 플로우 / 푸시 알림 on-off / 홈화면 드롭다운 진입점 /
  분석 이벤트 로그까지 마무리하여 피처 플래그 ON (#500, #519, #520, #561, #598, #599)
- **앱 영문 다국어 지원** — 영어 locale 대응 (#521)
- **시스템 알림 자동 정리** — 앱 내에서 알림을 확인하면 상태표시줄 알림도 함께 제거 (#596)
- **알림함 → 본문 외부 링크 딥링크** 신규 구조로 구현 (#525, 외부 앱 열림 보정 #606)

### 화면 재작성 / 개편
사용자 동작은 동일하지만 내부 구조를 새로 작성한 화면들입니다.

- 홈 화면 (#524) / 검색 페이지 (#523)
- 강의 상세 페이지 (현재 시간표 강의 한정 1차) (#522)
- 강의평 바텀시트 — 최상위 별도 Route 분리 (#546)
- 테마 설정 / 테마 상세 (#529)
- 즐겨찾기 (#528) / 커스텀 강의 추가 (#527)
- 강의 리마인더 페이지 (#595)
- HomeDrawer (#502, #505)

### 시스템 / 호환성

- **targetSdk 36 (Android 16) 대응** (#509)
- Naver Map SDK 마이그레이션 (#594)
- 의존성 일괄 최신화: Paging / AGP 9.1.1 / Gradle 9.4 / Kotlin 2.3.20 등 (#508, #550, #573)

### 버그 수정 (사용자 체감)

- 화면 회전 등 configuration change 시 현재 화면이 초기화되던 문제 (#576)
- 상시강의 상세 진입 후 복귀 시 위로 스크롤이 막히던 문제 (#583)
- 시간대 필터에서 "시간대 직접 선택" x 를 눌러도 검색 시 필터가 남아있던 문제 (#552)
- 학과 탭이 아닌 검색 필터 탭에서도 '최근 찾아본 학과' 가 노출되던 문제 (#577)
- 강의평 rating 이 null 일 때 "n" 으로 표시되던 문제 (#547)
- 커스텀 테마 디폴트 색깔이 검정으로 잡히던 문제 (#515)
- HomeDrawer 다크모드 scrim 색 명시 (#591)
- RangeBar 드래그 핸들 스냅/콜백 동작 (#602)
- 알림 페이징의 page key 계산 / 예외 처리 (#605)

### 내부 개선 (사용자 영향 없음)

폴더 위계 / DTO·도메인 경계 / Repository·ViewModel 정리, Compose stability 정책 도입,
Compose Preview Screenshot Test 도입, ViewModel 테스트 인프라 + 다수 테스트 추가,
CI 정비(Lint baseline · Configuration Cache · GitHub Actions 버전업 등),
Moshi reflection → codegen 전환, SNUTTStorage 직렬화 모델 분리 등.

## Test plan

- [x] 강의일기장 진입 / 작성 / 푸시 on-off
- [x] 영문 locale 전반 확인
- [x] 화면 회전 시 현재 화면 유지
- [x] 검색 필터 (시간대 / 학과) 동작
- [x] 강의 상세 / 강의평 바텀시트 진입·뒤로가기
- [x] 테마 변경 / 커스텀 테마
- [x] 알림함 내부·외부 딥링크
- [x] QA 회귀 시나리오 일괄 확인