### PR TITLE
feat: 서버 응답 언어를 앱 설정과 연동

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/data/applanguage/AppLanguageDataSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/applanguage/AppLanguageDataSource.kt
@@ -1,0 +1,39 @@
+package com.wafflestudio.snutt2.data.applanguage
+
+import android.content.ComponentCallbacks
+import android.content.Context
+import android.content.res.Configuration
+import com.wafflestudio.snutt2.domain.model.AppLanguage
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppLanguageDataSource @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : ComponentCallbacks {
+
+    private val _appLanguage = MutableStateFlow(context.resources.configuration.toAppLanguage())
+    val appLanguage: StateFlow<AppLanguage> = _appLanguage.asStateFlow()
+
+    init {
+        context.registerComponentCallbacks(this)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        _appLanguage.value = newConfig.toAppLanguage()
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onLowMemory() = Unit
+
+    private fun Configuration.toAppLanguage(): AppLanguage = if (locales[0].language == Locale.KOREAN.language) {
+        AppLanguage.KOREAN
+    } else {
+        AppLanguage.ENGLISH
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/data/applanguage/AppLanguageRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/applanguage/AppLanguageRepository.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.snutt2.data.applanguage
+
+import com.wafflestudio.snutt2.domain.model.AppLanguage
+import kotlinx.coroutines.flow.StateFlow
+
+interface AppLanguageRepository {
+    val appLanguage: StateFlow<AppLanguage>
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/data/applanguage/AppLanguageRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/applanguage/AppLanguageRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.snutt2.data.applanguage
+
+import com.wafflestudio.snutt2.domain.model.AppLanguage
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppLanguageRepositoryImpl @Inject constructor(
+    appLanguageDataSource: AppLanguageDataSource,
+) : AppLanguageRepository {
+    override val appLanguage: StateFlow<AppLanguage> = appLanguageDataSource.appLanguage
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
@@ -71,10 +71,16 @@ class LectureSearchPagingSource(
 
     private fun List<SearchTag>.extractTagString(type: TagType): List<String> = filterIsInstance<SearchTag.Regular>().filter { it.type == type }.map { it.name }
 
-    // FIXME: 서버 인터페이스 수정 필요, 클라단에서 불필요한 컨버팅으로 보임
-    private fun String.toCreditNumber(): Long = substring(0, length - 2).toLong()
-
     companion object {
         const val LECTURE_SEARCH_STARTING_PAGE_INDEX: Long = 0
     }
 }
+
+// FIXME: 서버 인터페이스 수정 필요, 클라단에서 불필요한 컨버팅으로 보임
+internal fun String.toCreditNumber(): Long =
+    Regex("^\\s*(\\d+)")
+        .find(this)
+        ?.groupValues
+        ?.get(1)
+        ?.toLongOrNull()
+        ?: throw IllegalArgumentException("Invalid credit tag: $this")

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchPagingSource.kt
@@ -77,10 +77,9 @@ class LectureSearchPagingSource(
 }
 
 // FIXME: 서버 인터페이스 수정 필요, 클라단에서 불필요한 컨버팅으로 보임
-internal fun String.toCreditNumber(): Long =
-    Regex("^\\s*(\\d+)")
-        .find(this)
-        ?.groupValues
-        ?.get(1)
-        ?.toLongOrNull()
-        ?: throw IllegalArgumentException("Invalid credit tag: $this")
+internal fun String.toCreditNumber(): Long = Regex("^\\s*(\\d+)")
+    .find(this)
+    ?.groupValues
+    ?.get(1)
+    ?.toLongOrNull()
+    ?: throw IllegalArgumentException("Invalid credit tag: $this")

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepository.kt
@@ -19,7 +19,7 @@ interface LectureSearchRepository {
         timesToExclude: List<SearchTime>?,
     ): Flow<PagingData<SearchedLecture>>
 
-    suspend fun getSearchTags(courseBook: CourseBook): List<SearchTag>
+    fun getSearchTags(courseBook: CourseBook): Flow<List<SearchTag>>
 
     fun storeRecentSearchedDepartment(tag: SearchTag)
 

--- a/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/data/lecturesearch/LectureSearchRepositoryImpl.kt
@@ -4,6 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.wafflestudio.snutt2.data.applanguage.AppLanguageDataSource
 import com.wafflestudio.snutt2.data.mapper.toSearchedLecture
 import com.wafflestudio.snutt2.domain.model.CourseBook
 import com.wafflestudio.snutt2.domain.model.SearchTag
@@ -11,10 +12,15 @@ import com.wafflestudio.snutt2.domain.model.SearchTime
 import com.wafflestudio.snutt2.domain.model.SearchedLecture
 import com.wafflestudio.snutt2.domain.model.TagType
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
+import com.wafflestudio.snutt2.network.dto.GetTagListResults
 import com.wafflestudio.snutt2.storage.SNUTTStorage
 import com.wafflestudio.snutt2.storage.model.toDomainModel
 import com.wafflestudio.snutt2.storage.model.toLocalEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,6 +29,7 @@ import javax.inject.Singleton
 class LectureSearchRepositoryImpl @Inject constructor(
     private val api: SNUTTRestApi,
     private val storage: SNUTTStorage,
+    private val appLanguageDataSource: AppLanguageDataSource,
 ) : LectureSearchRepository {
 
     override val recentSearchedDepartmentTags: Flow<List<SearchTag>> =
@@ -54,19 +61,16 @@ class LectureSearchRepositoryImpl @Inject constructor(
         },
     ).flow.map { pagingData -> pagingData.map { it.toSearchedLecture() } }
 
-    override suspend fun getSearchTags(courseBook: CourseBook): List<SearchTag> {
-        val response = api._getTagList(courseBook.year.toInt(), courseBook.semester.toInt())
-        val list = mutableListOf<SearchTag>()
-        list.apply {
-            addAll(response.department.map { SearchTag.Regular(TagType.DEPARTMENT, it) })
-            addAll(response.classification.map { SearchTag.Regular(TagType.CLASSIFICATION, it) })
-            addAll(response.academicYear.map { SearchTag.Regular(TagType.ACADEMIC_YEAR, it) })
-            addAll(response.credit.map { SearchTag.Regular(TagType.CREDIT, it) })
-            addAll(response.category.map { SearchTag.Regular(TagType.CATEGORY, it) })
-            addAll(response.categoryPre2025.map { SearchTag.Regular(TagType.CATEGORY_PRE2025, it) })
-            addAll(response.sortCriteria.map { SearchTag.Regular(TagType.SORT_CRITERIA, it) })
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun getSearchTags(courseBook: CourseBook): Flow<List<SearchTag>> = appLanguageDataSource.appLanguage.flatMapLatest {
+        flow {
+            emit(
+                api._getTagList(courseBook.year.toInt(), courseBook.semester.toInt())
+                    .toSearchTags(),
+            )
+        }.catch {
+            emit(emptyList())
         }
-        return list
     }
 
     override fun storeRecentSearchedDepartment(tag: SearchTag) {
@@ -86,4 +90,14 @@ class LectureSearchRepositoryImpl @Inject constructor(
     companion object {
         const val LECTURES_LOAD_PAGE_SIZE = 30
     }
+}
+
+private fun GetTagListResults.toSearchTags(): List<SearchTag> = buildList {
+    addAll(department.map { SearchTag.Regular(TagType.DEPARTMENT, it) })
+    addAll(classification.map { SearchTag.Regular(TagType.CLASSIFICATION, it) })
+    addAll(academicYear.map { SearchTag.Regular(TagType.ACADEMIC_YEAR, it) })
+    addAll(credit.map { SearchTag.Regular(TagType.CREDIT, it) })
+    addAll(category.map { SearchTag.Regular(TagType.CATEGORY, it) })
+    addAll(categoryPre2025.map { SearchTag.Regular(TagType.CATEGORY_PRE2025, it) })
+    addAll(sortCriteria.map { SearchTag.Regular(TagType.SORT_CRITERIA, it) })
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/NetworkModule.kt
@@ -13,6 +13,7 @@ import com.wafflestudio.snutt2.lib.android.DisplayMessageResolverImpl
 import com.wafflestudio.snutt2.lib.android.createNewNetworkLog
 import com.wafflestudio.snutt2.lib.serializer.Serializer
 import com.wafflestudio.snutt2.network.AuthInterceptor
+import com.wafflestudio.snutt2.network.LanguageInterceptor
 import com.wafflestudio.snutt2.network.api.SNUTTRestApi
 import com.wafflestudio.snutt2.network.error.ErrorParsingCallAdapterFactory
 import com.wafflestudio.snutt2.storage.SNUTTStorage
@@ -43,11 +44,13 @@ object NetworkModule {
         @ApplicationContext context: Context,
         snuttStorage: SNUTTStorage,
         authInterceptor: AuthInterceptor,
+        languageInterceptor: LanguageInterceptor,
     ): OkHttpClient {
         val cache = Cache(File(context.cacheDir, "http"), SIZE_OF_CACHE)
         return OkHttpClient.Builder()
             .cache(cache)
             .addInterceptor(authInterceptor)
+            .addInterceptor(languageInterceptor)
             .addInterceptor { chain ->
                 val newRequest = chain.request().newBuilder()
                     .addHeader(

--- a/app/src/main/java/com/wafflestudio/snutt2/di/RepositoryModule.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.snutt2.di
 
+import com.wafflestudio.snutt2.data.applanguage.AppLanguageRepository
+import com.wafflestudio.snutt2.data.applanguage.AppLanguageRepositoryImpl
 import com.wafflestudio.snutt2.data.bookmark.BookmarkRepository
 import com.wafflestudio.snutt2.data.bookmark.BookmarkRepositoryImpl
 import com.wafflestudio.snutt2.data.coursebooks.CourseBookRepository
@@ -40,6 +42,9 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 @Module
 abstract class RepositoryModule {
+
+    @Binds
+    abstract fun bindsAppLanguageRepository(impl: AppLanguageRepositoryImpl): AppLanguageRepository
 
     @Binds
     abstract fun bindsBookmarkRepository(impl: BookmarkRepositoryImpl): BookmarkRepository

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/model/AppLanguage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/model/AppLanguage.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.snutt2.domain.model
+
+enum class AppLanguage {
+    KOREAN,
+    ENGLISH,
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchViewModel.kt
@@ -201,13 +201,7 @@ class SearchViewModel @Inject constructor(
                     .filterNotNull()
                     .distinctUntilChanged { o, n -> o.summary.courseBook == n.summary.courseBook }
                     .flatMapLatest { table ->
-                        flow {
-                            try {
-                                emit(lectureSearchRepository.getSearchTags(table.summary.courseBook))
-                            } catch (_: Exception) {
-                                emit(emptyList())
-                            }
-                        }
+                        lectureSearchRepository.getSearchTags(table.summary.courseBook)
                     },
             ) { table, (trimParam, lectureCustom, compact), (recentDepts, theme), (vacancy, bookmarks, disableMap), searchTags ->
                 val prevState = _uiState.value
@@ -218,6 +212,9 @@ class SearchViewModel @Inject constructor(
                 val tagTypes = allTags.map { it.type }.toSet().toList()
 
                 _uiState.update { current ->
+                    val selectedTags = current.selectedTags.filter {
+                        it !is SearchTag.Regular || it in allTags
+                    }
                     val selectedTagType = if (tagTypes.contains(current.selectedTagType)) current.selectedTagType else TagType.SORT_CRITERIA
                     var next = current.copy(
                         courseBook = courseBook,
@@ -233,8 +230,9 @@ class SearchViewModel @Inject constructor(
                         tagTypes = tagTypes,
                         selectedTagType = selectedTagType,
                         allSearchTags = allTags,
-                        searchTags = buildSelectableTags(allTags, selectedTagType, current.selectedTags),
-                        recentSearchedDepartments = buildRecentDepts(recentDepts, allTags, current.selectedTags),
+                        selectedTags = selectedTags,
+                        searchTags = buildSelectableTags(allTags, selectedTagType, selectedTags),
+                        recentSearchedDepartments = buildRecentDepts(recentDepts, allTags, selectedTags),
                     )
                     if (courseBookChanged) {
                         next = next.copy(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/search/SearchViewModel.kt
@@ -213,7 +213,7 @@ class SearchViewModel @Inject constructor(
 
                 _uiState.update { current ->
                     val selectedTags = current.selectedTags.filter {
-                        it !is SearchTag.Regular || it in allTags
+                        it !is SearchTag.Regular || it in searchTags
                     }
                     val selectedTagType = if (tagTypes.contains(current.selectedTagType)) current.selectedTagType else TagType.SORT_CRITERIA
                     var next = current.copy(

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -24,6 +23,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.wafflestudio.snutt2.BuildConfig
 import com.wafflestudio.snutt2.R
 import com.wafflestudio.snutt2.config.FeatureFlag
+import com.wafflestudio.snutt2.domain.model.AppLanguage
 import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.logging.AnalyticsScreen
 import com.wafflestudio.snutt2.logging.compose.logImpression
@@ -35,7 +35,6 @@ import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
 import com.wafflestudio.snutt2.ui.util.openAppLanguageSettings
-import java.util.Locale
 
 @Composable
 fun SettingsRoute(
@@ -64,13 +63,6 @@ fun SettingsRoute(
 ) {
     val uiState by viewModel.settingsUiState.collectAsState()
     val context = LocalContext.current
-    val language = stringResource(
-        if (LocalConfiguration.current.locales[0].language == Locale.KOREAN.language) {
-            R.string.settings_language_korean
-        } else {
-            R.string.settings_language_english
-        },
-    )
 
     LaunchedEffect(Unit) {
         viewModel.logoutFinishedUiEvent.collect {
@@ -80,7 +72,6 @@ fun SettingsRoute(
 
     SettingsScreen(
         uiState = uiState,
-        language = language,
         bottomBar = bottomBar,
         uncheckedNotifications = uncheckedNotifications,
         onClickUserConfig = onNavigateUserConfig,
@@ -111,7 +102,6 @@ fun SettingsRoute(
 @Composable
 fun SettingsScreen(
     uiState: SettingsUiState,
-    language: String,
     bottomBar: @Composable () -> Unit = {},
     uncheckedNotifications: Long,
     onClickUserConfig: () -> Unit,
@@ -226,7 +216,12 @@ fun SettingsScreen(
                     onClick = onClickLanguage,
                 ) {
                     Text(
-                        text = language,
+                        text = stringResource(
+                            when (uiState.appLanguage) {
+                                AppLanguage.KOREAN -> R.string.settings_language_korean
+                                AppLanguage.ENGLISH -> R.string.settings_language_english
+                            },
+                        ),
                         style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
                     )
                 }
@@ -361,8 +356,7 @@ fun SettingsScreen(
 private fun SettingsScreen_Default() {
     SnuttPreviewSurface {
         SettingsScreen(
-            uiState = SettingsUiState("양주현", ThemeMode.DARK, false, listOf("빈자리 알림")),
-            language = "한국어",
+            uiState = SettingsUiState("양주현", ThemeMode.DARK, false, listOf("빈자리 알림"), AppLanguage.KOREAN),
             uncheckedNotifications = 0L,
             onClickUserConfig = {},
             onClickNotification = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -32,6 +33,7 @@ import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
+import java.util.Locale
 
 @Composable
 fun SettingsRoute(
@@ -59,6 +61,13 @@ fun SettingsRoute(
     onNavigateOnboardAsOrigin: () -> Unit,
 ) {
     val uiState by viewModel.settingsUiState.collectAsState()
+    val language = stringResource(
+        if (LocalConfiguration.current.locales[0].language == Locale.KOREAN.language) {
+            R.string.settings_language_korean
+        } else {
+            R.string.settings_language_english
+        },
+    )
 
     LaunchedEffect(Unit) {
         viewModel.logoutFinishedUiEvent.collect {
@@ -68,6 +77,7 @@ fun SettingsRoute(
 
     SettingsScreen(
         uiState = uiState,
+        language = language,
         bottomBar = bottomBar,
         uncheckedNotifications = uncheckedNotifications,
         onClickUserConfig = onNavigateUserConfig,
@@ -97,6 +107,7 @@ fun SettingsRoute(
 @Composable
 fun SettingsScreen(
     uiState: SettingsUiState,
+    language: String,
     bottomBar: @Composable () -> Unit = {},
     uncheckedNotifications: Long,
     onClickUserConfig: () -> Unit,
@@ -204,6 +215,16 @@ fun SettingsScreen(
                     settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
                     onClick = onClickThemeConfig,
                 )
+                SettingItem(
+                    title = stringResource(R.string.settings_language_title),
+                    hasNextPage = false,
+                    settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                ) {
+                    Text(
+                        text = language,
+                        style = SNUTTTypography.body1.copy(color = SNUTTColors.Black500),
+                    )
+                }
             }
             SettingColumn {
                 SettingItem(
@@ -336,6 +357,7 @@ private fun SettingsScreen_Default() {
     SnuttPreviewSurface {
         SettingsScreen(
             uiState = SettingsUiState("양주현", ThemeMode.DARK, false, listOf("빈자리 알림")),
+            language = "한국어",
             uncheckedNotifications = 0L,
             onClickUserConfig = {},
             onClickNotification = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsPage.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -33,6 +34,7 @@ import com.wafflestudio.snutt2.ui.preview.SnuttPreview
 import com.wafflestudio.snutt2.ui.preview.SnuttPreviewSurface
 import com.wafflestudio.snutt2.ui.theme.SNUTTColors
 import com.wafflestudio.snutt2.ui.theme.SNUTTTypography
+import com.wafflestudio.snutt2.ui.util.openAppLanguageSettings
 import java.util.Locale
 
 @Composable
@@ -61,6 +63,7 @@ fun SettingsRoute(
     onNavigateOnboardAsOrigin: () -> Unit,
 ) {
     val uiState by viewModel.settingsUiState.collectAsState()
+    val context = LocalContext.current
     val language = stringResource(
         if (LocalConfiguration.current.locales[0].language == Locale.KOREAN.language) {
             R.string.settings_language_korean
@@ -85,6 +88,7 @@ fun SettingsRoute(
         onClickThemeModeSelect = onNavigateThemeModeSelect,
         onClickTimeTableConfig = onNavigateTimeTableConfig,
         onClickThemeConfig = onNavigateThemeConfig,
+        onClickLanguage = context::openAppLanguageSettings,
         onClickVacancyNotification = onNavigateVacancyNotification,
         onClickThemeMarket = onNavigateThemeMarket,
         onClickPushPreference = onNavigatePushPreference,
@@ -115,6 +119,7 @@ fun SettingsScreen(
     onClickThemeModeSelect: () -> Unit,
     onClickTimeTableConfig: () -> Unit,
     onClickThemeConfig: () -> Unit,
+    onClickLanguage: () -> Unit,
     onClickVacancyNotification: () -> Unit,
     onClickThemeMarket: () -> Unit,
     onClickPushPreference: () -> Unit,
@@ -217,8 +222,8 @@ fun SettingsScreen(
                 )
                 SettingItem(
                     title = stringResource(R.string.settings_language_title),
-                    hasNextPage = false,
                     settingPageNewBadgeTitles = uiState.settingPageNewBadgeTitles,
+                    onClick = onClickLanguage,
                 ) {
                     Text(
                         text = language,
@@ -364,6 +369,7 @@ private fun SettingsScreen_Default() {
             onClickThemeModeSelect = {},
             onClickTimeTableConfig = {},
             onClickThemeConfig = {},
+            onClickLanguage = {},
             onClickVacancyNotification = {},
             onClickThemeMarket = {},
             onClickPushPreference = {},

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/SettingsViewModel.kt
@@ -4,9 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wafflestudio.snutt2.config.RemoteConfig
+import com.wafflestudio.snutt2.data.applanguage.AppLanguageRepository
 import com.wafflestudio.snutt2.data.onFailure
 import com.wafflestudio.snutt2.data.onSuccess
 import com.wafflestudio.snutt2.data.user.UserRepository
+import com.wafflestudio.snutt2.domain.model.AppLanguage
 import com.wafflestudio.snutt2.domain.model.ThemeMode
 import com.wafflestudio.snutt2.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.logging.AnalyticsLogger
@@ -23,6 +25,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
+    private val appLanguageRepository: AppLanguageRepository,
     private val userRepository: UserRepository,
     private val analyticsLogger: AnalyticsLogger,
     private val remoteConfig: RemoteConfig,
@@ -60,20 +63,22 @@ class SettingsViewModel @Inject constructor(
     }
 
     val settingsUiState = combine(
+        appLanguageRepository.appLanguage,
         userRepository.user,
         userRepository.themeMode,
         showLogoutDialog,
         remoteConfig.settingPageNewBadgeTitles,
-    ) { user, themeMode, showLogoutDialog, settingPageNewBadgeTitles ->
+    ) { appLanguage, user, themeMode, showLogoutDialog, settingPageNewBadgeTitles ->
         if (user == null) {
-            return@combine SettingsUiState.DEFAULT
+            return@combine SettingsUiState.DEFAULT.copy(appLanguage = appLanguage)
         }
 
         SettingsUiState(
-            user.nickname?.getDisplayName() ?: "",
-            themeMode,
-            showLogoutDialog,
-            settingPageNewBadgeTitles,
+            userName = user.nickname?.getDisplayName() ?: "",
+            themeMode = themeMode,
+            showLogoutDialog = showLogoutDialog,
+            settingPageNewBadgeTitles = settingPageNewBadgeTitles,
+            appLanguage = appLanguage,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, SettingsUiState.DEFAULT)
 }
@@ -83,8 +88,9 @@ data class SettingsUiState(
     val themeMode: ThemeMode,
     val showLogoutDialog: Boolean,
     val settingPageNewBadgeTitles: List<String>,
+    val appLanguage: AppLanguage,
 ) {
     companion object {
-        val DEFAULT = SettingsUiState("", ThemeMode.AUTO, false, emptyList())
+        val DEFAULT = SettingsUiState("", ThemeMode.AUTO, false, emptyList(), AppLanguage.KOREAN)
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/network/LanguageInterceptor.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/LanguageInterceptor.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.snutt2.network
+
+import android.content.Context
+import androidx.core.os.ConfigurationCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LanguageInterceptor @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val language = ConfigurationCompat.getLocales(context.resources.configuration)[0]?.language
+        val serverLanguage = if (language == Locale.ENGLISH.language) ENGLISH else KOREAN
+
+        val newRequest = chain.request().newBuilder()
+            .header(HEADER_NAME, serverLanguage)
+            .build()
+        return chain.proceed(newRequest)
+    }
+
+    companion object {
+        const val HEADER_NAME = "x-language"
+
+        private const val KOREAN = "ko"
+        private const val ENGLISH = "en"
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/network/LanguageInterceptor.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/LanguageInterceptor.kt
@@ -16,7 +16,7 @@ class LanguageInterceptor @Inject constructor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val language = ConfigurationCompat.getLocales(context.resources.configuration)[0]?.language
-        val serverLanguage = if (language == Locale.ENGLISH.language) ENGLISH else KOREAN
+        val serverLanguage = if (language == Locale.KOREAN.language) KOREAN else ENGLISH
 
         val newRequest = chain.request().newBuilder()
             .header(HEADER_NAME, serverLanguage)

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.widget.Toast
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 fun Context.toast(message: String) {
     Toast.makeText(
@@ -28,11 +29,13 @@ fun Context.openAppLanguageSettings() {
 
     try {
         startActivity(intent)
-    } catch (_: ActivityNotFoundException) {
+    } catch (e: ActivityNotFoundException) {
+        FirebaseCrashlytics.getInstance().recordException(e)
         if (intent !== appDetailsIntent) {
             try {
                 startActivity(appDetailsIntent)
-            } catch (_: ActivityNotFoundException) {
+            } catch (e: ActivityNotFoundException) {
+                FirebaseCrashlytics.getInstance().recordException(e)
                 // 처리 가능한 설정 화면이 없는 경우 무시한다.
             }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/ui/util/ContextExt.kt
@@ -2,6 +2,9 @@ package com.wafflestudio.snutt2.ui.util
 
 import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import android.widget.Toast
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
@@ -12,6 +15,28 @@ fun Context.toast(message: String) {
         message,
         Toast.LENGTH_SHORT,
     ).show()
+}
+
+fun Context.openAppLanguageSettings() {
+    val packageUri = "package:$packageName".toUri()
+    val appDetailsIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
+    val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Intent(Settings.ACTION_APP_LOCALE_SETTINGS, packageUri)
+    } else {
+        appDetailsIntent
+    }
+
+    try {
+        startActivity(intent)
+    } catch (_: ActivityNotFoundException) {
+        if (intent !== appDetailsIntent) {
+            try {
+                startActivity(appDetailsIntent)
+            } catch (_: ActivityNotFoundException) {
+                // 처리 가능한 설정 화면이 없는 경우 무시한다.
+            }
+        }
+    }
 }
 
 /**

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -226,6 +226,9 @@
     <string name="settings_service_info">Terms of Service</string>
     <string name="settings_version_info">Version Info</string>
     <string name="settings_team_info">Developer Info</string>
+    <string name="settings_language_title">Language</string>
+    <string name="settings_language_korean">Korean</string>
+    <string name="settings_language_english">English</string>
     <string name="settings_logout_title">Log Out</string>
     <string name="settings_logout_message">Are you sure you want to log out?</string>
     <string name="settings_timetable_config_force_fit">Auto-fit Timetable</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -407,6 +407,9 @@
     <string name="settings_service_info">서비스 약관</string>
     <string name="settings_version_info">버전 정보</string>
     <string name="settings_team_info">개발자 정보</string>
+    <string name="settings_language_title">언어</string>
+    <string name="settings_language_korean">한국어</string>
+    <string name="settings_language_english">영어</string>
     <string name="settings_logout_title">로그아웃</string>
     <string name="settings_logout_message">로그아웃 하시겠습니까?</string>
     <string name="settings_timetable_config_force_fit">시간표 자동 정렬</string>

--- a/app/src/test/java/com/wafflestudio/snutt2/data/lecturesearch/CreditTagParsingTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/data/lecturesearch/CreditTagParsingTest.kt
@@ -1,8 +1,8 @@
 package com.wafflestudio.snutt2.data.lecturesearch
 
+import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import org.junit.Test
 
 class CreditTagParsingTest {
 

--- a/app/src/test/java/com/wafflestudio/snutt2/data/lecturesearch/CreditTagParsingTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/data/lecturesearch/CreditTagParsingTest.kt
@@ -1,0 +1,32 @@
+package com.wafflestudio.snutt2.data.lecturesearch
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.Test
+
+class CreditTagParsingTest {
+
+    @Test
+    fun `한글과 영문 학점 태그에서 학점 수를 추출한다`() {
+        val fixtures = mapOf(
+            "1학점" to 1L,
+            "3학점" to 3L,
+            "3 credits" to 3L,
+            "3 Credits" to 3L,
+            "  6 credits" to 6L,
+        )
+
+        fixtures.forEach { (tag, expectedCredit) ->
+            assertEquals(expectedCredit, tag.toCreditNumber())
+        }
+    }
+
+    @Test
+    fun `숫자가 없는 학점 태그는 IllegalArgumentException을 던진다`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            "credits".toCreditNumber()
+        }
+
+        assertEquals("Invalid credit tag: credits", exception.message)
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/network/LanguageInterceptorTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/network/LanguageInterceptorTest.kt
@@ -28,9 +28,13 @@ class LanguageInterceptorTest {
     }
 
     @Test
-    fun `한국어와 미지원 앱 로케일이면 ko 헤더를 주입한다`() {
+    fun `한국어 앱 로케일이면 ko 헤더를 주입한다`() {
         assertEquals("ko", interceptRequest(locale = Locale.KOREAN).header(LanguageInterceptor.HEADER_NAME))
-        assertEquals("ko", interceptRequest(locale = Locale.JAPANESE).header(LanguageInterceptor.HEADER_NAME))
+    }
+
+    @Test
+    fun `미지원 앱 로케일이면 en 헤더를 주입한다`() {
+        assertEquals("en", interceptRequest(locale = Locale.JAPANESE).header(LanguageInterceptor.HEADER_NAME))
     }
 
     @Test

--- a/app/src/test/java/com/wafflestudio/snutt2/network/LanguageInterceptorTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/network/LanguageInterceptorTest.kt
@@ -1,0 +1,83 @@
+package com.wafflestudio.snutt2.network
+
+import android.content.Context
+import android.content.res.Configuration
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.Locale
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class LanguageInterceptorTest {
+
+    @Test
+    fun `영어 앱 로케일이면 en 헤더를 주입한다`() {
+        val request = interceptRequest(locale = Locale.ENGLISH)
+
+        assertEquals("en", request.header(LanguageInterceptor.HEADER_NAME))
+    }
+
+    @Test
+    fun `한국어와 미지원 앱 로케일이면 ko 헤더를 주입한다`() {
+        assertEquals("ko", interceptRequest(locale = Locale.KOREAN).header(LanguageInterceptor.HEADER_NAME))
+        assertEquals("ko", interceptRequest(locale = Locale.JAPANESE).header(LanguageInterceptor.HEADER_NAME))
+    }
+
+    @Test
+    fun `기존 x-language 헤더를 단일 현재 언어 값으로 교체한다`() {
+        val request = interceptRequest(
+            locale = Locale.ENGLISH,
+            originalRequest = Request.Builder()
+                .url("https://example.com")
+                .header(LanguageInterceptor.HEADER_NAME, "ko")
+                .build(),
+        )
+
+        assertEquals(listOf("en"), request.headers(LanguageInterceptor.HEADER_NAME))
+    }
+
+    private fun interceptRequest(
+        locale: Locale,
+        originalRequest: Request = Request.Builder().url("https://example.com").build(),
+    ): Request {
+        var interceptedRequest: Request? = null
+        OkHttpClient.Builder()
+            .addInterceptor(LanguageInterceptor(contextFor(locale)))
+            .addInterceptor(
+                Interceptor { chain ->
+                    interceptedRequest = chain.request()
+                    Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body("".toResponseBody())
+                        .build()
+                },
+            )
+            .build()
+            .newCall(originalRequest)
+            .execute()
+            .close()
+
+        return requireNotNull(interceptedRequest)
+    }
+
+    private fun contextFor(locale: Locale): Context {
+        val application = RuntimeEnvironment.getApplication()
+        val configuration = Configuration(application.resources.configuration).apply {
+            setLocale(locale)
+        }
+        return application.createConfigurationContext(configuration)
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 현재 앱 언어를 x-language 헤더로 SNUTT API 요청에 전달
- 한국어 외 로케일은 영어로 폴백
- 앱 설정에 현재 언어를 표시하고 시스템 앱 언어 설정으로 이동
- 앱 언어 변경 시 현재 학기의 검색 태그를 자동 재조회

## 검증
- ./gradlew ktlintCheck
- ./gradlew :app:compileDevDebugKotlin
- LanguageInterceptorTest