### PR TITLE
feat: 권장과목 검색 필터 추가

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
@@ -37,6 +37,7 @@ class LectureSearchPagingSource(
             when (it) {
                 SearchTag.EtcEng -> "E"
                 SearchTag.EtcMilitary -> "MO"
+                SearchTag.EtcRecommended -> "권장과목"
                 else -> null
             }
         }.ifEmpty { null },

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
@@ -37,7 +37,7 @@ class LectureSearchPagingSource(
             when (it) {
                 SearchTag.EtcEng -> "E"
                 SearchTag.EtcMilitary -> "MO"
-                SearchTag.EtcRecommended -> "권장과목"
+                SearchTag.EtcRecommended -> "R"
                 else -> null
             }
         }.ifEmpty { null },

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/model/SearchTag.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/model/SearchTag.kt
@@ -22,8 +22,12 @@ sealed interface SearchTag {
         override val type = TagType.ETC
     }
 
+    data object EtcRecommended : SearchTag {
+        override val type = TagType.ETC
+    }
+
     companion object {
         val timeTags = listOf(TimeEmpty, TimeSelect)
-        val etcTags = listOf(EtcEng, EtcMilitary)
+        val etcTags = listOf(EtcEng, EtcMilitary, EtcRecommended)
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/SearchTagExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/components/compose/SearchTagExt.kt
@@ -11,5 +11,6 @@ fun SearchTag.displayName(): String = when (this) {
     SearchTag.TimeSelect -> stringResource(R.string.search_tag_time_select)
     SearchTag.EtcEng -> stringResource(R.string.search_tag_etc_eng)
     SearchTag.EtcMilitary -> stringResource(R.string.search_tag_etc_military)
+    SearchTag.EtcRecommended -> stringResource(R.string.search_tag_etc_recommended)
     is SearchTag.Regular -> name
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/preview/SearchTagPreviewData.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/preview/SearchTagPreviewData.kt
@@ -36,5 +36,6 @@ object SearchTagPreviewData {
         SearchTag.TimeSelect,
         SearchTag.EtcEng,
         SearchTag.EtcMilitary,
+        SearchTag.EtcRecommended,
     )
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -150,6 +150,7 @@
     <string name="search_tag_time_select">Select Time Slots</string>
     <string name="search_tag_etc_eng">English Courses</string>
     <string name="search_tag_etc_military">Military Leave Courses</string>
+    <string name="search_tag_etc_recommended">Recommended Courses</string>
     <string name="search_option_apply_button">Apply Filters</string>
     <string name="search_option_select_empty_time_slots">Select Empty Time Slots</string>
     <string name="search_option_select_clear_time_slots">Reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,6 +329,7 @@
     <string name="search_tag_time_select">시간대 직접 선택</string>
     <string name="search_tag_etc_eng">영어진행 강의</string>
     <string name="search_tag_etc_military">군휴학 원격수업</string>
+    <string name="search_tag_etc_recommended">권장과목</string>
     <string name="search_option_apply_button">필터 적용</string>
     <string name="search_option_select_empty_time_slots">빈시간대 선택하기</string>
     <string name="search_option_select_clear_time_slots">초기화</string>


### PR DESCRIPTION
## 개요

강의 검색 필터에 **권장과목** 필터를 신설합니다. 기존 **영강**(`EtcEng`), **군휴학**(`EtcMilitary`)과 동일한 `TagType.ETC` 위계로 추가했습니다.

## 변경 사항

| 파일 | 변경 |
|------|------|
| `domain/model/SearchTag.kt` | `EtcRecommended` data object 추가 + `etcTags` 등록 |
| `data/lecturesearch/LectureSearchPagingSource.kt` | `etc` 매핑에 `EtcRecommended -> "권장과목"` 추가 |
| `ui/components/compose/SearchTagExt.kt` | `displayName()` 라벨 매핑 |
| `res/values/strings.xml` | `search_tag_etc_recommended` = "권장과목" |
| `res/values-en/strings.xml` | 동일 키 = "Recommended Courses" |
| `ui/preview/SearchTagPreviewData.kt` | preview 데이터 추가 |

## 동작

- `etcTags`에 추가하면 `SearchViewModel`의 `allTags`에 자동 편입되어, 영강·군휴학과 완전히 같은 렌더링/토글 경로를 탑니다. `TagType.ETC`(`isExclusive=false`)라 다중 선택도 동일하게 동작합니다.
- 서버 연동: 영강(`"E"`)·군휴학(`"MO"`)과 달리, 권장과목은 한글 문자열 `"권장과목"`을 `etc` 배열로 전송합니다. 서버가 강의 비고(remark)를 `.*권장과목.*` 정규식으로 매칭합니다.

## 참조

- 서버 PR: wafflestudio/snutt#521

## 검증

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` BUILD SUCCESSFUL