### PR TITLE
fix: 학기 마지막 순서 시간표 삭제 시 IndexOutOfBounds 크래시 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/domain/DomainError.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/DomainError.kt
@@ -66,3 +66,11 @@ object NotSelectedTimetable : DomainError {
     //  displayMessage를 직접 참조하는 코드가 추가될 경우 문제 발생 가능. DomainError를 @StringRes 기반으로 전환 검토.
     override val displayMessage = "현재 선택된 시간표의 테마만 변경할 수 있습니다."
 }
+
+object LastTimetableNotDeletable : DomainError {
+    override val displayTitle = ""
+
+    // FIXME: 하드코딩 한국어. 실제로는 DisplayMessageResolverImpl에서 리소스로 대체되므로 사용되지 않지만,
+    //  displayMessage를 직접 참조하는 코드가 추가될 경우 문제 발생 가능. DomainError를 @StringRes 기반으로 전환 검토.
+    override val displayMessage = "하나 남은 시간표는 삭제할 수 없습니다."
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerViewModel.kt
@@ -10,6 +10,7 @@ import com.wafflestudio.snutt2.data.themes.ThemeRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
 import com.wafflestudio.snutt2.domain.GetCurrentTableThemeUseCase
+import com.wafflestudio.snutt2.domain.LastTimetableNotDeletable
 import com.wafflestudio.snutt2.domain.NotSelectedTimetable
 import com.wafflestudio.snutt2.domain.model.BuiltInTheme
 import com.wafflestudio.snutt2.domain.model.CourseBook
@@ -331,6 +332,18 @@ class HomeDrawerViewModel @Inject constructor(
     }
 
     fun openDeleteTableDialog(tableSummary: TableSummary) {
+        val totalTableCount =
+            _uiState.value.courseBookDrawerItemList.sumOf { it.item.tableList.size }
+        if (totalTableCount <= 1) {
+            viewModelScope.launch {
+                _uiEvent.emit(
+                    HomeDrawerUiEvent.ShowToast(
+                        displayMessageResolver.getDisplayMessage(LastTimetableNotDeletable),
+                    ),
+                )
+            }
+            return
+        }
         _uiState.update {
             it.copy(dialogState = HomeDrawerUiState.DialogState.DeleteTable(tableSummary))
         }
@@ -385,21 +398,17 @@ class HomeDrawerViewModel @Inject constructor(
                             sameCourseBookTables.filter { it.id != tableSummary.id }
 
                         val nextTableId = if (remainingSameCourseBookTables.isEmpty()) {
-                            // 같은 학기에 남은 시간표가 없으면 전체에서 선택
+                            // 같은 학기에 남은 시간표가 없으면 전체에서 선택한다.
+                            // 삭제된 자리의 다음 시간표를, 마지막을 지웠다면 직전 시간표를 선택한다.
                             val remainingAllTables =
                                 allTables.filter { it.id != tableSummary.id }
-                            if (indexInAll == allTables.size) {
-                                remainingAllTables.last().id
-                            } else {
-                                remainingAllTables[indexInAll].id
-                            }
+                            remainingAllTables.getOrNull(indexInAll)?.id
+                                ?: remainingAllTables.last().id
                         } else {
-                            // 같은 학기에 남은 시간표가 있으면 그 중에서 선택
-                            if (indexInSameCourseBook == sameCourseBookTables.size) {
-                                remainingSameCourseBookTables.last().id
-                            } else {
-                                remainingSameCourseBookTables[indexInSameCourseBook].id
-                            }
+                            // 같은 학기에 남은 시간표 중에서 선택한다.
+                            // 삭제된 자리의 다음 시간표를, 마지막을 지웠다면 직전 시간표를 선택한다.
+                            remainingSameCourseBookTables.getOrNull(indexInSameCourseBook)?.id
+                                ?: remainingSameCourseBookTables.last().id
                         }
                         tableRepository.fetchAndSelectTable(nextTableId)
                     }

--- a/app/src/main/java/com/wafflestudio/snutt2/lib/android/DisplayMessageResolverImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/lib/android/DisplayMessageResolverImpl.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.domain.BookmarkLectureNotFound
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
+import com.wafflestudio.snutt2.domain.LastTimetableNotDeletable
 import com.wafflestudio.snutt2.domain.NetworkDisconnect
 import com.wafflestudio.snutt2.domain.NotSelectedTimetable
 import com.wafflestudio.snutt2.domain.TimetableLectureNotFound
@@ -27,6 +28,7 @@ class DisplayMessageResolverImpl @Inject constructor(
         is TimetableLectureNotFound -> context.getString(R.string.deeplink_page_timetable_lecture_page_not_existing_lecture)
         is BookmarkLectureNotFound -> context.getString(R.string.deeplink_page_timetable_lecture_page_not_existing_bookmark_lecture)
         is NotSelectedTimetable -> context.getString(R.string.home_drawer_change_theme_unable_alert_message)
+        is LastTimetableNotDeletable -> context.getString(R.string.home_drawer_delete_table_unable_alert_message)
         is Unknown -> error.displayMessage.takeUnless { it.isBlank() } ?: context.getString(R.string.error_unknown)
         else -> error.displayMessage
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -116,6 +116,7 @@
     <string name="common_no">No</string>
     <string name="common_notification">Notification</string>
     <string name="home_drawer_table_delete">Delete Timetable</string>
+    <string name="home_drawer_delete_table_unable_alert_message">You cannot delete the last remaining timetable.</string>
     <string name="home_drawer_change_name_dialog_title">Rename</string>
     <string name="home_drawer_table_credit">(%d credits)</string>
 <string name="home_drawer_change_theme_unable_alert_message">You can only change the theme of the currently selected timetable.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,6 +295,7 @@
     <string name="common_no">아니요</string>
     <string name="common_notification">알림</string>
     <string name="home_drawer_table_delete">시간표 삭제</string>
+    <string name="home_drawer_delete_table_unable_alert_message">하나 남은 시간표는 삭제할 수 없습니다.</string>
     <string name="home_drawer_change_name_dialog_title">이름 변경하기</string>
     <string name="home_drawer_table_credit">(%d학점)</string>
 <string name="home_drawer_change_theme_unable_alert_message">현재 선택된 시간표의 테마만 변경할 수 있습니다.</string>

--- a/app/src/test/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerViewModelTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerViewModelTest.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.snutt2.feature.home.drawer
 import app.cash.turbine.test
 import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.domain.GetCurrentTableThemeUseCase
+import com.wafflestudio.snutt2.domain.LastTimetableNotDeletable
 import com.wafflestudio.snutt2.domain.NotSelectedTimetable
 import com.wafflestudio.snutt2.domain.Unknown
 import com.wafflestudio.snutt2.domain.model.BuiltInTheme
@@ -566,15 +567,38 @@ class HomeDrawerViewModelTest {
 
     @Test
     fun `openDeleteTableDialog 호출 시 DeleteTable 다이얼로그가 열린다`() = runTest {
+        val summary = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        val other = tableSummary(id = "t2", courseBook = courseBook2025_1)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary, other)
         val viewModel = createViewModel()
         val before = viewModel.uiState.value
-        val summary = tableSummary(id = "t1")
 
         viewModel.openDeleteTableDialog(summary)
 
         assertEquals(
             before.copy(dialogState = HomeDrawerUiState.DialogState.DeleteTable(summary)),
             viewModel.uiState.value,
+        )
+    }
+
+    @Test
+    fun `openDeleteTableDialog 호출 시 시간표가 하나뿐이면 다이얼로그를 열지 않고 ShowToast 이벤트가 발생한다`() = runTest {
+        val summary = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(summary)
+        val viewModel = createViewModel()
+
+        viewModel.uiEvent.test {
+            viewModel.openDeleteTableDialog(summary)
+            assertEquals(
+                HomeDrawerUiEvent.ShowToast(LastTimetableNotDeletable.displayMessage),
+                awaitItem(),
+            )
+        }
+        assertEquals(
+            HomeDrawerUiState.DialogState.None,
+            viewModel.uiState.value.dialogState,
         )
     }
 
@@ -613,11 +637,10 @@ class HomeDrawerViewModelTest {
     @Test
     fun `deleteTable 성공 시 다이얼로그가 닫힌다`() = runTest {
         val summary = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        val other = tableSummary(id = "t2", courseBook = courseBook2025_1)
         fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
-        fakeTableRepository.tableSummaryList.value = listOf(summary)
-        fakeTableRepository.currentTable.value = table(
-            summary = tableSummary(id = "t2", courseBook = courseBook2025_1),
-        )
+        fakeTableRepository.tableSummaryList.value = listOf(summary, other)
+        fakeTableRepository.currentTable.value = table(summary = other)
         fakeTableRepository.deleteTableResult = Result.Success(Unit)
         val viewModel = createViewModel()
         viewModel.openDeleteTableDialog(summary)
@@ -659,6 +682,21 @@ class HomeDrawerViewModelTest {
         viewModel.deleteTable(current)
 
         assertEquals("t2", fakeTableRepository.fetchAndSelectTableCalledWith)
+    }
+
+    @Test
+    fun `deleteTable 성공 시 같은 학기의 마지막 순서 시간표를 삭제하면 직전 시간표로 전환한다`() = runTest {
+        val first = tableSummary(id = "t1", courseBook = courseBook2025_1)
+        val last = tableSummary(id = "t2", courseBook = courseBook2025_1)
+        fakeCourseBookRepository.courseBooks.value = listOf(courseBook2025_1)
+        fakeTableRepository.tableSummaryList.value = listOf(first, last)
+        fakeTableRepository.currentTable.value = table(summary = last)
+        fakeTableRepository.deleteTableResult = Result.Success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.deleteTable(last)
+
+        assertEquals("t1", fakeTableRepository.fetchAndSelectTableCalledWith)
     }
 
     @Test


### PR DESCRIPTION
## 문제

홈 화면 서랍에서 **현재 선택된 시간표가 그룹(같은 학기 또는 전체)의 마지막 인덱스**일 때 삭제하면 `IndexOutOfBoundsException`으로 앱이 크래시된다.

`deleteTable`에서 삭제 후 선택할 시간표를 고를 때, 삭제 위치가 마지막이었는지 판단하는 조건이 `index == list.size`로 작성돼 있다. `indexOfFirst` 결과는 항상 `0..size-1`이므로 이 조건은 **항상 false**가 되어, 마지막을 지웠을 때 `.last()`로 보정하려던 의도가 죽고 범위를 벗어난 인덱스에 접근한다.

재현 케이스:
- 같은 학기에 여러 시간표가 있고, 그중 마지막 순서(=현재 선택된) 시간표 삭제
- 어떤 학기의 유일한 시간표이면서 전체 목록에서도 가장 마지막인 시간표 삭제

추가로, 리팩토링(#485) 과정에서 옛 `checkTableDeletable`(전체 1개 삭제 차단) 방어로직이 사라져 있었다.

## 변경

- **버그 수정**: `== size` 비교 → `getOrNull(index) ?: last()`. 삭제된 자리의 다음 시간표를(마지막을 지웠다면 직전 시간표를) 안전하게 선택한다.
- **방어로직 복원**: `openDeleteTableDialog`에서 전체 시간표가 1개뿐이면 다이얼로그를 열지 않고 "하나 남은 시간표는 삭제할 수 없습니다." 토스트를 띄운다. 기존 `NotSelectedTimetable` 패턴을 따라 `DomainError` + `DisplayMessageResolver` + `ShowToast`로 구현.

## 테스트

- 기존 삭제 관련 테스트 2건 fixture 보정(다이얼로그가 실제로 열리도록 ≥2개 세팅)
- 회귀 방어 테스트 2건 추가
  - 같은 학기 마지막 순서 삭제 시 직전 시간표로 전환
  - 전체 1개뿐일 때 다이얼로그 미오픈 + 토스트 이벤트
- `ktlintFormat`, `compileDevDebugUnitTestKotlin`, `compileDevDebugScreenshotTestKotlin`, `HomeDrawerViewModelTest` 전체 통과