### PR TITLE
feat: 강의일기장 빈 상태 화면 구현

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepository.kt
@@ -1,11 +1,13 @@
 package com.wafflestudio.snutt2.data.lecturediary
 
 import com.wafflestudio.snutt2.data.Result
+import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.diary.CourseBookDiarySubmissions
 import com.wafflestudio.snutt2.domain.model.diary.DiaryAnsweredQuestion
 import com.wafflestudio.snutt2.domain.model.diary.DiaryDailyClassType
 import com.wafflestudio.snutt2.domain.model.diary.DiaryQuestion
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
+import com.wafflestudio.snutt2.domain.model.diary.DiaryTargetLecture
 
 // TODO: Diary 관련해서는 data layer 다 한 repository 로 통일하기
 interface DiaryRepository {
@@ -26,6 +28,8 @@ interface DiaryRepository {
     suspend fun getMyDiarySubmissions(): Result<List<CourseBookDiarySubmissions>>
 
     suspend fun removeDiarySubmission(diary: DiarySummary): Result<Unit>
+
+    suspend fun getDiaryTargetLecture(courseBook: CourseBook): Result<DiaryTargetLecture>
 }
 
 data class DiaryQuestionnaireData(

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturediary/DiaryRepositoryImpl.kt
@@ -2,9 +2,11 @@ package com.wafflestudio.snutt2.data.lecturediary
 
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.mapper.toDomain
+import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.diary.DiaryAnsweredQuestion
 import com.wafflestudio.snutt2.domain.model.diary.DiaryDailyClassType
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
+import com.wafflestudio.snutt2.domain.model.diary.DiaryTargetLecture
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionAnswerDto
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionnaireRequestDto
@@ -84,6 +86,21 @@ class DiaryRepositoryImpl @Inject constructor(
     override suspend fun removeDiarySubmission(diary: DiarySummary): Result<Unit> = try {
         api._removeDiarySubmission(diary.id)
         Result.Success(Unit)
+    } catch (e: Exception) {
+        Result.Fail(e.toDomainError())
+    }
+
+    override suspend fun getDiaryTargetLecture(courseBook: CourseBook): Result<DiaryTargetLecture> = try {
+        val result = api._getDiaryTargetLecture(
+            year = courseBook.year.toInt(),
+            semester = courseBook.semester.toInt(),
+        )
+        Result.Success(
+            DiaryTargetLecture(
+                lectureId = result.lectureId,
+                courseTitle = result.courseTitle,
+            ),
+        )
     } catch (e: Exception) {
         Result.Fail(e.toDomainError())
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/model/diary/DiaryModels.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/model/diary/DiaryModels.kt
@@ -38,3 +38,8 @@ data class CourseBookDiarySubmissions(
     val courseBook: CourseBook,
     val submissions: List<DiarySummary>,
 )
+
+data class DiaryTargetLecture(
+    val lectureId: String,
+    val courseTitle: String,
+)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryDialogs.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryDialogs.kt
@@ -5,25 +5,45 @@ import androidx.compose.ui.res.stringResource
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.model.diary.DiarySummary
 import com.wafflestudio.snutt2.ui.components.compose.ConfirmDialog
+import com.wafflestudio.snutt2.ui.components.compose.CustomDialog
 import com.wafflestudio.snutt2.ui.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 
 @Composable
 internal fun DiaryHistoryDialogs(
-    dialogState: DiaryHistoryUiState.DialogState,
-    onDismiss: () -> Unit,
+    uiState: DiaryHistoryUiState,
+    onDismissDialog: () -> Unit,
     onConfirmDeleteDiary: (DiarySummary) -> Unit,
+    onDismissWriteUnavailableDialog: () -> Unit,
 ) {
-    when (dialogState) {
-        DiaryHistoryUiState.DialogState.None -> {}
-        is DiaryHistoryUiState.DialogState.DeleteDiary -> {
-            ConfirmDialog(
-                onDismiss = onDismiss,
-                onConfirm = { onConfirmDeleteDiary(dialogState.diary) },
-                title = stringResource(R.string.diary_delete_confirm_message, dialogState.diary.courseName),
-            )
+    when (uiState) {
+        is DiaryHistoryUiState.Success -> {
+            when (val dialogState = uiState.dialogState) {
+                DiaryHistoryUiState.DialogState.None -> {}
+                is DiaryHistoryUiState.DialogState.DeleteDiary -> {
+                    ConfirmDialog(
+                        onDismiss = onDismissDialog,
+                        onConfirm = { onConfirmDeleteDiary(dialogState.diary) },
+                        title = stringResource(R.string.diary_delete_confirm_message, dialogState.diary.courseName),
+                    )
+                }
+            }
         }
+        is DiaryHistoryUiState.Empty -> {
+            if (uiState.showWriteUnavailableDialog) {
+                CustomDialog(
+                    onDismiss = onDismissWriteUnavailableDialog,
+                    onConfirm = onDismissWriteUnavailableDialog,
+                    title = stringResource(R.string.diary_history_empty_no_target_lecture_dialog_title),
+                    negativeButtonText = null,
+                    content = {},
+                )
+            }
+        }
+        DiaryHistoryUiState.Error,
+        DiaryHistoryUiState.Loading,
+        -> {}
     }
 }
 
@@ -32,11 +52,30 @@ internal fun DiaryHistoryDialogs(
 private fun DiaryHistoryDialogs_DeleteDiary() {
     SnuttPreviewSurface {
         DiaryHistoryDialogs(
-            dialogState = DiaryHistoryUiState.DialogState.DeleteDiary(
-                diary = DiaryPreviewData.sampleDiarySummaryShortComment,
+            uiState = DiaryHistoryUiState.Success(
+                courseBooks = DiaryPreviewData.courseBookList,
+                selectedCourseBook = DiaryPreviewData.courseBookList[0],
+                diarySummariesByCourseBook = emptyMap(),
+                dialogState = DiaryHistoryUiState.DialogState.DeleteDiary(
+                    diary = DiaryPreviewData.sampleDiarySummaryShortComment,
+                ),
             ),
-            onDismiss = {},
+            onDismissDialog = {},
             onConfirmDeleteDiary = {},
+            onDismissWriteUnavailableDialog = {},
+        )
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun DiaryHistoryDialogs_EmptyWriteUnavailable() {
+    SnuttPreviewSurface {
+        DiaryHistoryDialogs(
+            uiState = DiaryHistoryUiState.Empty(showWriteUnavailableDialog = true),
+            onDismissDialog = {},
+            onConfirmDeleteDiary = {},
+            onDismissWriteUnavailableDialog = {},
         )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
@@ -1,14 +1,18 @@
 package com.wafflestudio.snutt2.feature.diary.diaryhistory
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -22,10 +26,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -38,6 +44,7 @@ import com.wafflestudio.snutt2.ui.components.compose.clicks
 import com.wafflestudio.snutt2.ui.preview.DiaryPreviewData
 import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
+import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 import com.wafflestudio.snutt2.ui.util.formatter.toAbbvString
 import com.wafflestudio.snutt2.ui.util.toast
@@ -46,6 +53,7 @@ import java.time.LocalDate
 @Composable
 fun DiaryHistoryRoute(
     onNavigateBack: () -> Unit,
+    onNavigateToDiaryWrite: (lectureId: String, courseTitle: String) -> Unit,
     viewModel: DiaryHistoryViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -60,19 +68,24 @@ fun DiaryHistoryRoute(
                         context.toast(message)
                     }
                 }
+                is DiaryHistoryUiEvent.NavigateToDiaryWrite -> {
+                    onNavigateToDiaryWrite(uiEvent.lectureId, uiEvent.courseTitle)
+                }
             }
         }
     }
 
     DiaryTheme {
         DiaryHistoryScreen(
-            uiState,
-            onNavigateBack,
-            { idx -> viewModel.selectCourseBook(idx) },
-            viewModel::toggleDateExpand,
-            viewModel::openDeleteDiaryDialog,
-            viewModel::dismissDialog,
-            viewModel::confirmDeleteDiary,
+            uiState = uiState,
+            onNavigateBack = onNavigateBack,
+            onClickCourseBook = { idx -> viewModel.selectCourseBook(idx) },
+            onToggleExpandOfDate = viewModel::toggleDateExpand,
+            onDeleteDiary = viewModel::openDeleteDiaryDialog,
+            onDismissDialog = viewModel::dismissDialog,
+            onConfirmDeleteDiary = viewModel::confirmDeleteDiary,
+            onClickWriteFromEmpty = viewModel::requestDiaryWrite,
+            onDismissWriteUnavailableDialog = viewModel::dismissWriteUnavailableDialog,
         )
     }
 }
@@ -86,15 +99,16 @@ fun DiaryHistoryScreen(
     onDeleteDiary: (DiarySummary) -> Unit,
     onDismissDialog: () -> Unit,
     onConfirmDeleteDiary: (DiarySummary) -> Unit,
+    onClickWriteFromEmpty: () -> Unit,
+    onDismissWriteUnavailableDialog: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (uiState is DiaryHistoryUiState.Success) {
-        DiaryHistoryDialogs(
-            dialogState = uiState.dialogState,
-            onDismiss = onDismissDialog,
-            onConfirmDeleteDiary = onConfirmDeleteDiary,
-        )
-    }
+    DiaryHistoryDialogs(
+        uiState = uiState,
+        onDismissDialog = onDismissDialog,
+        onConfirmDeleteDiary = onConfirmDeleteDiary,
+        onDismissWriteUnavailableDialog = onDismissWriteUnavailableDialog,
+    )
 
     Column(
         modifier = modifier
@@ -121,7 +135,9 @@ fun DiaryHistoryScreen(
         )
 
         when (uiState) {
-            DiaryHistoryUiState.Empty -> {}
+            is DiaryHistoryUiState.Empty -> DiaryHistoryEmpty(
+                onClickAction = onClickWriteFromEmpty,
+            )
             DiaryHistoryUiState.Error -> {}
             DiaryHistoryUiState.Loading -> {}
             is DiaryHistoryUiState.Success -> {
@@ -173,6 +189,68 @@ fun DiaryHistoryScreen(
     }
 }
 
+@Composable
+private fun DiaryHistoryEmpty(
+    onClickAction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(DiaryTheme.colors.screenBackground),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            SnuttIcon(
+                id = R.drawable.ic_cat_retry,
+                modifier = Modifier.size(60.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(R.string.diary_history_empty_title),
+                style = SNUTTTypography.h3.copy(fontSize = 15.sp, fontWeight = FontWeight.SemiBold),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.diary_history_empty_subtitle),
+                style = SNUTTTypography.body1.copy(
+                    fontSize = 13.sp,
+                    color = DiaryTheme.colors.textSubtitle,
+                ),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = Color(0xffe4e4e5),
+                        shape = RoundedCornerShape(30.dp),
+                    )
+                    .clicks { onClickAction() }
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.diary_history_empty_action),
+                    style = SNUTTTypography.body1.copy(
+                        fontSize = 15.sp,
+                        color = SNUTTColors.Black900,
+                    ),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                SnuttIcon(
+                    id = R.drawable.ic_arrow_right,
+                    modifier = Modifier.size(20.dp),
+                    colorFilter = ColorFilter.tint(DiaryTheme.colors.iconPrimary),
+                )
+            }
+        }
+    }
+}
+
 @SnuttPreview
 @Composable
 private fun DiaryHistoryScreen_Default() {
@@ -186,11 +264,33 @@ private fun DiaryHistoryScreen_Default() {
                 onDeleteDiary = { _ -> },
                 onDismissDialog = {},
                 onConfirmDeleteDiary = {},
+                onClickWriteFromEmpty = {},
+                onDismissWriteUnavailableDialog = {},
                 uiState = DiaryHistoryUiState.Success(
                     courseBooks = courseBookList,
                     selectedCourseBook = courseBookList[0],
                     diarySummariesByCourseBook = mapOf(courseBookList[0] to DiaryPreviewData.diaryList),
                 ),
+            )
+        }
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun DiaryHistoryScreen_Empty() {
+    SnuttPreviewSurface {
+        DiaryTheme {
+            DiaryHistoryScreen(
+                onNavigateBack = {},
+                onClickCourseBook = {},
+                onToggleExpandOfDate = {},
+                onDeleteDiary = { _ -> },
+                onDismissDialog = {},
+                onConfirmDeleteDiary = {},
+                onClickWriteFromEmpty = {},
+                onDismissWriteUnavailableDialog = {},
+                uiState = DiaryHistoryUiState.Empty(),
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryPage.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -226,7 +225,7 @@ private fun DiaryHistoryEmpty(
                 modifier = Modifier
                     .border(
                         width = 1.dp,
-                        color = Color(0xffe4e4e5),
+                        color = DiaryTheme.colors.nextActionBorder,
                         shape = RoundedCornerShape(30.dp),
                     )
                     .clicks { onClickAction() }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryUiState.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryUiState.kt
@@ -22,7 +22,10 @@ sealed interface DiaryHistoryUiState {
 
     data object Error : DiaryHistoryUiState
     data object Loading : DiaryHistoryUiState
-    data object Empty : DiaryHistoryUiState
+
+    data class Empty(
+        val showWriteUnavailableDialog: Boolean = false,
+    ) : DiaryHistoryUiState
 }
 
 // NOTE: 각 날짜 별 expand 상태가 수정 페이지 이동 후 되돌아왔을 때도 유지되기 위해, uiState 에서 관리한다.

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/diary/diaryhistory/DiaryHistoryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.data.lecturediary.DiaryRepository
 import com.wafflestudio.snutt2.data.onFailure
 import com.wafflestudio.snutt2.data.onSuccess
+import com.wafflestudio.snutt2.data.semesterstatus.SemesterStatusRepository
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.model.CourseBook
@@ -27,6 +28,7 @@ import javax.inject.Inject
 class DiaryHistoryViewModel @Inject constructor(
     private val diaryRepository: DiaryRepository,
     private val userRepository: UserRepository,
+    private val semesterStatusRepository: SemesterStatusRepository,
     private val displayMessageResolver: DisplayMessageResolver,
 ) : ViewModel() {
 
@@ -41,7 +43,7 @@ class DiaryHistoryViewModel @Inject constructor(
             diaryRepository.getMyDiarySubmissions()
                 .onSuccess { courseBookDiarySubmissionsList ->
                     if (courseBookDiarySubmissionsList.isEmpty()) {
-                        _uiState.update { DiaryHistoryUiState.Empty }
+                        _uiState.update { DiaryHistoryUiState.Empty() }
                         return@onSuccess
                     }
 
@@ -143,6 +145,49 @@ class DiaryHistoryViewModel @Inject constructor(
         }
     }
 
+    fun requestDiaryWrite() {
+        val courseBook = semesterStatusRepository.semesterStatus.value
+            ?.let { it.current ?: it.next }
+
+        if (courseBook == null) {
+            showWriteUnavailableDialog()
+            return
+        }
+
+        viewModelScope.launch {
+            diaryRepository.getDiaryTargetLecture(courseBook)
+                .onSuccess { targetLecture ->
+                    _uiEvent.emit(
+                        DiaryHistoryUiEvent.NavigateToDiaryWrite(
+                            lectureId = targetLecture.lectureId,
+                            courseTitle = targetLecture.courseTitle,
+                        ),
+                    )
+                }
+                .onFailure {
+                    showWriteUnavailableDialog()
+                }
+        }
+    }
+
+    fun dismissWriteUnavailableDialog() {
+        _uiState.update { state ->
+            when (state) {
+                is DiaryHistoryUiState.Empty -> state.copy(showWriteUnavailableDialog = false)
+                else -> state
+            }
+        }
+    }
+
+    private fun showWriteUnavailableDialog() {
+        _uiState.update { state ->
+            when (state) {
+                is DiaryHistoryUiState.Empty -> state.copy(showWriteUnavailableDialog = true)
+                else -> state
+            }
+        }
+    }
+
     fun confirmDeleteDiary(diary: DiarySummary) {
         viewModelScope.launch {
             diaryRepository.removeDiarySubmission(diary)
@@ -180,4 +225,8 @@ class DiaryHistoryViewModel @Inject constructor(
 
 sealed interface DiaryHistoryUiEvent {
     data class ShowToast(val message: String) : DiaryHistoryUiEvent
+    data class NavigateToDiaryWrite(
+        val lectureId: String,
+        val courseTitle: String,
+    ) : DiaryHistoryUiEvent
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/navigation/RootNavGraph.kt
@@ -442,6 +442,11 @@ private fun NavGraphBuilder.settingComposables(
                         navController.popBackStack()
                     }
                 },
+                onNavigateToDiaryWrite = { lectureId, courseTitle ->
+                    navController.navigate(
+                        NavigationDestination.LectureDiaryWrite(lectureId, courseTitle),
+                    )
+                },
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/network/api/SNUTTRestApi.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/api/SNUTTRestApi.kt
@@ -9,6 +9,7 @@ import com.wafflestudio.snutt2.network.dto.DeleteUserAccountResults
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionnaireDto
 import com.wafflestudio.snutt2.network.dto.DiaryQuestionnaireRequestDto
 import com.wafflestudio.snutt2.network.dto.DiarySubmissionRequestDto
+import com.wafflestudio.snutt2.network.dto.DiaryTargetLectureDto
 import com.wafflestudio.snutt2.network.dto.GetBookmarkListResults
 import com.wafflestudio.snutt2.network.dto.GetCoursebookResults
 import com.wafflestudio.snutt2.network.dto.GetCoursebooksOfficialResults
@@ -521,6 +522,12 @@ interface SNUTTRestApi {
 
     @GET("/v1/diary/my")
     suspend fun _getMyDiarySubmissions(): GetMyDiarySubmissionsResults
+
+    @GET("/v1/diary/target")
+    suspend fun _getDiaryTargetLecture(
+        @Query("year") year: Int,
+        @Query("semester") semester: Int,
+    ): DiaryTargetLectureDto
 
     @POST("/v1/diary/questionnaire")
     suspend fun _getQuestionnaireFromActivities(

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/DiaryTargetLectureDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/DiaryTargetLectureDto.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.snutt2.network.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class DiaryTargetLectureDto(
+    @param:Json(name = "lectureId") val lectureId: String,
+    @param:Json(name = "courseTitle") val courseTitle: String,
+)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -445,6 +445,10 @@
     <string name="diary_write_more_text_hint">Briefly write about what you learned or felt in today\'s class.</string>
     <string name="diary_delete_confirm_message">Delete the lecture diary for \'%s\'?</string>
     <string name="diary_summary_more_text_label">Additional Notes</string>
+    <string name="diary_history_empty_title">Your lecture diary is empty.</string>
+    <string name="diary_history_empty_subtitle">Every last class of the week,\nwrite a lecture diary through push notifications!</string>
+    <string name="diary_history_empty_action">Write Lecture Diary</string>
+    <string name="diary_history_empty_no_target_lecture_dialog_title">No lectures available to write a diary.</string>
 
 <!-- Debug -->
     <string name="debug_network_log_title">Network Log</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -627,6 +627,10 @@
     <string name="diary_write_more_text_hint">오늘 수업에서 배운 내용, 느낀 점 등을 간단하게 적어보세요.</string>
     <string name="diary_delete_confirm_message">\'%s\'\n강의일기를 삭제하시겠습니까?</string>
     <string name="diary_summary_more_text_label">남기고 싶은 말</string>
+    <string name="diary_history_empty_title">강의일기장이 비어있어요.</string>
+    <string name="diary_history_empty_subtitle">매주 마지막 수업날,\n푸시알림을 통해 강의일기를 작성해보세요!</string>
+    <string name="diary_history_empty_action">강의일기 작성하기</string>
+    <string name="diary_history_empty_no_target_lecture_dialog_title">강의일기장을 작성할 수 있는 강의가 없습니다.</string>
 
 <!-- Debug -->
     <string name="debug_network_log_title">네트워크 로그</string>


### PR DESCRIPTION
## Summary

강의일기장(`DiaryHistoryRoute`) 진입 시 작성된 일기가 하나도 없는 경우를 위한 빈 상태 UI 를 구현했습니다. iOS `LectureDiaryListView.emptyStateView` 와 동치 동작입니다.

### UI (`DiaryHistoryEmpty`)

중앙 정렬로 다음을 수직 배열:

- `ic_cat_retry` 60dp
- spacing 24
- "강의일기장이 비어있어요." — 15sp / SemiBold / `SNUTTColors.Black900`
- spacing 8
- "매주 마지막 수업날,\n푸시알림을 통해 강의일기를 작성해보세요!" — 13sp / Regular / `DiaryTheme.colors.textSubtitle` (#000000 50%)
- spacing 16
- 버튼: "강의일기 작성하기" + `ic_arrow_right` 20dp (수평간격 4, 패딩 12, border 1dp `#E4E4E5`, radius 30)

### 동작

"강의일기 작성하기" 클릭 시:

1. `SemesterStatusRepository.semesterStatus` 의 current (없으면 next) `CourseBook` 으로 `GET /v1/diary/target` 호출
2. 응답으로 받은 `(lectureId, courseTitle)` 로 `LectureDiaryWrite` 로 네비게이트
3. 작성 가능한 강의가 없거나 (서버 404 `DIARY_TARGET_LECTURE_NOT_FOUND`) semester status 가 없으면 "강의일기장을 작성할 수 있는 강의가 없습니다." 안내 다이얼로그 노출

### 변경 파일

- `network/dto/DiaryTargetLectureDto.kt` (신규)
- `domain/model/diary/DiaryModels.kt` — `DiaryTargetLecture` 도메인 모델 추가
- `network/api/SNUTTRestApi.kt` — `_getDiaryTargetLecture(year, semester)` 추가
- `data/lecturediary/DiaryRepository(Impl).kt` — `getDiaryTargetLecture(courseBook: CourseBook)` 추가 (year/semester 변환은 Repository 책임)
- `feature/diary/diaryhistory/DiaryHistoryUiState.kt` — `Empty` 를 `data object` → `data class Empty(showWriteUnavailableDialog)` 로 변경
- `feature/diary/diaryhistory/DiaryHistoryViewModel.kt` — `SemesterStatusRepository` 주입, `requestDiaryWrite()` / `dismissWriteUnavailableDialog()` 추가, `NavigateToDiaryWrite` UiEvent 추가
- `feature/diary/diaryhistory/DiaryHistoryDialogs.kt` — Empty 의 다이얼로그 분기까지 통합 (`uiState` 통째로 받아 분기)
- `feature/diary/diaryhistory/DiaryHistoryPage.kt` — `DiaryHistoryEmpty` 컴포저블, Route 에 `onNavigateToDiaryWrite` 콜백, preview `DiaryHistoryScreen_Empty` 추가
- `navigation/RootNavGraph.kt` — `DiaryHistoryRoute` 에 `onNavigateToDiaryWrite` 연결
- `res/values/strings.xml`, `res/values-en/strings.xml` — 빈 상태/다이얼로그 문구 4건 추가 (iOS 와 동일 문구)

## 알려진 절충

- alert 는 단일-버튼 dialog 컴포넌트가 별도로 없어 `CustomDialog(negativeButtonText = null)` 로 처리. iOS 시스템 alert 와 비교하면 정렬/타이포 차이가 있을 수 있음. 추후 디자인 통일 작업 시 재정비 권장.
- `#E4E4E5` 는 `DiaryColors` 토큰에 매핑되는 값이 없어 hardcode. 다크모드 별도 색 명세가 들어오면 토큰화 검토.

## Test plan

- [ ] 일기 작성 이력이 0건인 계정으로 강의일기장 진입 시 빈 상태 UI 정상 노출 (light/dark)
- [ ] "강의일기 작성하기" 클릭 시 현재 학기에 작성 가능한 강의가 있으면 작성 화면 이동
- [ ] 작성 가능 강의가 없으면 "강의일기장을 작성할 수 있는 강의가 없습니다." 다이얼로그 노출 + 확인 클릭 시 닫힘
- [ ] 영문 locale 에서 문구 정상
- [ ] 기존 일기 목록/삭제 다이얼로그 동작 회귀 없음