### PR TITLE
fix: 위젯 크기 미확정 시 0 크기 비트맵 생성 크래시 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/TimetableWidgetProvider.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/TimetableWidgetProvider.kt
@@ -118,6 +118,11 @@ TimetableWidgetProvider : AppWidgetProvider() {
 
         views.setViewVisibility(R.id.placeholder, View.VISIBLE)
         views.setViewVisibility(R.id.table, View.GONE)
+
+        // 위젯 크기가 아직 확정되지 않은 경우(0) 비트맵 생성을 건너뛰고 placeholder만 노출한다.
+        // 크기가 확정되면 onUpdate/onAppWidgetOptionsChanged 가 유효한 크기로 다시 호출된다.
+        if (width <= 0 || height <= 0) return views
+
         tableRepository.currentTable.value?.let { table ->
             val tableView = TimetableView(context, compactMode)
 


### PR DESCRIPTION
## 문제

홈 화면 위젯 업데이트 시 크래시 발생.

```
java.lang.RuntimeException: Unable to start receiver TimetableWidgetProvider:
  java.lang.IllegalArgumentException: width and height must be > 0
Caused by: at android.graphics.Bitmap.createBitmap
  at TimetableWidgetProvider.createRemoteViews(TimetableWidgetProvider.kt:128)
  at TimetableWidgetProvider.createResponsiveRemoteViews(TimetableWidgetProvider.kt:94)
  at TimetableWidgetProvider.onUpdate(TimetableWidgetProvider.kt:48)
```

## 원인

`createRemoteViews()`의 `createBitmap(width, height)`에 `width`/`height`가 `0`으로 전달되어 발생한다.

스택트레이스의 line 94는 API 31(`Build.VERSION_CODES.S`) 미만 경로의 분기다:

```kotlin
val minWidth = (options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH) * dm.density).toInt()
...
if (minWidth == maxWidth && minHeight == maxHeight) {
    return createRemoteViews(context, minWidth, minHeight)  // ← line 94
}
```

위젯이 **막 추가되어 크기 옵션이 아직 확정되지 않은 시점**(또는 옵션 Bundle이 비어 있는 상태)에 `onUpdate`가 호출되면 `getAppWidgetOptions()`가 반환하는 `MIN_WIDTH`/`MIN_HEIGHT` 등이 `0`이 된다. 그 결과 `minWidth == maxWidth == 0 && minHeight == maxHeight == 0`이 되어 `createRemoteViews(context, 0, 0)` → `createBitmap(0, 0)` 크래시로 이어진다.

API 31+ 경로(line 83)도 size 값이 `0`이면 동일한 문제가 잠재한다.

## 수정

`createRemoteViews()`에서 `width <= 0 || height <= 0`이면 비트맵을 생성하지 않고 placeholder만 노출하는 `RemoteViews`를 반환하도록 가드를 추가했다. 위젯 크기가 확정되면 `onUpdate`/`onAppWidgetOptionsChanged`가 유효한 크기로 다시 호출되어 정상 렌더링된다.

## 테스트

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과