### PR TITLE
fix: 현재 시간표 준비 후 홈 진입

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/RootActivity.kt
@@ -36,7 +36,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.FirebaseApp
 import com.wafflestudio.snutt2.config.RemoteConfig
-import com.wafflestudio.snutt2.domain.RefreshInitialDataUseCase
+import com.wafflestudio.snutt2.domain.InitializeHomeUseCase
 import com.wafflestudio.snutt2.feature.home.HomeItem
 import com.wafflestudio.snutt2.feature.settings.RootViewModel
 import com.wafflestudio.snutt2.logging.AnalyticsLogger
@@ -60,7 +60,7 @@ class RootActivity : AppCompatActivity() {
     private val rootViewModel: RootViewModel by viewModels()
 
     @Inject
-    lateinit var refreshInitialDataUseCase: RefreshInitialDataUseCase
+    lateinit var initializeHomeUseCase: InitializeHomeUseCase
 
     @Inject
     lateinit var remoteConfig: RemoteConfig
@@ -84,20 +84,22 @@ class RootActivity : AppCompatActivity() {
 
         val token = rootViewModel.accessToken.value
 
-        lifecycleScope.launch {
-            if (token.isNotEmpty()) {
-                refreshInitialDataUseCase()
-            }
-            isLoading = false
-        }
         val initialDeeplinkTab = parseHomePageDeeplink()
-        setUpContents(
-            if (token.isEmpty()) {
+        lifecycleScope.launch {
+            val startDestination = if (token.isEmpty()) {
                 NavigationDestination.Onboard
             } else {
-                NavigationDestination.Home(initialTab = initialDeeplinkTab?.toTabString())
-            },
-        )
+                if (initializeHomeUseCase()) {
+                    NavigationDestination.Home(initialTab = initialDeeplinkTab?.toTabString())
+                } else {
+                    rootViewModel.performLogout()
+                    NavigationDestination.Onboard
+                }
+            }
+
+            setUpContents(startDestination)
+            isLoading = false
+        }
         setWindowAppearance()
         if (savedInstanceState == null) {
             checkNotificationPermission()

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/EnsureCurrentTableLoadedUseCase.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/EnsureCurrentTableLoadedUseCase.kt
@@ -1,0 +1,38 @@
+package com.wafflestudio.snutt2.domain
+
+import com.wafflestudio.snutt2.data.Result
+import com.wafflestudio.snutt2.data.tables.TableRepository
+import javax.inject.Inject
+
+class EnsureCurrentTableLoadedUseCase @Inject constructor(
+    private val tableRepository: TableRepository,
+) {
+    suspend operator fun invoke(): Result<Unit> {
+        var lastFailure: Result.Fail? = null
+
+        repeat(MAX_ATTEMPTS) {
+            when (val result = loadCurrentTable()) {
+                is Result.Success -> return result
+                is Result.Fail -> lastFailure = result
+            }
+        }
+
+        return checkNotNull(lastFailure)
+    }
+
+    private suspend fun loadCurrentTable(): Result<Unit> {
+        val lastViewedTableId = tableRepository.currentTable.value?.summary?.id
+        if (lastViewedTableId != null) {
+            when (val result = tableRepository.fetchAndSelectTable(lastViewedTableId)) {
+                is Result.Success -> return result
+                is Result.Fail -> Unit
+            }
+        }
+
+        return tableRepository.fetchAndSelectDefaultTable()
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 2
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/InitializeHomeUseCase.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/InitializeHomeUseCase.kt
@@ -2,8 +2,9 @@ package com.wafflestudio.snutt2.domain
 
 import com.wafflestudio.snutt2.data.Result
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 class InitializeHomeUseCase @Inject constructor(
@@ -14,12 +15,18 @@ class InitializeHomeUseCase @Inject constructor(
     suspend operator fun invoke(): Boolean {
         val refreshJob = externalScope.launch { refreshInitialDataUseCase() }
 
-        return when (ensureCurrentTableLoadedUseCase()) {
-            is Result.Success -> true
-            is Result.Fail -> {
-                refreshJob.cancelAndJoin()
-                false
-            }
+        val canEnterHome = withTimeoutOrNull(CURRENT_TABLE_LOADING_TIMEOUT_MILLIS) {
+            ensureCurrentTableLoadedUseCase() is Result.Success
+        } ?: false
+
+        if (!canEnterHome) {
+            refreshJob.cancel()
         }
+
+        return canEnterHome
+    }
+
+    private companion object {
+        const val CURRENT_TABLE_LOADING_TIMEOUT_MILLIS = 10_000L
     }
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/InitializeHomeUseCase.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/InitializeHomeUseCase.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.snutt2.domain
+
+import com.wafflestudio.snutt2.data.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class InitializeHomeUseCase @Inject constructor(
+    private val ensureCurrentTableLoadedUseCase: EnsureCurrentTableLoadedUseCase,
+    private val refreshInitialDataUseCase: RefreshInitialDataUseCase,
+    private val externalScope: CoroutineScope,
+) {
+    suspend operator fun invoke(): Boolean {
+        val refreshJob = externalScope.launch { refreshInitialDataUseCase() }
+
+        return when (ensureCurrentTableLoadedUseCase()) {
+            is Result.Success -> true
+            is Result.Fail -> {
+                refreshJob.cancelAndJoin()
+                false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snutt2/domain/RefreshInitialDataUseCase.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/domain/RefreshInitialDataUseCase.kt
@@ -1,8 +1,6 @@
 package com.wafflestudio.snutt2.domain
 
-import com.wafflestudio.snutt2.data.onFailure
 import com.wafflestudio.snutt2.data.semesterstatus.SemesterStatusRepository
-import com.wafflestudio.snutt2.data.tables.TableRepository
 import com.wafflestudio.snutt2.data.themes.ThemeRepository
 import com.wafflestudio.snutt2.data.user.UserRepository
 import kotlinx.coroutines.async
@@ -11,7 +9,6 @@ import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 
 class RefreshInitialDataUseCase @Inject constructor(
-    private val tableRepository: TableRepository,
     private val userRepository: UserRepository,
     private val themeRepository: ThemeRepository,
     private val semesterStatusRepository: SemesterStatusRepository,
@@ -19,12 +16,6 @@ class RefreshInitialDataUseCase @Inject constructor(
     suspend operator fun invoke() {
         coroutineScope {
             awaitAll(
-                async {
-                    tableRepository.currentTable.value?.let {
-                        tableRepository.fetchAndSelectTable(it.summary.id)
-                            .onFailure { tableRepository.fetchAndSelectDefaultTable() }
-                    } ?: tableRepository.fetchAndSelectDefaultTable()
-                },
                 async { userRepository.fetchUserInfo() },
                 async { themeRepository.fetchThemes() },
                 async { semesterStatusRepository.fetchSemesterStatus() },

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignInViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignInViewModel.kt
@@ -7,7 +7,7 @@ import com.wafflestudio.snutt2.data.onSuccess
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
-import com.wafflestudio.snutt2.domain.RefreshInitialDataUseCase
+import com.wafflestudio.snutt2.domain.InitializeHomeUseCase
 import com.wafflestudio.snutt2.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.logging.AnalyticsLogger
 import com.wafflestudio.snutt2.logging.LoginParameter
@@ -24,7 +24,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignInViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    private val refreshInitialDataUseCase: RefreshInitialDataUseCase,
+    private val initializeHomeUseCase: InitializeHomeUseCase,
     private val displayMessageResolver: DisplayMessageResolver,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
@@ -50,8 +50,12 @@ class SignInViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
             userRepository.postSignIn(state.idField, state.passwordField)
                 .onSuccess {
-                    refreshInitialDataUseCase()
-                    _uiEvent.emit(SignInUiEvent.NavigateHome)
+                    if (initializeHomeUseCase()) {
+                        _uiEvent.emit(SignInUiEvent.NavigateHome)
+                    } else {
+                        userRepository.performLogout()
+                        _uiState.update { it.copy(isLoading = false) }
+                    }
                 }
                 .onFailure { handleError(it) }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignUpViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/SignUpViewModel.kt
@@ -7,7 +7,7 @@ import com.wafflestudio.snutt2.data.onSuccess
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
-import com.wafflestudio.snutt2.domain.RefreshInitialDataUseCase
+import com.wafflestudio.snutt2.domain.InitializeHomeUseCase
 import com.wafflestudio.snutt2.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.logging.AnalyticsLogger
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    private val refreshInitialDataUseCase: RefreshInitialDataUseCase,
+    private val initializeHomeUseCase: InitializeHomeUseCase,
     private val displayMessageResolver: DisplayMessageResolver,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
@@ -57,8 +57,12 @@ class SignUpViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
             userRepository.postSignUp(state.idField, state.passwordField, formattedEmail)
                 .onSuccess {
-                    refreshInitialDataUseCase()
-                    _uiEvent.emit(SignUpUiEvent.NavigateEmailVerification)
+                    if (initializeHomeUseCase()) {
+                        _uiEvent.emit(SignUpUiEvent.NavigateEmailVerification)
+                    } else {
+                        userRepository.performLogout()
+                        _uiState.update { it.copy(isLoading = false) }
+                    }
                 }
                 .onFailure { handleError(it) }
         }

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/login/TutorialViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/login/TutorialViewModel.kt
@@ -7,7 +7,7 @@ import com.wafflestudio.snutt2.data.onSuccess
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.DisplayMessageResolver
 import com.wafflestudio.snutt2.domain.DomainError
-import com.wafflestudio.snutt2.domain.RefreshInitialDataUseCase
+import com.wafflestudio.snutt2.domain.InitializeHomeUseCase
 import com.wafflestudio.snutt2.logging.AnalyticsEvent
 import com.wafflestudio.snutt2.logging.AnalyticsLogger
 import com.wafflestudio.snutt2.logging.LoginParameter
@@ -24,7 +24,7 @@ import javax.inject.Inject
 @HiltViewModel
 class TutorialViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    private val refreshInitialDataUseCase: RefreshInitialDataUseCase,
+    private val initializeHomeUseCase: InitializeHomeUseCase,
     private val displayMessageResolver: DisplayMessageResolver,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
@@ -47,8 +47,7 @@ class TutorialViewModel @Inject constructor(
             analyticsLogger.logEvent(AnalyticsEvent.Login(LoginParameter(LoginParameter.Provider.FACEBOOK)))
             userRepository.postLoginFacebook(token)
                 .onSuccess {
-                    refreshInitialDataUseCase()
-                    _uiEvent.emit(TutorialUiEvent.NavigateHome)
+                    onLoginSucceeded()
                 }
                 .onFailure { handleError(it) }
         }
@@ -68,8 +67,7 @@ class TutorialViewModel @Inject constructor(
                     analyticsLogger.logEvent(AnalyticsEvent.Login(LoginParameter(LoginParameter.Provider.GOOGLE)))
                     userRepository.postLoginGoogle(googleAccessToken)
                         .onSuccess {
-                            refreshInitialDataUseCase()
-                            _uiEvent.emit(TutorialUiEvent.NavigateHome)
+                            onLoginSucceeded()
                         }
                         .onFailure { handleError(it) }
                 }
@@ -89,8 +87,7 @@ class TutorialViewModel @Inject constructor(
             analyticsLogger.logEvent(AnalyticsEvent.Login(LoginParameter(LoginParameter.Provider.KAKAO)))
             userRepository.postLoginKakao(token)
                 .onSuccess {
-                    refreshInitialDataUseCase()
-                    _uiEvent.emit(TutorialUiEvent.NavigateHome)
+                    onLoginSucceeded()
                 }
                 .onFailure { handleError(it) }
         }
@@ -99,6 +96,15 @@ class TutorialViewModel @Inject constructor(
     private suspend fun handleError(error: DomainError) {
         _uiState.update { it.copy(isLoading = false) }
         _uiEvent.emit(TutorialUiEvent.ShowToast(displayMessageResolver.getDisplayMessage(error)))
+    }
+
+    private suspend fun onLoginSucceeded() {
+        if (initializeHomeUseCase()) {
+            _uiEvent.emit(TutorialUiEvent.NavigateHome)
+        } else {
+            userRepository.performLogout()
+            _uiState.update { it.copy(isLoading = false) }
+        }
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snutt2/feature/settings/RootViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/feature/settings/RootViewModel.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snutt2.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wafflestudio.snutt2.data.Result
 import com.wafflestudio.snutt2.data.user.UserRepository
 import com.wafflestudio.snutt2.domain.model.ThemeMode
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,4 +24,6 @@ class RootViewModel @Inject constructor(
             userRepository.registerToken()
         }
     }
+
+    suspend fun performLogout(): Result<Unit> = userRepository.performLogout()
 }

--- a/app/src/main/java/com/wafflestudio/snutt2/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/AuthInterceptor.kt
@@ -1,8 +1,6 @@
 package com.wafflestudio.snutt2.network
 
 import com.wafflestudio.snutt2.storage.SNUTTStorage
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
@@ -11,23 +9,13 @@ import javax.inject.Singleton
 @Singleton
 class AuthInterceptor @Inject constructor(
     snuttStorage: SNUTTStorage,
-    externalScope: CoroutineScope,
 ) : Interceptor {
 
     private val accessToken = snuttStorage.accessToken.asStateFlow()
 
-    @Volatile
-    private var token: String = accessToken.value
-
-    init {
-        externalScope.launch {
-            accessToken.collect { token = it }
-        }
-    }
-
     override fun intercept(chain: Interceptor.Chain): Response {
         val newRequest = chain.request().newBuilder()
-            .addHeader("x-access-token", token)
+            .addHeader("x-access-token", accessToken.value)
             .build()
         return chain.proceed(newRequest)
     }

--- a/app/src/test/java/com/wafflestudio/snutt2/domain/EnsureCurrentTableLoadedUseCaseTest.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/domain/EnsureCurrentTableLoadedUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.wafflestudio.snutt2.domain
+
+import com.wafflestudio.snutt2.data.Result
+import com.wafflestudio.snutt2.fake.FakeTableRepository
+import com.wafflestudio.snutt2.fixture.TestFixtures.courseBook2025_1
+import com.wafflestudio.snutt2.fixture.TestFixtures.table
+import com.wafflestudio.snutt2.fixture.TestFixtures.tableSummary
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EnsureCurrentTableLoadedUseCaseTest {
+
+    private val tableRepository = FakeTableRepository()
+    private val useCase = EnsureCurrentTableLoadedUseCase(tableRepository)
+
+    @Test
+    fun `마지막으로 본 시간표가 있으면 해당 시간표를 조회한다`() = runTest {
+        val currentTable = table(summary = tableSummary(courseBook = courseBook2025_1))
+        tableRepository.currentTable.value = currentTable
+
+        val result = useCase()
+
+        assertTrue(result is Result.Success)
+        assertEquals(currentTable.summary.id, tableRepository.fetchAndSelectTableCalledWith)
+        assertEquals(0, tableRepository.fetchAndSelectDefaultTableCallCount)
+    }
+
+    @Test
+    fun `마지막으로 본 시간표 조회에 실패하면 기본 시간표를 조회한다`() = runTest {
+        tableRepository.currentTable.value = table(summary = tableSummary(courseBook = courseBook2025_1))
+        tableRepository.fetchAndSelectTableResult = Result.Fail(Unknown("", ""))
+
+        val result = useCase()
+
+        assertTrue(result is Result.Success)
+        assertEquals(1, tableRepository.fetchAndSelectDefaultTableCallCount)
+    }
+
+    @Test
+    fun `첫 기본 시간표 조회가 실패하면 한 번 재시도한다`() = runTest {
+        tableRepository.fetchAndSelectDefaultTableResults += Result.Fail(Unknown("", ""))
+        tableRepository.fetchAndSelectDefaultTableResults += Result.Success(Unit)
+
+        val result = useCase()
+
+        assertTrue(result is Result.Success)
+        assertEquals(2, tableRepository.fetchAndSelectDefaultTableCallCount)
+    }
+
+    @Test
+    fun `기본 시간표 조회가 두 번 실패하면 실패를 반환한다`() = runTest {
+        tableRepository.fetchAndSelectDefaultTableResult = Result.Fail(Unknown("", ""))
+
+        val result = useCase()
+
+        assertTrue(result is Result.Fail)
+        assertEquals(2, tableRepository.fetchAndSelectDefaultTableCallCount)
+    }
+}

--- a/app/src/test/java/com/wafflestudio/snutt2/fake/FakeTableRepository.kt
+++ b/app/src/test/java/com/wafflestudio/snutt2/fake/FakeTableRepository.kt
@@ -18,7 +18,13 @@ class FakeTableRepository : TableRepository {
 
     // --- 테스트 제어용 필드 ---
     var fetchAndSelectTableResult: Result<Unit> = Result.Success(Unit)
+    val fetchAndSelectTableResults = mutableListOf<Result<Unit>>()
     var fetchAndSelectTableCalledWith: String? = null
+        private set
+
+    var fetchAndSelectDefaultTableResult: Result<Unit> = Result.Success(Unit)
+    val fetchAndSelectDefaultTableResults = mutableListOf<Result<Unit>>()
+    var fetchAndSelectDefaultTableCallCount = 0
         private set
 
     var createAndSelectTableResult: Result<Unit> = Result.Success(Unit)
@@ -66,7 +72,7 @@ class FakeTableRepository : TableRepository {
     // --- 인터페이스 구현 ---
     override suspend fun fetchAndSelectTable(id: String): Result<Unit> {
         fetchAndSelectTableCalledWith = id
-        return fetchAndSelectTableResult
+        return fetchAndSelectTableResults.removeFirstOrNull() ?: fetchAndSelectTableResult
     }
 
     override suspend fun createAndSelectTable(courseBook: CourseBook, title: String): Result<Unit> {
@@ -121,7 +127,10 @@ class FakeTableRepository : TableRepository {
 
     // --- 미사용 메서드 ---
     override suspend fun updateCurrentTable() = TODO("Not used in this test")
-    override suspend fun fetchAndSelectDefaultTable(): Result<Unit> = TODO("Not used in this test")
+    override suspend fun fetchAndSelectDefaultTable(): Result<Unit> {
+        fetchAndSelectDefaultTableCallCount += 1
+        return fetchAndSelectDefaultTableResults.removeFirstOrNull() ?: fetchAndSelectDefaultTableResult
+    }
     override suspend fun getTimetableReminders(timetableId: String): Result<TimetableLectureReminders> = TODO("Not used in this test")
     override suspend fun getTimetableLectureReminder(timetableId: String, lectureId: String): Result<LectureWithReminderOption> = TODO("Not used in this test")
     override suspend fun updateTimetableLectureReminder(timetableId: String, lectureId: String, offset: LectureReminderOffset): Result<LectureWithReminderOption> = TODO("Not used in this test")


### PR DESCRIPTION
## 배경

동일 계정을 여러 기기에서 사용하는 경우, 새 기기에는 로컬 `lastViewedTable`이 없어 앱 시작 시 `currentTable`이 비어 있을 수 있습니다. 이 상태에서 Home이 먼저 구성되면 시간표 화면은 아무것도 표시하지 않고, 검색 화면은 `currentTable`을 전제로 생성되어 크래시할 수 있습니다.

시간표는 가입 시 기본 시간표가 생성되고 마지막 시간표 삭제도 제한되어 있어, 로그인된 사용자의 `currentTable` 부재는 정상 화면 상태가 아니라 초기화 실패로 취급합니다.

## 변경 사항

- `EnsureCurrentTableLoadedUseCase`를 추가했습니다.
  - 로컬 마지막 시간표가 있으면 서버에서 해당 시간표를 갱신합니다.
  - 없거나 조회에 실패하면 서버 기본 시간표를 조회합니다.
  - 전체 절차를 한 번 재시도한 뒤에도 실패하면 실패를 반환합니다.

- `InitializeHomeUseCase`를 추가했습니다.
  - 부가 초기 데이터 갱신과 현재 시간표 준비를 병렬로 시작합니다.
  - 외부에는 Home 진입 가능 여부만 반환합니다.
  - 현재 시간표 준비에 실패하면 진행 중인 부가 초기 데이터 갱신을 취소합니다.

- 앱 재시작, 일반 로그인, 회원가입, 소셜 로그인에서 `InitializeHomeUseCase` 성공 뒤에만 Home 또는 다음 인증 화면으로 이동하도록 변경했습니다.
  - 앱 재시작 시 실패하면 로컬 로그아웃 후 Onboard로 이동합니다.
  - 인증 직후 실패하면 로컬 로그아웃하고 현재 인증 화면에서 다시 시도할 수 있게 합니다.

### 선택한 방식: Home 진입 전 현재 시간표 보장

`EnsureCurrentTableLoadedUseCase`는 현재 시간표 준비만 보장하고, `InitializeHomeUseCase`는 이를 부가 초기 데이터 갱신과 병렬로 조정해 Home 진입 가능 여부만 외부에 제공합니다.

이 방식의 장점은 다음과 같습니다.

- Home과 Search는 `currentTable`이 존재한다는 기존 전제를 유지할 수 있습니다.
- Splash가 유지되는 동안 Home 자체를 구성하지 않으므로 빈 화면과 Search 초기화 크래시를 함께 방지합니다.
- 사용자 정보·테마·학기 상태는 Home 진입을 불필요하게 지연시키지 않습니다.
- 시간표 로딩 fallback·재시도 정책이 한 곳에 모입니다.
- 화면 진입부는 `InitializeHomeUseCase(): Boolean`만 판단하므로, 초기화 세부 로직에 의존하지 않습니다.