### PR TITLE
feat: 앱별 언어 설정(시스템) 노출

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,12 @@ android {
         targetSdk = 36
     }
 
+    androidResources {
+        // res/values-* 를 스캔해 _generated_res_locale_config 를 빌드 시 자동 생성한다.
+        // 시스템 "앱별 언어 설정"(API 33+) 노출에 사용. 지원 언어 추가 시 자동 반영된다.
+        generateLocaleConfig = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=ko-KR


### PR DESCRIPTION
## 요약

Android 13(API 33)+ 시스템 설정의 **"앱별 언어 설정"** 에 **한국어 / English** 선택지가 노출되도록 `localeConfig` 를 추가합니다.

기존에 `res/values`(한국어) + `res/values-en`(영어) 리소스는 이미 갖춰져 있었으나, `localeConfig` 가 없어 시스템 언어 선택 UI 가 뜨지 않았습니다.

## 변경 사항

- **`app/build.gradle.kts`**: `androidResources { generateLocaleConfig = true }`
  - AGP 가 `res/values-*` 를 스캔해 `_generated_res_locale_config` 를 빌드 시 자동 생성하고, 병합 매니페스트에 `android:localeConfig` 를 자동 주입합니다.
  - 향후 언어를 추가하면 자동으로 목록에 반영됩니다.
- **`app/src/main/res/resources.properties`** (신규): `unqualifiedResLocale=ko-KR`
  - 기본 `res/values` 가 한국어임을 명시합니다.

> ℹ️ 자동 생성 방식에서는 `AndroidManifest.xml` 에 `localeConfig` 를 **직접 선언하면 안 됩니다** (AGP 가 주입하므로 충돌). 그래서 매니페스트는 변경하지 않았습니다.

## 검증

- `mergeDevDebugResources` 로 생성 확인:
  ```xml
  <locale-config ... android:defaultLocale="ko-KR">
      <locale android:name="ko-KR"/>
      <locale android:name="en"/>
  </locale-config>
  ```
- `processDevDebugMainManifest` 병합 결과에 `android:localeConfig="@xml/_generated_res_locale_config"` 자동 주입 확인.
- `ktlintFormat` 통과.

## 범위 / 참고

- 이번 PR 은 **시스템 설정 노출(API 33+)** 만을 목표로 합니다.
- API 33 미만(minSdk 24~32) 기기에서의 인앱 언어 전환은 범위에 포함하지 않았습니다 (필요 시 AppCompat 연동을 추가하면 됩니다).
