### PR TITLE
feat: 강의계획서를 외부 브라우저에서 Chrome Custom Tab으로 전환

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,6 +198,7 @@ dependencies {
 
     // UI & Misc
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.browser)
     implementation(libs.facebook.login)
     implementation(libs.timber)
     implementation(libs.androidx.core.splashscreen)

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/bookmark/BookmarkPage.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.bookmark
 
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
@@ -40,6 +38,7 @@ import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.isDarkMode
+import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 import kotlinx.coroutines.launch
 
@@ -83,7 +82,7 @@ fun BookmarkRoute(
                 }
 
                 is BookmarkUiEvent.OpenUrl -> {
-                    context.startActivity(Intent(Intent.ACTION_VIEW, event.url.toUri()))
+                    context.openCustomTab(event.url)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/bookmark/BookmarkPage.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -53,6 +54,7 @@ fun BookmarkRoute(
     val scope = rememberCoroutineScope()
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isDarkMode by rememberUpdatedState(isDarkMode())
 
     val sheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
@@ -82,7 +84,7 @@ fun BookmarkRoute(
                 }
 
                 is BookmarkUiEvent.OpenUrl -> {
-                    context.openCustomTab(event.url)
+                    context.openCustomTab(event.url, isDarkMode)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/currenttable/CurrentTableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/currenttable/CurrentTableLectureDetailRoute.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.snutt2.feature.lecturedetail.currenttable
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ModalBottomSheetValue
@@ -15,7 +14,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.R
@@ -32,6 +30,7 @@ import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarDura
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarHostState
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.SnackBarScaffold
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.dismiss
+import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -122,8 +121,7 @@ fun CurrentTableLectureDetailRoute(
                 }
 
                 is CurrentTableLectureDetailUiEvent.OpenUrl -> {
-                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    context.startActivity(intent)
+                    context.openCustomTab(event.url)
                 }
 
                 is CurrentTableLectureDetailUiEvent.OpenBottomSheet -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/currenttable/CurrentTableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/currenttable/CurrentTableLectureDetailRoute.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -30,6 +31,7 @@ import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarDura
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarHostState
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.SnackBarScaffold
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.dismiss
+import com.wafflestudio.snutt2.ui.theme.isDarkMode
 import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 import dev.chrisbanes.haze.hazeSource
@@ -51,6 +53,7 @@ fun CurrentTableLectureDetailRoute(
     val scope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
+    val isDarkMode by rememberUpdatedState(isDarkMode())
 
     LaunchedEffect(Unit) {
         colorSelectorSavedStateHandle
@@ -121,7 +124,7 @@ fun CurrentTableLectureDetailRoute(
                 }
 
                 is CurrentTableLectureDetailUiEvent.OpenUrl -> {
-                    context.openCustomTab(event.url)
+                    context.openCustomTab(event.url, isDarkMode)
                 }
 
                 is CurrentTableLectureDetailUiEvent.OpenBottomSheet -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -22,6 +23,7 @@ import com.wafflestudio.snutt2.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
+import com.wafflestudio.snutt2.ui.theme.isDarkMode
 import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 
@@ -33,6 +35,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
 ) {
     val context = LocalContext.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
+    val isDarkMode by rememberUpdatedState(isDarkMode())
 
     LaunchedEffect(Unit) {
         vm.uiEvent.collect { event ->
@@ -47,7 +50,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
                 }
 
                 is DeeplinkBookmarkLectureDetailUiEvent.OpenUrl -> {
-                    context.openCustomTab(event.url)
+                    context.openCustomTab(event.url, isDarkMode)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkBookmarkLectureDetailRoute.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.lecturedetail.deeplink
 
-import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.domain.model.BuiltInTheme
@@ -24,6 +22,7 @@ import com.wafflestudio.snutt2.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
+import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 
 @Composable
@@ -48,8 +47,7 @@ fun DeeplinkBookmarkLectureDetailRoute(
                 }
 
                 is DeeplinkBookmarkLectureDetailUiEvent.OpenUrl -> {
-                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    context.startActivity(intent)
+                    context.openCustomTab(event.url)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.lecturedetail.deeplink
 
-import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wafflestudio.snutt2.domain.model.BuiltInTheme
@@ -25,6 +23,7 @@ import com.wafflestudio.snutt2.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
+import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 
 @Composable
@@ -51,8 +50,7 @@ fun DeeplinkTimetableLectureDetailRoute(
                 }
 
                 is DeeplinkTimetableLectureDetailUiEvent.OpenUrl -> {
-                    val intent = Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    context.startActivity(intent)
+                    context.openCustomTab(event.url)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/lecturedetail/deeplink/DeeplinkTimetableLectureDetailRoute.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -23,6 +24,7 @@ import com.wafflestudio.snutt2.logging.DetailScreenReferrer
 import com.wafflestudio.snutt2.logging.LectureDetailParameter
 import com.wafflestudio.snutt2.logging.compose.logImpression
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
+import com.wafflestudio.snutt2.ui.theme.isDarkMode
 import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 
@@ -35,6 +37,7 @@ fun DeeplinkTimetableLectureDetailRoute(
 ) {
     val context = LocalContext.current
     val uiState by vm.uiState.collectAsStateWithLifecycle()
+    val isDarkMode by rememberUpdatedState(isDarkMode())
 
     LaunchedEffect(Unit) {
         vm.uiEvent.collect { event ->
@@ -50,7 +53,7 @@ fun DeeplinkTimetableLectureDetailRoute(
                 }
 
                 is DeeplinkTimetableLectureDetailUiEvent.OpenUrl -> {
-                    context.openCustomTab(event.url)
+                    context.openCustomTab(event.url, isDarkMode)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.snutt2.feature.search
 
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -31,6 +29,7 @@ import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarDura
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarHostState
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.SnackBarScaffold
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.dismiss
+import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -90,7 +89,7 @@ fun SearchRoute(
                 }
 
                 is SearchUiEvent.OpenUrl -> {
-                    context.startActivity(Intent(Intent.ACTION_VIEW, uiEvent.url.toUri()))
+                    context.openCustomTab(uiEvent.url)
                 }
 
                 is SearchUiEvent.ShowSnackBar -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchRoute.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -29,6 +30,7 @@ import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarDura
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.CustomSnackBarHostState
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.SnackBarScaffold
 import com.wafflestudio.snutt2.ui.components.compose.snackbar.dismiss
+import com.wafflestudio.snutt2.ui.theme.isDarkMode
 import com.wafflestudio.snutt2.ui.util.openCustomTab
 import com.wafflestudio.snutt2.ui.util.toast
 import dev.chrisbanes.haze.hazeSource
@@ -50,6 +52,7 @@ fun SearchRoute(
     val vacancyFirstAddActionLabel = stringResource(R.string.vacancy_first_add_snackbar_action_label)
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isDarkMode by rememberUpdatedState(isDarkMode())
     val queryResults = viewModel.queryResults.collectAsLazyPagingItems()
 
     val sheetState = rememberModalBottomSheetState(
@@ -89,7 +92,7 @@ fun SearchRoute(
                 }
 
                 is SearchUiEvent.OpenUrl -> {
-                    context.openCustomTab(uiEvent.url)
+                    context.openCustomTab(uiEvent.url, isDarkMode)
                 }
 
                 is SearchUiEvent.ShowSnackBar -> {

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
@@ -1,7 +1,10 @@
 package com.wafflestudio.snutt2.ui.util
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.widget.Toast
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 
 fun Context.toast(message: String) {
     Toast.makeText(
@@ -9,4 +12,22 @@ fun Context.toast(message: String) {
         message,
         Toast.LENGTH_SHORT,
     ).show()
+}
+
+/**
+ * Chrome Custom Tab 으로 [url] 을 연다.
+ *
+ * Custom Tab 을 지원하는 브라우저가 있으면 인앱 형태의 Custom Tab 으로 열리고,
+ * 없으면 CustomTabsIntent 내부의 ACTION_VIEW 로 일반 브라우저에 폴백된다.
+ * 처리할 수 있는 브라우저가 전혀 없는 경우엔 조용히 무시한다.
+ */
+fun Context.openCustomTab(url: String) {
+    val customTabsIntent = CustomTabsIntent.Builder()
+        .setShowTitle(true)
+        .build()
+    try {
+        customTabsIntent.launchUrl(this, url.toUri())
+    } catch (e: ActivityNotFoundException) {
+        // 처리 가능한 브라우저가 없는 경우 무시한다.
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
@@ -17,13 +17,23 @@ fun Context.toast(message: String) {
 /**
  * Chrome Custom Tab 으로 [url] 을 연다.
  *
+ * [darkMode] 로 Custom Tab 툴바의 라이트/다크 색상을 결정한다. 앱은 OS 설정보다
+ * 우선하는 자체 테마 설정을 가지므로, 호출부에서 앱 테마 기준값(`isDarkMode()`)을
+ * 넘겨 Custom Tab 이 앱 설정과 일치하도록 한다.
+ *
  * Custom Tab 을 지원하는 브라우저가 있으면 인앱 형태의 Custom Tab 으로 열리고,
  * 없으면 CustomTabsIntent 내부의 ACTION_VIEW 로 일반 브라우저에 폴백된다.
  * 처리할 수 있는 브라우저가 전혀 없는 경우엔 조용히 무시한다.
  */
-fun Context.openCustomTab(url: String) {
+fun Context.openCustomTab(url: String, darkMode: Boolean) {
+    val colorScheme = if (darkMode) {
+        CustomTabsIntent.COLOR_SCHEME_DARK
+    } else {
+        CustomTabsIntent.COLOR_SCHEME_LIGHT
+    }
     val customTabsIntent = CustomTabsIntent.Builder()
         .setShowTitle(true)
+        .setColorScheme(colorScheme)
         .build()
     try {
         customTabsIntent.launchUrl(this, url.toUri())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ naverMapCompose = "1.9.0"
 
 # Misc
 androidxCore = "1.18.0"
+androidxBrowser = "1.8.0"
 material = "1.14.0"
 timber = "5.0.1"
 gson = "2.14.0"
@@ -66,6 +67,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 
 # Android Core
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "androidxBrowser" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splashscreen" }
 


### PR DESCRIPTION
## 개요

강의계획서(syllabus)를 열 때 외부 브라우저(`Intent.ACTION_VIEW` + `startActivity`)로 앱을 벗어나던 동작을, 앱 위에 겹쳐 뜨는 **Chrome Custom Tab** 으로 전환합니다.

## 변경 사항

- `androidx.browser` 의존성 추가 (`libs.versions.toml`, `app/build.gradle.kts`)
- `ui/util/ContextExt.kt` 에 공통 헬퍼 `Context.openCustomTab(url, darkMode)` 추가
  - `CustomTabsIntent` 로 Custom Tab 을 띄우며, `setShowTitle(true)` 로 페이지 제목 노출
  - `setColorScheme` 으로 툴바 라이트/다크 색상을 지정 (아래 "테마" 참고)
  - Custom Tab 미지원 브라우저 환경에서는 `CustomTabsIntent` 내부의 `ACTION_VIEW` 로 일반 브라우저에 자동 폴백
  - 처리 가능한 브라우저가 전혀 없는 경우 `ActivityNotFoundException` 을 잡아 조용히 무시 (기존 미가드 대비 안전)
- 강의계획서를 여는 `OpenUrl` 이벤트를 처리하는 5개 Route 를 `openCustomTab` 사용으로 교체
  - `CurrentTableLectureDetailRoute` (강의 상세)
  - `DeeplinkBookmarkLectureDetailRoute` (딥링크 - 북마크)
  - `DeeplinkTimetableLectureDetailRoute` (딥링크 - 시간표)
  - `SearchRoute` (검색)
  - `BookmarkPage` (북마크 목록)
  - 각 Route 에서 불필요해진 `android.content.Intent`, `androidx.core.net.toUri` import 정리

> 위 5개 ViewModel 의 `OpenUrl` 이벤트는 모두 `openSyllabus`(강의계획서) 경로에서만 emit 되므로, 이 변경은 강의계획서 열람에만 영향을 줍니다. 홈 팝업 링크 등 다른 `ACTION_VIEW` 사용처는 이번 범위에서 제외했습니다.

## 테마

앱은 OS 다크모드보다 **우선하는 자체 테마 설정**(`ThemeMode` / `LocalThemeState`)을 가집니다. Custom Tab 은 color scheme 미지정 시 `COLOR_SCHEME_SYSTEM`(OS 기준)을 따르므로 앱 설정과 어긋날 수 있어, 앱 테마 기준값 `isDarkMode()` 를 `setColorScheme(COLOR_SCHEME_DARK / LIGHT)` 으로 명시 지정합니다.

- 각 Route 는 Composable 이므로 `isDarkMode()` 로 앱 테마를 읽고, `OpenUrl` 을 소비하는 `LaunchedEffect` collect 콜백이 **stale 값을 캡처하지 않도록** `rememberUpdatedState` 로 감싸 최신값을 전달합니다.

## 참고

- `CustomTabsIntent.launchUrl` 은 내부적으로 `ACTION_VIEW` 인텐트로 `startActivity` 를 호출하므로(기존과 동일한 인텐트 해석 경로), Android 11+ package visibility 를 위한 `<queries>` 매니페스트 추가는 필요하지 않습니다. (service 바인딩/warmup 미사용)
- 툴바 배경을 SNUTT 브랜드 색상으로 커스터마이즈(`CustomTabColorSchemeParams`)하는 것은 이번 범위에서 제외했습니다. (라이트/다크 판정만 앱 설정에 맞춤)

## 검증

- `./gradlew ktlintFormat compileDevDebugUnitTestKotlin compileDevDebugScreenshotTestKotlin` → BUILD SUCCESSFUL
- 실기기에서의 Custom Tab 동작(테마별 툴바 색상 등)은 정적 검증만 거쳤으므로 병합 전 확인 권장
