### PR TITLE
chore: targetSdk 37 상향 · 배포 그룹 설정 · 알림 권한 relaunch 크래시 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
             versionName = propertyVersionName
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "APK"
-                testers = "urban"
+                groups = "android-users"
                 serviceCredentialsFile = "gcp-service-account-dev.json"
                 appId = System.getenv("FIREBASE_APP_ID")
             }
@@ -107,6 +107,7 @@ android {
             versionName = propertyVersionName
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "AAB"
+                groups = "android-user"
                 serviceCredentialsFile = "gcp-service-account-live.json"
                 appId = System.getenv("FIREBASE_APP_ID")
             }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,12 +34,12 @@ val versionProps =
 
 android {
     namespace = "com.wafflestudio.snutt2"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.wafflestudio.snutt2"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
     }
 
     androidResources {

--- a/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snutt2
 
 import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -25,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowInsetsControllerCompat
@@ -66,6 +68,9 @@ class RootActivity : AppCompatActivity() {
     @Inject
     lateinit var analyticsLogger: AnalyticsLogger
 
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         var isLoading = true
@@ -94,7 +99,9 @@ class RootActivity : AppCompatActivity() {
             },
         )
         setWindowAppearance()
-        checkNotificationPermission()
+        if (savedInstanceState == null) {
+            checkNotificationPermission()
+        }
         startUpdatingPushToken()
     }
 
@@ -182,10 +189,11 @@ class RootActivity : AppCompatActivity() {
 
     // 안드 13 대응
     private fun checkNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val requestPermissionLauncher =
-                registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
-            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 


### PR DESCRIPTION
## 개요

유지보수성 변경 3건을 묶어 반영합니다.

## 변경 사항

### 1. targetSdk / compileSdk 37 상향 (Android 17)
- `compileSdk 36 → 37`, `targetSdk 36 → 37`
- targetSdk 37 동작 변경 중 코드 수정이 강제되는 항목은 없음 (검토 결과 아래 참조).

### 2. App Distribution 배포 그룹 설정
- dev: `testers = "urban"` → `groups = "android-users"`
- live: `groups = "android-user"` 추가
- 업로드 시 지정 그룹으로 자동 배포되도록 정리.

### 3. 알림 권한 relaunch 크래시 수정
- `checkNotificationPermission()`의 `registerForActivityResult` 등록을 `onCreate` 실행 흐름 밖(멤버 프로퍼티)으로 이동. Activity 재생성(relaunch) 시 `onCreate` 이후 launcher 등록으로 발생하던 `LifecycleOwner ... is attempting to register while current state is RESUMED` 크래시 대응.
- `savedInstanceState == null` 일 때만 권한 요청하도록 하여 재생성 시 중복 요청 방지.
- 요청 전 `checkSelfPermission`으로 이미 허용된 경우 재요청하지 않도록 가드 추가.

## SDK 37 영향 검토

targetSdk 37에서 코드 대응이 필요한 항목은 없음. 주요 확인 결과:
- **방향/리사이즈 잠금 무시(sw>600dp 큰 화면)**: `RootActivity`의 `screenOrientation="portrait"`가 큰 화면에서 무시됨. 단 이 동작은 targetSdk 36(Android 16)부터 이미 적용되던 것이고(당시 opt-out property 미사용), 37은 opt-out 수단만 제거. 폰 타깃 기준 실질 변화 없음. 태블릿/폴더블 어댑티브 대응은 별도 과제.
- SMS OTP / Keystore 키 제한 / 백그라운드 오디오 하드닝 / MessageQueue / cross-profile loopback / LOCAL_NETWORK 권한: 모두 해당 사용처 없음.
- (후속 참고) `ScreenshotUtil`의 `ACTION_SEND` 공유는 Android 18(targetSdk 38)의 암묵적 URI 권한 부여 제거에 대비해 `FLAG_GRANT_READ_URI_PERMISSION` 추가가 권장됨. 현재 37에서는 영향 없어 본 PR 범위 외.

## 확인
- [ ] `ktlintFormat` / `compileDevDebugUnitTestKotlin` / `compileDevDebugScreenshotTestKotlin`
