### PR TITLE
fix: 강의 목록 로드 전 새 시간표 만들기 클릭 시 크래시 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/drawer/HomeDrawerViewModel.kt
@@ -133,6 +133,7 @@ class HomeDrawerViewModel @Inject constructor(
 
     fun openCreateNewTableSheet() {
         val allCourseBooks = courseBookRepository.courseBooks.value
+        if (allCourseBooks.isEmpty()) return
         _uiState.update {
             it.copy(
                 homeDrawerBottomSheetType = HomeDrawerBottomSheetType.CreateNewTable.SelectCourseBook(


### PR DESCRIPTION
## 문제

`HomeDrawerViewModel.openCreateNewTableSheet()`에서 `NoSuchElementException: List is empty.` 크래시 발생.

```
Fatal Exception: java.util.NoSuchElementException: List is empty.
  at kotlin.collections.CollectionsKt___CollectionsKt.first
  at HomeDrawerViewModel.openCreateNewTableSheet(HomeDrawerViewModel.java:139)
```

## 원인

`courseBookRepository.courseBooks`는 초기값이 `emptyList()`이고 `fetchCourseBooks()`가 성공해야 채워진다. fetch는 `onDrawerOpened()`에서 비동기로 트리거되므로 **완료가 보장되지 않는다.**

`selectedTable`이 `null`인 상태에서 강의 목록이 아직 비어 있으면, fallback인 `allCourseBooks.first()`가 빈 리스트에서 호출되어 크래시한다.

즉, **드로어를 연 직후 fetch 완료 전(또는 네트워크 실패 후)에 "새 시간표 만들기" 버튼을 누르면** 재현된다.

## 수정

`allCourseBooks`가 비어 있으면 시트를 열지 않고 early return 한다. 강의 목록 fetch가 완료되면 정상적으로 시트를 열 수 있다.

## 테스트

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과