### PR TITLE
release: 3.12.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
             versionName = propertyVersionName
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "APK"
-                testers = "urban"
+                groups = "android-user"
                 serviceCredentialsFile = "gcp-service-account-dev.json"
                 appId = System.getenv("FIREBASE_APP_ID")
             }
@@ -107,6 +107,7 @@ android {
             versionName = propertyVersionName
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "AAB"
+                groups = "android-user"
                 serviceCredentialsFile = "gcp-service-account-live.json"
                 appId = System.getenv("FIREBASE_APP_ID")
             }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
             versionName = propertyVersionName
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "APK"
-                groups = "android-user"
+                groups = "android-users"
                 serviceCredentialsFile = "gcp-service-account-dev.json"
                 appId = System.getenv("FIREBASE_APP_ID")
             }

--- a/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2
 
 import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -25,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowInsetsControllerCompat
@@ -66,6 +68,9 @@ class RootActivity : AppCompatActivity() {
     @Inject
     lateinit var analyticsLogger: AnalyticsLogger
 
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         var isLoading = true
@@ -94,7 +99,9 @@ class RootActivity : AppCompatActivity() {
             },
         )
         setWindowAppearance()
-        checkNotificationPermission()
+        if (savedInstanceState == null) {
+            checkNotificationPermission()
+        }
         startUpdatingPushToken()
     }
 
@@ -182,10 +189,11 @@ class RootActivity : AppCompatActivity() {
 
     // 안드 13 대응
     private fun checkNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val requestPermissionLauncher =
-                registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
-            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.ui.util
 
 import android.content.Context
 import android.content.Intent
+import android.webkit.MimeTypeMap
 import android.widget.Toast
 import androidx.core.content.FileProvider
 import com.wafflestudio.snutt2.R
@@ -26,10 +27,25 @@ fun Context.openFileInViewer(file: File, mimeType: String?): Boolean {
         file,
     )
     val intent = Intent(Intent.ACTION_VIEW).apply {
-        setDataAndType(uri, mimeType ?: "*/*")
+        setDataAndType(uri, resolveViewableMimeType(file, mimeType))
         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         // applicationContext 에서 호출될 수 있으므로 새 태스크로 띄운다.
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
     return runCatching { startActivity(intent) }.isSuccess
+}
+
+/**
+ * 뷰어 앱 매칭을 위한 mime type 을 결정한다.
+ * 서버가 준 mime type 은 종종 부정확(application/octet-stream 등)해서 PDF 뷰어가 매칭되지 않으므로,
+ * 파일 확장자로 도출한 값을 우선한다.
+ */
+private fun resolveViewableMimeType(file: File, mimeType: String?): String {
+    val fromExtension = MimeTypeMap.getSingleton()
+        .getMimeTypeFromExtension(file.extension.lowercase())
+    if (fromExtension != null) return fromExtension
+
+    return mimeType
+        ?.takeUnless { it.isBlank() || it == "application/octet-stream" }
+        ?: "*/*"
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.12.3-rc.1
+snuttVersionName=3.12.3-rc.2

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.12.3-rc.2
+snuttVersionName=3.12.3-rc.3

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.12.2
+snuttVersionName=3.12.3-rc.1


### PR DESCRIPTION
## Summary

3.12.2 이후 develop에 반영된 기능 개선과 문구 수정을 모은 릴리즈입니다.

이 PR은 `3.12.3-rc.1` 버전 커밋(`version.properties`)을 포함합니다.

### 기능 / 개선

- **강의계획서를 외부 브라우저에서 인앱 바텀시트 WebView로 전환** (#630)
- **강의 상세 및 검색 입력 동작 개선** (#629)
- **앱별 언어 설정(시스템) 노출** (#628)

### 문구

- **검색 꿀팁 영어 문구 변경** (#627)

### 포함 PR

#627, #628, #629, #630

## 버전

`snuttVersionName`: `3.12.2` → `3.12.3-rc.1`
