### PR TITLE
fix: 팝업 조회 시 Popup DTO 직렬화 크래시 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/GetPopupResults.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/GetPopupResults.kt
@@ -7,6 +7,7 @@ import com.squareup.moshi.JsonClass
 data class GetPopupResults(
     @param:Json(name = "content") val popups: List<Popup>,
 ) {
+    @JsonClass(generateAdapter = true)
     data class Popup(
         @param:Json(name = "key") val key: String,
         @param:Json(name = "imageUri") val imageUri: String,


### PR DESCRIPTION
## 문제

홈 진입 시 팝업 조회(`_getPopup`)에서 크래시 발생.

```
java.lang.IllegalArgumentException: Unable to create converter for class GetPopupResults
  for method SNUTTRestApi._getPopup
Caused by: Cannot serialize Kotlin type GetPopupResults$Popup.
  Reflective serialization of Kotlin classes without using kotlin-reflect has undefined and unexpected behavior.
```

## 원인

이 프로젝트의 Moshi 직렬화는 `moshi-kotlin-codegen`(KSP)으로 컴파일 타임에 `${ClassName}JsonAdapter`를 생성해 동작하며, reflection 기반 `KotlinJsonAdapterFactory`는 등록되어 있지 않다.

`GetPopupResults`에는 `@JsonClass(generateAdapter = true)`가 있지만, **nested 클래스 `Popup`에는 누락**되어 있었다. 따라서 `Popup`의 codegen 어댑터가 생성되지 않았고, Moshi가 reflective 직렬화로 fallback하면서 런타임에 실패한다.

## 수정

`GetPopupResults.Popup`에 `@JsonClass(generateAdapter = true)`를 추가한다.

빌드 후 KSP가 `GetPopupResults_PopupJsonAdapter`를 정상 생성하는 것을 확인했다.

## 테스트

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과
- `app/build/generated/ksp/devDebug/.../GetPopupResults_PopupJsonAdapter.kt` 생성 확인