### PR TITLE
fix: Firebase 토큰 획득 실패 시 원인 예외 보존

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/user/UserRepositoryImpl.kt
@@ -381,7 +381,9 @@ class UserRepositoryImpl @Inject constructor(
             FirebaseMessaging.getInstance().token.addOnCompleteListener(
                 OnCompleteListener { task ->
                     if (!task.isSuccessful) {
-                        cont.resumeWithException(RuntimeException("cannot get firebase token"))
+                        cont.resumeWithException(
+                            RuntimeException("cannot get firebase token", task.exception),
+                        )
                         return@OnCompleteListener
                     }
                     val token = task.result


### PR DESCRIPTION
## 문제

Crashlytics에 Non-fatal로 다음 예외가 반복 기록된다.

```
java.lang.RuntimeException: cannot get firebase token
  at UserRepositoryImpl$getFirebaseToken$2$1.onComplete(UserRepositoryImpl.kt:384)
```

## 원인 분석

`getFirebaseToken()`은 `FirebaseMessaging.getInstance().token` task가 실패하면 `RuntimeException("cannot get firebase token")`을 던진다. 이 예외는 호출자(`registerToken`/`postForceLogout`)의 try/catch에서 `e.toDomainError()`로 변환되는데, `ExceptionMapper.toDomainError()`는 알려진 타입(`IOException`/`HttpException` 등)이 아닌 예외를 `else` 분기에서 `FirebaseCrashlytics.recordException()` + `Unknown`으로 처리한다. 따라서 Firebase 토큰 실패가 Crashlytics Non-fatal로 기록된다.

이때 throw하는 예외가 메시지만 가진 generic `RuntimeException`이라, **실제 실패 원인(`task.exception`)이 유실**되어 Crashlytics에서 근본 원인을 파악할 수 없다.

## 수정 (최소 변경)

예외 처리·분류 정책은 그대로 두고, throw하는 `RuntimeException`에 `task.exception`을 cause로 포함시켜 Crashlytics에서 실제 원인을 확인할 수 있도록 한다.

```kotlin
cont.resumeWithException(
    RuntimeException("cannot get firebase token", task.exception),
)
```

이를 통해 Firebase 토큰 획득 실패가 어떤 하위 원인(Play Services 미탑재/구버전, 네트워크, FCM 장애 등)에서 비롯되는지 Crashlytics에서 구분할 수 있다.

## 테스트

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과