### PR TITLE
강의 상세 및 검색 입력 동작 개선

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureActionButtons.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureActionButtons.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.snutt2.feature.lecturedetail
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,7 +39,11 @@ internal fun LectureActionButtons(
     onReset: () -> Unit,
 ) {
     // 강의계획서 + 강의평
-    AnimatedVisibility(visible = lecture is LectureSyllabusInfo && !editMode) {
+    AnimatedVisibility(
+        visible = lecture is LectureSyllabusInfo && !editMode,
+        enter = expandVertically(),
+        exit = shrinkVertically(),
+    ) {
         Column(modifier = Modifier.background(SNUTTColors.White900)) {
             LectureDetailActionButton(
                 title = stringResource(R.string.lecture_detail_syllabus_button),
@@ -54,7 +60,11 @@ internal fun LectureActionButtons(
     if (hideDeleteButton.not()) {
         when (lecture) {
             is CustomLecture -> {
-                AnimatedVisibility(visible = !editMode) {
+                AnimatedVisibility(
+                    visible = !editMode,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
                     Box(modifier = Modifier.background(SNUTTColors.White900)) {
                         LectureDetailActionButton(
                             title = stringResource(R.string.lecture_detail_delete_button),

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetail.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/LectureDetail.kt
@@ -147,14 +147,16 @@ fun LectureDetail(
                 Spacer(modifier = Modifier.height(10.dp))
 
                 // 5. 시간/장소 + 지도
-                LectureSessionListSection(
-                    sessions = lecture.lectureSessions,
-                    editMode = editMode,
-                    onEditTime = onEditTime,
-                    onLocationChange = onLocationChange,
-                    onDeleteSession = onDeleteSession,
-                    onAddSession = onAddSession,
-                )
+                AnimatedVisibility(visible = editMode || lecture.lectureSessions.isNotEmpty()) {
+                    LectureSessionListSection(
+                        sessions = lecture.lectureSessions,
+                        editMode = editMode,
+                        onEditTime = onEditTime,
+                        onLocationChange = onLocationChange,
+                        onDeleteSession = onDeleteSession,
+                        onAddSession = onAddSession,
+                    )
+                }
                 AnimatedVisibility(visible = editMode.not() && disableMapFeature.not()) {
                     FoldableEmbedMap(
                         modifier = Modifier

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchScreen.kt
@@ -167,7 +167,10 @@ private fun RowScope.SearchTopBarContent(
             R.drawable.ic_search_unselected,
             modifier = Modifier
                 .size(30.dp)
-                .clicks { onSearch() },
+                .clicks {
+                    searchEditTextFocused = false
+                    onSearch()
+                },
             colorFilter = ColorFilter.tint(SNUTTColors.Black900),
         )
         EditText(
@@ -190,7 +193,16 @@ private fun RowScope.SearchTopBarContent(
             clearFocusFlag = !searchEditTextFocused,
         )
         if (searchEditTextFocused) {
-            SnuttIcon(R.drawable.ic_exit, modifier = Modifier.clicks { onClearEditText() }.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
+            SnuttIcon(
+                R.drawable.ic_exit,
+                modifier = Modifier
+                    .clicks {
+                        searchEditTextFocused = false
+                        onClearEditText()
+                    }
+                    .size(30.dp),
+                colorFilter = ColorFilter.tint(SNUTTColors.Black900),
+            )
         } else {
             SnuttIcon(R.drawable.ic_filter, modifier = Modifier.clicks { onFilter() }.size(30.dp), colorFilter = ColorFilter.tint(SNUTTColors.Black900))
         }


### PR DESCRIPTION
## 변경 내용

- LectureDetail 화면에서 강의계획서/강의평 버튼 영역이 편집 모드 전환 시 세로 방향으로 접히고 펼쳐지도록 수정했습니다.
- 시간/장소 세션이 없는 강의는 조회 모드에서 시간/장소 섹션과 지도를 숨기고, 편집 모드 진입 시 해당 섹션이 `AnimatedVisibility`로 나타나도록 수정했습니다.
- 검색 화면에서 X 버튼으로 검색어를 지우거나 좌측 돋보기 버튼으로 검색할 때, 키보드 Search 엔터와 동일하게 포커스를 해제해 키보드가 닫히도록 수정했습니다.

## 변경 이유

- LectureDetail 하단 버튼 영역은 편집 모드 전환 시 강의평점 영역과 다른 방식으로 애니메이션되어 화면 전환감이 어색했습니다.
- 실제 시간/장소 정보가 없는 강의에서도 빈 시간/장소 섹션이 노출될 수 있었습니다.
- 검색어 clear 및 검색 아이콘 클릭은 검색 실행/입력 종료 동작임에도 키보드가 남아 있어 IME Search 동작과 일관되지 않았습니다.

## 영향

- 강의 상세 화면의 편집 모드 전환 애니메이션이 더 일관되게 동작합니다.
- 시간/장소 정보가 없는 강의의 상세 화면에서 불필요한 빈 섹션이 사라집니다.
- 검색 화면에서 검색어 삭제 및 검색 아이콘 클릭 후 키보드가 자연스럽게 닫힙니다.

## 검증

- `GRADLE_USER_HOME=/private/tmp/gradle ./gradlew :app:compileLiveDebugKotlin`
