### PR TITLE
fix: RemoteConfigDto nested DTO 직렬화 크래시 방지

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/RemoteConfigDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/RemoteConfigDto.kt
@@ -13,18 +13,22 @@ data class RemoteConfigDto(
     @param:Json(name = "disableMapFeature") val disableMapFeature: Boolean? = null,
     @param:Json(name = "notice") val noticeConfig: NoticeConfig? = null,
 ) {
+    @JsonClass(generateAdapter = true)
     data class SettingsBadgeConfig(
         @param:Json(name = "new") val new: List<String> = emptyList(),
     )
 
+    @JsonClass(generateAdapter = true)
     data class VacancyBannerConfig(
         @param:Json(name = "visible") val visible: Boolean = false,
     )
 
+    @JsonClass(generateAdapter = true)
     data class VacancyUrlConfig(
         @param:Json(name = "url") val url: String? = null,
     )
 
+    @JsonClass(generateAdapter = true)
     data class NoticeConfig(
         @param:Json(name = "visible") val visible: Boolean = false,
         @param:Json(name = "title") val title: String? = null,


### PR DESCRIPTION
## 배경

#621(`GetPopupResults.Popup` 직렬화 크래시) 수정 후, 동일 패턴(top-level DTO에는 `@JsonClass`가 있으나 nested data class에는 누락)을 전수조사하여 발견한 추가 케이스다.

## 문제

이 프로젝트의 Moshi 직렬화는 `moshi-kotlin-codegen`(KSP)으로 동작하며 reflection 기반 `KotlinJsonAdapterFactory`는 등록되어 있지 않다. 따라서 codegen 어댑터가 없는 클래스는 런타임에 `Cannot serialize Kotlin type ...` 크래시로 이어진다.

`RemoteConfigDto`(부모)에는 `@JsonClass(generateAdapter = true)`가 있지만, 아래 4개 nested data class에 누락되어 있었다.

- `RemoteConfigDto.SettingsBadgeConfig`
- `RemoteConfigDto.VacancyBannerConfig`
- `RemoteConfigDto.VacancyUrlConfig`
- `RemoteConfigDto.NoticeConfig`

`RemoteConfigDto`는 `SNUTTRestApi._getRemoteConfig()`의 응답 타입(`GetRemoteConfigResponse`)으로 역직렬화 경로에 있다.

### 근거 (수정 전 빌드 산출물 확인)

- 생성된 `RemoteConfigDtoJsonAdapter`는 nested 타입을 `moshi.adapter(RemoteConfigDto.VacancyBannerConfig::class.java, ...)`로 **런타임 조회**한다.
- 그러나 nested 4개의 codegen 어댑터(`RemoteConfigDto_*JsonAdapter`)는 생성되지 않았다 → Moshi가 reflective 직렬화로 fallback하여 실패.

## 수정

4개 nested data class에 `@JsonClass(generateAdapter = true)`를 추가한다.

수정 후 빌드에서 `RemoteConfigDto_SettingsBadgeConfigJsonAdapter`, `RemoteConfigDto_VacancyBannerConfigJsonAdapter`, `RemoteConfigDto_VacancyUrlConfigJsonAdapter`, `RemoteConfigDto_NoticeConfigJsonAdapter`가 모두 생성됨을 확인했다.

## 테스트

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과
- nested 어댑터 4종 생성 확인