### PR TITLE
feat: 강의계획서를 외부 브라우저에서 인앱 바텀시트 WebView로 전환

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/lectureinfo/LectureInfoRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lectureinfo/LectureInfoRepositoryImpl.kt
@@ -23,7 +23,7 @@ class LectureInfoRepositoryImpl @Inject constructor(
         lecture: LectureSyllabusInfo,
     ): Result<String> {
         try {
-            val url = api._getCoursebooksOfficial(courseBook.year, courseBook.semester, lecture.courseNumber, lecture.lectureNumber).url
+            val url = api._getCoursebooksOfficial(courseBook.year, courseBook.semester, lecture.courseNumber, lecture.lectureNumber).noProxyUrl
             return Result.Success(url)
         } catch (e: Exception) {
             return Result.Fail(e.toDomainError())

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/bookmark/BookmarkPage.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.bookmark
 
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
@@ -49,6 +47,7 @@ fun BookmarkRoute(
     onNavigateToOnboard: () -> Unit,
     onNavigateBack: () -> Unit,
     onNavigateToReview: (SearchedLecture) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -83,7 +82,7 @@ fun BookmarkRoute(
                 }
 
                 is BookmarkUiEvent.OpenUrl -> {
-                    context.startActivity(Intent(Intent.ACTION_VIEW, event.url.toUri()))
+                    onNavigateToSyllabus(event.url)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/home/HomePage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/home/HomePage.kt
@@ -64,6 +64,7 @@ fun HomePageRoute(
     onNavigateNetworkLog: () -> Unit,
     onNavigateTest: () -> Unit,
     onNavigateToReview: (SearchedLecture) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -127,6 +128,7 @@ fun HomePageRoute(
         onNavigateNetworkLog = onNavigateNetworkLog,
         onNavigateTest = onNavigateTest,
         onNavigateToReview = onNavigateToReview,
+        onNavigateToSyllabus = onNavigateToSyllabus,
         onPopupClickFewDays = viewModel::closePopupWithHiddenDays,
         onPopupClickClose = viewModel::closePopup,
         onPopupClickImage = viewModel::onPopupImageClick,
@@ -163,6 +165,7 @@ private fun HomePageNewScreen(
     onNavigateNetworkLog: () -> Unit,
     onNavigateTest: () -> Unit,
     onNavigateToReview: (SearchedLecture) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
     onPopupClickFewDays: () -> Unit,
     onPopupClickClose: () -> Unit,
     onPopupClickImage: () -> Unit,
@@ -210,6 +213,7 @@ private fun HomePageNewScreen(
             onNavigateVacancy = onNavigateVacancyNotification,
             onNavigateOnboardAsOrigin = onNavigateOnboardAsOrigin,
             onNavigateToReview = onNavigateToReview,
+            onNavigateToSyllabus = onNavigateToSyllabus,
         )
 
         is HomeItem.Review -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/currenttable/CurrentTableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/currenttable/CurrentTableLectureDetailRoute.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.feature.lecturedetail.currenttable
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ModalBottomSheetValue
@@ -15,7 +14,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
@@ -47,6 +45,7 @@ fun CurrentTableLectureDetailRoute(
     onNavigateLectureReminder: () -> Unit,
     onNavigateOnboard: () -> Unit,
     onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -122,8 +121,7 @@ fun CurrentTableLectureDetailRoute(
                 }
 
                 is CurrentTableLectureDetailUiEvent.OpenUrl -> {
-                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    context.startActivity(intent)
+                    onNavigateToSyllabus(event.url)
                 }
 
                 is CurrentTableLectureDetailUiEvent.OpenBottomSheet -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.lecturedetail.deeplink
 
-import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.domain.model.BuiltInTheme
@@ -31,6 +29,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
     vm: DeeplinkBookmarkLectureDetailViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit,
     onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
@@ -48,8 +47,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
                 }
 
                 is DeeplinkBookmarkLectureDetailUiEvent.OpenUrl -> {
-                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    context.startActivity(intent)
+                    onNavigateToSyllabus(event.url)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.lecturedetail.deeplink
 
-import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.domain.model.BuiltInTheme
@@ -33,6 +31,7 @@ fun DeeplinkTimetableLectureDetailRoute(
     onNavigateBack: () -> Unit,
     onNavigateHome: () -> Unit,
     onNavigateToReview: (reviewId: String, lectureId: String) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
@@ -51,8 +50,7 @@ fun DeeplinkTimetableLectureDetailRoute(
                 }
 
                 is DeeplinkTimetableLectureDetailUiEvent.OpenUrl -> {
-                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    context.startActivity(intent)
+                    onNavigateToSyllabus(event.url)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.search
 
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -43,6 +41,7 @@ fun SearchRoute(
     onNavigateVacancy: () -> Unit,
     onNavigateOnboardAsOrigin: () -> Unit,
     onNavigateToReview: (SearchedLecture) -> Unit,
+    onNavigateToSyllabus: (url: String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -90,7 +89,7 @@ fun SearchRoute(
                 }
 
                 is SearchUiEvent.OpenUrl -> {
-                    context.startActivity(Intent(Intent.ACTION_VIEW, uiEvent.url.toUri()))
+                    onNavigateToSyllabus(uiEvent.url)
                 }
 
                 is SearchUiEvent.ShowSnackBar -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusBottomSheetRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusBottomSheetRoute.kt
@@ -1,0 +1,48 @@
+package com.wafflestudio.snutt2.feature.syllabus
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.ui.util.toast
+
+@Composable
+fun SyllabusBottomSheetRoute(
+    onNavigateBack: () -> Unit,
+    viewModel: SyllabusBottomSheetViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val downloadStartedMessage = stringResource(R.string.syllabus_download_started)
+
+    val syllabusWebViewContainer = remember {
+        SyllabusWebViewContainer(
+            context = context,
+            onDownloadStart = {
+                context.toast(downloadStartedMessage)
+            },
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        syllabusWebViewContainer.openPage(viewModel.url)
+    }
+
+    BackHandler {
+        if (syllabusWebViewContainer.webView.canGoBack()) {
+            syllabusWebViewContainer.webView.goBack()
+        } else {
+            onNavigateBack()
+        }
+    }
+
+    SyllabusWebView(
+        modifier = Modifier.fillMaxHeight(0.95f),
+        syllabusWebViewContainer = syllabusWebViewContainer,
+    )
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusBottomSheetViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusBottomSheetViewModel.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.snutt2.feature.syllabus
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.wafflestudio.snutt2.navigation.NavigationDestination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SyllabusBottomSheetViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val route = savedStateHandle.toRoute<NavigationDestination.Syllabus>()
+
+    val url: String = route.url
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusDownloader.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusDownloader.kt
@@ -1,0 +1,105 @@
+package com.wafflestudio.snutt2.feature.syllabus
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.Uri
+import android.webkit.CookieManager
+import android.webkit.URLUtil
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.ui.util.openFileInViewer
+import com.wafflestudio.snutt2.ui.util.toast
+import java.io.File
+
+/**
+ * WebView 세션 안에서 트리거된 강의계획서 첨부 파일(PDF 등)을 앱 전용 캐시로 내려받는다.
+ *
+ * WebView 다운로드는 브라우징 세션의 연속이므로, 시스템 다운로드 서비스인 DownloadManager 에
+ * WebView 세션의 Referer·쿠키·User-Agent 를 그대로 실어 위임한다. 저장 위치는 앱 전용 외부 캐시라
+ * 저장소 권한이 필요 없고 저장공간이 부족하면 시스템이 자동 정리한다.
+ * 다운로드가 끝나면 뷰어 앱으로 연다.
+ */
+object SyllabusDownloader {
+
+    private const val CACHE_SUBDIR = "syllabus"
+
+    fun enqueue(
+        context: Context,
+        url: String,
+        userAgent: String?,
+        contentDisposition: String?,
+        mimeType: String?,
+        referer: String,
+    ) {
+        val appContext = context.applicationContext
+        val cacheDir = appContext.externalCacheDir ?: return
+        val downloadDir = File(cacheDir, CACHE_SUBDIR).apply { mkdirs() }
+        val fileName = URLUtil.guessFileName(url, contentDisposition, mimeType)
+        val destFile = File(downloadDir, fileName)
+        // 같은 파일명이 있으면 덮어쓴다(중복 파일 누적 방지).
+        if (destFile.exists()) destFile.delete()
+
+        val request = DownloadManager.Request(url.toUri()).apply {
+            addRequestHeader("Referer", referer)
+            CookieManager.getInstance().getCookie(url)?.let { addRequestHeader("Cookie", it) }
+            userAgent?.let { addRequestHeader("User-Agent", it) }
+            setMimeType(mimeType)
+            setTitle(fileName)
+            setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            setDestinationUri(Uri.fromFile(destFile))
+        }
+        val downloadManager = appContext.getSystemService(DownloadManager::class.java)
+        val downloadId = downloadManager.enqueue(request)
+        registerCompletionReceiver(appContext, downloadManager, downloadId, mimeType)
+    }
+
+    private fun registerCompletionReceiver(
+        appContext: Context,
+        downloadManager: DownloadManager,
+        downloadId: Long,
+        mimeType: String?,
+    ) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                val completedId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
+                if (completedId != downloadId) return
+                appContext.unregisterReceiver(this)
+                openDownloadedFile(appContext, downloadManager, downloadId, mimeType)
+            }
+        }
+        ContextCompat.registerReceiver(
+            appContext,
+            receiver,
+            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+            ContextCompat.RECEIVER_EXPORTED,
+        )
+    }
+
+    private fun openDownloadedFile(
+        appContext: Context,
+        downloadManager: DownloadManager,
+        downloadId: Long,
+        mimeType: String?,
+    ) {
+        val file = queryDownloadedFile(downloadManager, downloadId) ?: return
+        if (!appContext.openFileInViewer(file, mimeType)) {
+            appContext.toast(appContext.getString(R.string.syllabus_download_open_failed))
+        }
+    }
+
+    private fun queryDownloadedFile(downloadManager: DownloadManager, downloadId: Long): File? {
+        downloadManager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
+            if (!cursor.moveToFirst()) return null
+            val statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
+            if (cursor.getInt(statusIndex) != DownloadManager.STATUS_SUCCESSFUL) return null
+            val localUriIndex = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
+            val localUri = cursor.getString(localUriIndex) ?: return null
+            val path = localUri.toUri().path ?: return null
+            return File(path)
+        }
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusWebView.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusWebView.kt
@@ -1,0 +1,151 @@
+package com.wafflestudio.snutt2.feature.syllabus
+
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.wafflestudio.snutt2.R
+import com.wafflestudio.snutt2.lib.android.webview.LoadState
+import com.wafflestudio.snutt2.ui.preview.SnuttPreview
+import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
+import com.wafflestudio.snutt2.ui.theme.SNUTTColors
+import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
+
+@Composable
+fun SyllabusWebView(
+    syllabusWebViewContainer: SyllabusWebViewContainer,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+            .background(SNUTTColors.White900),
+    ) {
+        when (val loadState = syllabusWebViewContainer.loadState.value) {
+            LoadState.Error -> SyllabusWebViewError(
+                modifier = Modifier.fillMaxSize(),
+                onRetry = { syllabusWebViewContainer.reload() },
+            )
+
+            is LoadState.Loading -> SyllabusWebViewLoading(
+                modifier = Modifier.fillMaxSize(),
+                progress = loadState.progress / 100.0f,
+            )
+
+            LoadState.Success -> SyllabusWebViewSuccess(
+                modifier = Modifier.fillMaxSize(),
+                webView = syllabusWebViewContainer.webView,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SyllabusWebViewError(modifier: Modifier, onRetry: () -> Unit) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Image(
+            modifier = Modifier.size(width = 50.dp, height = 58.dp),
+            painter = painterResource(id = R.drawable.ic_cat_retry),
+            contentDescription = stringResource(R.string.syllabus_webview_error),
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            text = stringResource(id = R.string.syllabus_webview_error),
+            style = SNUTTTypography.subtitle1,
+            color = SNUTTColors.Black900,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(backgroundColor = SNUTTColors.Sky),
+        ) {
+            Text(
+                text = stringResource(id = R.string.syllabus_webview_error_retry),
+                style = SNUTTTypography.h3,
+                color = SNUTTColors.White900,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SyllabusWebViewSuccess(modifier: Modifier, webView: WebView) {
+    Column(modifier = modifier.fillMaxSize()) {
+        AndroidView(
+            factory = {
+                webView.apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SyllabusWebViewLoading(modifier: Modifier, progress: Float) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        LinearProgressIndicator(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp),
+            progress = progress,
+            color = SNUTTColors.Gray200,
+        )
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun SyllabusWebViewError_Default() {
+    SnuttPreviewSurface {
+        SyllabusWebViewError(
+            modifier = Modifier.fillMaxSize(),
+            onRetry = {},
+        )
+    }
+}
+
+@SnuttPreview
+@Composable
+private fun SyllabusWebViewLoading_Default() {
+    SnuttPreviewSurface {
+        SyllabusWebViewLoading(
+            modifier = Modifier.fillMaxSize(),
+            progress = 0.5f,
+        )
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusWebViewContainer.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/syllabus/SyllabusWebViewContainer.kt
@@ -1,0 +1,106 @@
+package com.wafflestudio.snutt2.feature.syllabus
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Bitmap
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import com.wafflestudio.snutt2.BuildConfig
+import com.wafflestudio.snutt2.lib.android.webview.LoadState
+import com.wafflestudio.snutt2.lib.android.webview.WebViewContainer
+
+/**
+ * 강의계획서(수강신청 시스템)를 인앱 WebView 로 띄우기 위한 컨테이너.
+ *
+ * 강의계획서 URL(noProxyUrl)은 sugang.snu.ac.kr 을 직접 가리키며, 해당 서버가
+ * Referer 를 검증하기 때문에 요청에 Referer 헤더를 실어야 페이지가 열린다.
+ * (강의평 WebView 와 달리 SNUTT 인증 쿠키는 주입하지 않는다 — 외부 도메인이다.)
+ *
+ * WebView 는 그 자체로 sugang 과 대화하는 미니 브라우저다. 페이지 로드의 Referer 도, 페이지
+ * 안에서 트리거되는 파일 다운로드도 이 WebView 세션(쿠키/Referer/UA)의 연속이므로, 다운로드까지
+ * 이 컨테이너 안에서 완결한다. ViewModel/Repository 는 관여하지 않는다.
+ */
+class SyllabusWebViewContainer(
+    context: Context,
+    private val onDownloadStart: () -> Unit,
+) : WebViewContainer {
+    val loadState: MutableState<LoadState> = mutableStateOf(LoadState.Loading(0))
+
+    private var lastUrl: String? = null
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override val webView: WebView = WebView(context).apply {
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true)
+        }
+        this.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                if (loadState.value != LoadState.Error) {
+                    loadState.value = LoadState.Success
+                }
+            }
+
+            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                loadState.value = LoadState.Loading(0)
+            }
+
+            override fun onReceivedError(
+                view: WebView?,
+                request: WebResourceRequest?,
+                error: WebResourceError?,
+            ) {
+                loadState.value = LoadState.Error
+            }
+        }
+        this.webChromeClient = object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                when (loadState.value) {
+                    is LoadState.Loading -> LoadState.Loading(newProgress)
+                    else -> null
+                }?.let {
+                    loadState.value = it
+                }
+            }
+        }
+        this.settings.javaScriptEnabled = true
+        // noProxyUrl 자체는 항상 HTML 페이지지만, 그 페이지 안에서 PDF 등 첨부 파일 다운로드가
+        // 트리거되면 WebView 가 렌더할 수 없으므로 WebView 세션째 다운로드로 처리한다.
+        setDownloadListener { url, userAgent, contentDisposition, mimeType, _ ->
+            SyllabusDownloader.enqueue(
+                context = context,
+                url = url,
+                userAgent = userAgent,
+                contentDisposition = contentDisposition,
+                mimeType = mimeType,
+                referer = SUGANG_REFERER,
+            )
+            onDownloadStart()
+        }
+    }
+
+    override suspend fun openPage(url: String?) {
+        lastUrl = url
+        loadWithReferer(url)
+    }
+
+    fun reload() {
+        loadWithReferer(lastUrl)
+    }
+
+    private fun loadWithReferer(url: String?) {
+        val target = url ?: return
+        loadState.value = LoadState.Loading(0)
+        webView.loadUrl(target, mapOf("Referer" to SUGANG_REFERER))
+    }
+
+    companion object {
+        // 이 Referer 가 있어야 sugang 서버가 강의계획서 페이지를 내려준다.
+        private const val SUGANG_REFERER =
+            "https://sugang.snu.ac.kr/sugang/cc/cc100InterfaceExcel.action"
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/navigation/NavigationDestination.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/navigation/NavigationDestination.kt
@@ -173,6 +173,12 @@ sealed interface NavigationDestination {
     ) : NavigationDestination
 
     @Serializable
+    @DeepLinkPath("syllabus")
+    data class Syllabus(
+        val url: String,
+    ) : NavigationDestination
+
+    @Serializable
     @DeepLinkPath("social_link")
     data object SocialLink : NavigationDestination
 

--- a/app/src/main/java/com/wafflestudio/snutt2/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/navigation/RootNavGraph.kt
@@ -58,6 +58,7 @@ import com.wafflestudio.snutt2.feature.settings.TeamInfoPage
 import com.wafflestudio.snutt2.feature.settings.ThemeModeSelectPage
 import com.wafflestudio.snutt2.feature.settings.TimetableConfigRoute
 import com.wafflestudio.snutt2.feature.settings.UserConfigRoute
+import com.wafflestudio.snutt2.feature.syllabus.SyllabusBottomSheetRoute
 import com.wafflestudio.snutt2.feature.tablelectures.TableLecturesRoute
 import com.wafflestudio.snutt2.feature.themeconfig.ThemeConfigRoute
 import com.wafflestudio.snutt2.feature.themeconfig.ThemeDetailRoute
@@ -118,6 +119,9 @@ internal fun NavGraphBuilder.buildRootNavGraph(
                         lectureId = lecture.id,
                     ),
                 )
+            },
+            onNavigateToSyllabus = { url ->
+                navController.navigate(NavigationDestination.Syllabus(url))
             },
         )
     }
@@ -182,6 +186,9 @@ internal fun NavGraphBuilder.buildRootNavGraph(
                     ),
                 )
             },
+            onNavigateToSyllabus = { url ->
+                navController.navigate(NavigationDestination.Syllabus(url))
+            },
         )
     }
 
@@ -197,6 +204,9 @@ internal fun NavGraphBuilder.buildRootNavGraph(
                         referrer = DetailScreenReferrer.Bookmark.encode(),
                     ),
                 )
+            },
+            onNavigateToSyllabus = { url ->
+                navController.navigate(NavigationDestination.Syllabus(url))
             },
         )
     }
@@ -237,6 +247,12 @@ internal fun NavGraphBuilder.buildRootNavGraph(
         )
     }
 
+    bottomSheet<NavigationDestination.Syllabus> {
+        SyllabusBottomSheetRoute(
+            onNavigateBack = { navController.popBackStack() },
+        )
+    }
+
     composableAnimated<NavigationDestination.DeeplinkTimetableLectureDetail>(scheme) {
         DeeplinkTimetableLectureDetailRoute(
             onNavigateBack = { navController.popBackStack() },
@@ -249,6 +265,9 @@ internal fun NavGraphBuilder.buildRootNavGraph(
                         referrer = DetailScreenReferrer.Notification.encode(),
                     ),
                 )
+            },
+            onNavigateToSyllabus = { url ->
+                navController.navigate(NavigationDestination.Syllabus(url))
             },
         )
     }
@@ -264,6 +283,9 @@ internal fun NavGraphBuilder.buildRootNavGraph(
                         referrer = DetailScreenReferrer.Bookmark.encode(),
                     ),
                 )
+            },
+            onNavigateToSyllabus = { url ->
+                navController.navigate(NavigationDestination.Syllabus(url))
             },
         )
     }

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/GetCoursebooksOfficialResults.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/GetCoursebooksOfficialResults.kt
@@ -6,4 +6,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class GetCoursebooksOfficialResults(
     @param:Json(name = "url") val url: String,
+    @param:Json(name = "noProxyUrl") val noProxyUrl: String,
 )

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
@@ -1,7 +1,11 @@
 package com.wafflestudio.snutt2.ui.util
 
 import android.content.Context
+import android.content.Intent
 import android.widget.Toast
+import androidx.core.content.FileProvider
+import com.wafflestudio.snutt2.R
+import java.io.File
 
 fun Context.toast(message: String) {
     Toast.makeText(
@@ -9,4 +13,23 @@ fun Context.toast(message: String) {
         message,
         Toast.LENGTH_SHORT,
     ).show()
+}
+
+/**
+ * 앱이 내려받은 파일을 FileProvider content URI 로 감싸 외부 뷰어 앱(PDF 뷰어 등)으로 연다.
+ * 열 수 있는 앱이 없으면 false 를 반환한다.
+ */
+fun Context.openFileInViewer(file: File, mimeType: String?): Boolean {
+    val uri = FileProvider.getUriForFile(
+        this,
+        getString(R.string.file_provider_authorities),
+        file,
+    )
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(uri, mimeType ?: "*/*")
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        // applicationContext 에서 호출될 수 있으므로 새 태스크로 띄운다.
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    return runCatching { startActivity(intent) }.isSuccess
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -428,6 +428,10 @@
     <string name="theme_market_app_bar_title">Theme Market</string>
     <string name="theme_market_webview_error">Please check your network connection</string>
     <string name="theme_market_webview_error_retry">Retry</string>
+    <string name="syllabus_webview_error">Please check your network connection</string>
+    <string name="syllabus_webview_error_retry">Retry</string>
+    <string name="syllabus_download_started">Downloading the syllabus</string>
+    <string name="syllabus_download_open_failed">No app can open the downloaded file</string>
     <string name="common_copied_to_clipboard">Copied to clipboard.</string>
     <string name="firebase_messaging_service_channel_name">App Notifications</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -610,6 +610,10 @@
     <string name="theme_market_app_bar_title">테마 마켓</string>
     <string name="theme_market_webview_error">네트워크 연결을 확인해주세요</string>
     <string name="theme_market_webview_error_retry">다시 불러오기</string>
+    <string name="syllabus_webview_error">네트워크 연결을 확인해주세요</string>
+    <string name="syllabus_webview_error_retry">다시 불러오기</string>
+    <string name="syllabus_download_started">강의계획서를 다운로드합니다</string>
+    <string name="syllabus_download_open_failed">다운로드한 파일을 열 수 있는 앱이 없습니다</string>
     <string name="common_copied_to_clipboard">클립보드에 복사되었습니다.</string>
     <string name="firebase_messaging_service_channel_name">앱 알림</string>
 

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -3,4 +3,7 @@
     <cache-path
         name="shared_images"
         path="images/" />
+    <external-cache-path
+        name="syllabus_downloads"
+        path="syllabus/" />
 </paths>


### PR DESCRIPTION
## 배경

강의계획서를 지금까지 외부 브라우저(`ACTION_VIEW` Intent)로 열었는데, 이를 iOS와 동일하게 **인앱 바텀시트 WebView**로 전환합니다. iOS는 `noProxyUrl`을 Referer 헤더와 함께 WebView로 띄우고 있어, 링크·로딩 방식을 iOS에 맞췄습니다.

## 변경 사항

### 1. 여는 링크를 iOS와 동일하게 (`url` → `noProxyUrl`)
- `/v1/course_books/official` 응답에서 iOS가 쓰는 `noProxyUrl` 필드를 사용합니다.

### 2. 인앱 바텀시트 WebView (강의평과 동일 패턴)
- `sugang.snu.ac.kr`는 Referer를 검증하므로, iOS와 동일하게 WebView 로드에 `Referer` 헤더를 주입합니다. (외부 브라우저/Custom Tab으로는 Referer를 실을 수 없어 인앱 WebView가 유일한 방법)
- 강의계획서를 여는 **5개 진입점**(시간표 상세 / 딥링크 2종 / 북마크 / 검색)을 모두 바텀시트로 통일했습니다.

### 3. PDF 다운로드 (권한 0개)
- 강의계획서 페이지(HTML) 안의 PDF 등 첨부 파일은 **WebView 세션(Referer·쿠키·UA)째** `DownloadManager`로 다운로드합니다.
- 앱 전용 외부 캐시에 저장 → 저장소 권한 불필요 + 시스템 자동 정리(iOS `tmp`와 동일 성격) → 완료 시 뷰어 앱 자동 실행.
- 같은 파일명은 덮어써서 중복 누적을 방지합니다.

## 아키텍처 결정

WebView 다운로드는 "우리 서버에서 도메인 데이터를 받는 것"이 아니라 **"WebView 브라우징 세션의 연속"**입니다. 쿠키·Referer·UA는 전부 WebView가 만든 세션의 산물이므로, sugang과 접촉하는 특수 코드(Referer 상수, 세션 헤더, 다운로드)를 **WebView 컨테이너 안에 격리**했습니다.

- `noProxyUrl` 획득(SNUTT API 호출)만 Repository(data)에 남김
- WebView 로드·다운로드는 `SyllabusWebViewContainer`(View)에서 완결
- ViewModel/Repository는 HTTP 전송 디테일을 전혀 모름

## 커밋 구성

1. 강의계획서 URL을 iOS와 동일한 `noProxyUrl`로 변경
2. 강의계획서 인앱 WebView 바텀시트 및 PDF 다운로드 추가
3. 강의계획서 열기를 외부 브라우저에서 인앱 바텀시트로 전환

## 실기기 검증 필요

- [ ] HTML 강의계획서가 바텀시트에 정상 렌더되는지 (Referer 적용 확인)
- [ ] 페이지 내 PDF 링크 클릭 시 다운로드 트리거 → 캐시 저장 → 뷰어 자동 실행
- [ ] 한글 파일명이 깨지지 않는지 (서버가 percent-encoding으로 주는 경우)
