### PR TITLE
fix: 알림 권한 요청 relaunch 크래시 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2
 
 import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -25,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowInsetsControllerCompat
@@ -66,6 +68,9 @@ class RootActivity : AppCompatActivity() {
     @Inject
     lateinit var analyticsLogger: AnalyticsLogger
 
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         var isLoading = true
@@ -94,7 +99,9 @@ class RootActivity : AppCompatActivity() {
             },
         )
         setWindowAppearance()
-        checkNotificationPermission()
+        if (savedInstanceState == null) {
+            checkNotificationPermission()
+        }
         startUpdatingPushToken()
     }
 
@@ -182,10 +189,11 @@ class RootActivity : AppCompatActivity() {
 
     // 안드 13 대응
     private fun checkNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val requestPermissionLauncher =
-                registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
-            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 


### PR DESCRIPTION
## 문제

`RootActivity.onCreate` 에서 알림 권한 요청을 동기적으로 띄우다가, 액티비티 **relaunch(재생성) 도중** system_server 측 NPE 로 크래시가 발생합니다.

```
onCreate → checkNotificationPermission → launcher.launch()
  → startActivityForResult → execStartActivity
  → RemoteException (system_server NPE)
      at com.android.server.wm.ActivityMetricsLogger.notifyActivityLaunched
```

- 크래시 최상단이 `handleRelaunchActivity` → 최초 실행이 아니라 relaunch 중 onCreate 에서 발생.
- 실제 NPE 발생처가 앱이 아니라 system_server 의 `ActivityMetricsLogger.notifyActivityLaunched` → 특정 Android 14/15 단말의 플랫폼 버그로, 불안정한 상태(relaunch 중 onCreate)에서 권한 다이얼로그를 동기적으로 띄울 때 표면화됩니다.

## 수정

앱 코드가 이 경로를 밟지 않도록 세 가지를 적용했습니다.

1. `registerForActivityResult` 를 메서드 내부가 아닌 **필드로 무조건 등록** (AndroidX 권장 계약 준수).
2. `checkSelfPermission` **가드 추가** — 이미 허용된 경우 재요청하지 않아 대다수 케이스에서 launch 경로 자체를 회피.
3. `savedInstanceState == null` **일 때만 요청** — relaunch 중 재요청을 차단해 크래시의 핵심 조건을 제거.

## 동작 변경

- 기존: 앱을 켤 때마다(모든 onCreate/relaunch/config change 포함) 권한을 재요청.
- 변경: 세션당 최초 생성 시 1회, 그리고 아직 미허용일 때만 요청.

## 검증

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` 통과.