### PR TITLE
fix: 커스텀 강의 응답 파싱

### DIFF
--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/LectureDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/LectureDto.kt
@@ -13,12 +13,13 @@ data class LectureDto(
     @param:Json(name = "course_number") val course_number: String?,
     @param:Json(name = "lecture_number") val lecture_number: String?,
     @param:Json(name = "course_title") val course_title: String,
-    @param:Json(name = "credit") val credit: Long,
-    @param:Json(name = "class_time_json") val class_time_json: List<ClassTimeDto>,
-    @param:Json(name = "instructor") val instructor: String,
+    // 커스텀 강의의 legacy 응답은 아래 필드를 생략할 수 있다.
+    @param:Json(name = "credit") val credit: Long = 0,
+    @param:Json(name = "class_time_json") val class_time_json: List<ClassTimeDto> = emptyList(),
+    @param:Json(name = "instructor") val instructor: String = "",
     @param:Json(name = "quota") val quota: Long = 0,
     @param:Json(name = "freshmanQuota") val freshmanQuota: Long?,
-    @param:Json(name = "remark") val remark: String,
+    @param:Json(name = "remark") val remark: String = "",
     @param:Json(name = "category") val category: String?,
     @param:Json(name = "categoryPre2025") val categoryPre2025: String?,
     @param:Json(name = "colorIndex") val colorIndex: Long = 0, // 색상

--- a/app/src/main/java/com/wafflestudio/snutt2/network/dto/LectureDto.kt
+++ b/app/src/main/java/com/wafflestudio/snutt2/network/dto/LectureDto.kt
@@ -18,7 +18,7 @@ data class LectureDto(
     @param:Json(name = "class_time_json") val class_time_json: List<ClassTimeDto> = emptyList(),
     @param:Json(name = "instructor") val instructor: String = "",
     @param:Json(name = "quota") val quota: Long = 0,
-    @param:Json(name = "freshmanQuota") val freshmanQuota: Long?,
+    @param:Json(name = "freshman_quota") val freshmanQuota: Long?,
     @param:Json(name = "remark") val remark: String = "",
     @param:Json(name = "category") val category: String?,
     @param:Json(name = "categoryPre2025") val categoryPre2025: String?,

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-snuttVersionName=3.12.2
+snuttVersionName=3.13.0


### PR DESCRIPTION
## 변경 사항
- 커스텀 강의 legacy 응답에서 생략될 수 있는 credit, class_time_json, instructor, remark에 기본값을 적용합니다.
- legacy 시간표 응답의 freshman_quota 필드를 올바르게 역직렬화합니다.

## 배경
커스텀 강의가 포함된 현재 시간표 응답을 Moshi가 파싱하지 못해 currentTable 초기화가 실패하던 문제를 수정합니다.

## 검증
- git diff --check